### PR TITLE
parts: add parts support (CRAFT-27)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,9 +14,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install -y libapt-pkg-dev
       - name: Install python packages and dependencies
         run: |
-          pip install -U -r requirements.txt -r requirements-dev.txt
+          pip install -U -r requirements-focal.txt -r requirements.txt -r requirements-dev.txt
       - name: Run black
         run: |
           make test-black
@@ -57,6 +61,24 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install python packages and dependencies
+        run: |
+          pip install -U wheel
+      - name: Install Ubuntu-specific dependencies
+        if: ${{ matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04' }}
+        run: |
+          sudo apt update
+          sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
+      - name: Install Ubuntu 18.04-specific dependencies
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
+        run: |
+          # pip 20.2 breaks python3-apt, so pin the version before building
+          pip install -U pip==20.1
+          pip install -U -r requirements-bionic.txt
+      - name: Install Ubuntu 20.04-specific dependencies
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          pip install -U -r requirements-focal.txt
       - name: Install dependencies
         run: |
           pip install -U -r requirements.txt -r requirements-dev.txt

--- a/requirements-bionic.txt
+++ b/requirements-bionic.txt
@@ -1,0 +1,1 @@
+http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_1.6.5ubuntu0.5.tar.xz; sys_platform == 'linux'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,6 +42,7 @@ py==1.10.0
 pycodestyle==2.8.0
 pycparser==2.20
 pydantic==1.8.2
+pydantic-yaml==0.4.2
 pydocstyle==6.1.1
 pyflakes==2.4.0
 Pygments==2.10.0
@@ -53,13 +54,16 @@ pytest==6.2.5
 pytest-mock==3.6.1
 pytest-subprocess==1.2.0
 pytz==2021.3
+pyxdg==0.27
 PyYAML==6.0
 readme-renderer==30.0
 regex==2021.10.8
 requests==2.26.0
 requests-toolbelt==0.9.1
+requests-unixsocket==0.2.0
 rfc3986==1.5.0
 SecretStorage==3.3.1
+semver==2.13.0
 six==1.16.0
 snowballstemmer==2.1.0
 Sphinx==4.2.0
@@ -88,3 +92,4 @@ webencodings==0.5.1
 wrapt==1.13.2
 zipp==3.6.0
 git+https://github.com/canonical/craft-cli.git@616673f9312338c841e0da5de6417056aac88aa5#egg=craft_cli
+git+https://github.com/canonical/craft-parts.git@47ce20b75a7074dff7f64dbda03b62d5740d5b60#egg=craft_parts

--- a/requirements-focal.txt
+++ b/requirements-focal.txt
@@ -1,0 +1,1 @@
+https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.0ubuntu0.20.04.6/python-apt_2.0.0ubuntu0.20.04.6.tar.xz; sys_platform == 'linux'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,15 @@
 appdirs==1.4.4
+certifi==2021.10.8
+charset-normalizer==2.0.7
+idna==3.3
 pydantic==1.8.2
+pydantic-yaml==0.4.2
+pyxdg==0.27
 PyYAML==6.0
+requests==2.26.0
+requests-unixsocket==0.2.0
+semver==2.13.0
 typing-extensions==3.10.0.2
+urllib3==1.26.7
 git+https://github.com/canonical/craft-cli.git@616673f9312338c841e0da5de6417056aac88aa5#egg=craft_cli
+git+https://github.com/canonical/craft-parts.git@47ce20b75a7074dff7f64dbda03b62d5740d5b60#egg=craft_parts

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -18,9 +18,41 @@
 
 """Lifecycle integration."""
 
+from pathlib import Path
+
+import yaml
+from craft_cli.errors import CraftError
+
+from .parts import PartsLifecycle, Step
 from .ui import emit
 
 
 def pack():
     """Pack a ROCK."""
-    emit.progress("Fake packing")
+    # XXX: replace with proper rockcraft.yaml unmarshal and validation
+    try:
+        with open("rockcraft.yaml", encoding="utf-8") as yaml_file:
+            yaml_data = yaml.safe_load(yaml_file)
+    except OSError as err:
+        raise CraftError(err) from err
+
+    parts_data = yaml_data.get("parts")
+    if not parts_data:
+        emit.message("No parts specified.")
+        return
+
+    # TODO: add base image retrieval
+
+    # TODO: add base image extraction
+
+    # TODO: pass base image to parts lifecycle
+
+    lifecycle = PartsLifecycle(
+        parts_data,
+        work_dir=Path("build"),
+    )
+    lifecycle.run(Step.PRIME)
+
+    # TODO: generate layer with prime contents
+
+    # TODO: build image with new layer

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -1,0 +1,134 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Craft-parts lifecycle."""
+
+import pathlib
+from typing import Any, Dict
+
+import craft_parts
+from craft_cli.errors import CraftError
+from craft_parts import ActionType, Step
+from xdg import BaseDirectory  # type: ignore
+
+from rockcraft import ui
+
+
+class PartsLifecycleError(CraftError):
+    """Error during parts processing."""
+
+
+class PartsLifecycle:
+    """Create and manage the parts lifecycle.
+
+    :param all_parts: A dictionary containing the parts defined in the project.
+    :param work_dir: The working directory for parts processing.
+
+    :raises PartsLifecycleError: On error initializing the parts lifecycle.
+    """
+
+    def __init__(
+        self,
+        all_parts: Dict[str, Any],
+        *,
+        work_dir: pathlib.Path,
+    ):
+        ui.emit.progress("Initializing parts lifecycle")
+
+        # set the cache dir for parts package management
+        cache_dir = BaseDirectory.save_cache_path("rockcraft")
+
+        try:
+            self._lcm = craft_parts.LifecycleManager(
+                {"parts": all_parts},
+                application_name="rockcraft",
+                work_dir=work_dir,
+                cache_dir=cache_dir,
+            )
+        except craft_parts.PartsError as err:
+            raise PartsLifecycleError(err) from err
+
+    @property
+    def prime_dir(self) -> pathlib.Path:
+        """Return the parts prime directory path."""
+        return self._lcm.project_info.prime_dir
+
+    def run(self, target_step: Step) -> None:
+        """Run the parts lifecycle.
+
+        :param target_step: The final step to execute.
+
+        :raises PartsLifecycleError: On error during lifecycle.
+        :raises RuntimeError: On unexpected error.
+        """
+        try:
+            ui.emit.progress("Executing parts lifecycle")
+            actions = self._lcm.plan(target_step)
+            with self._lcm.action_executor() as aex:
+                for action in actions:
+                    message = _action_message(action)
+                    ui.emit.progress(message)
+                    aex.execute(action)
+        except RuntimeError as err:
+            raise RuntimeError(f"Parts processing internal error: {err}") from err
+        except OSError as err:
+            msg = err.strerror
+            if err.filename:
+                msg = f"{err.filename}: {msg}"
+            raise PartsLifecycleError(msg) from err
+        except Exception as err:
+            raise PartsLifecycleError(err) from err
+
+
+def _action_message(action: craft_parts.Action) -> str:
+    msg = {
+        Step.PULL: {
+            ActionType.RUN: "Pull",
+            ActionType.RERUN: "Repull",
+            ActionType.SKIP: "Skip pull",
+            ActionType.UPDATE: "Update sources for",
+        },
+        Step.OVERLAY: {
+            ActionType.RUN: "Overlay",
+            ActionType.RERUN: "Re-overlay",
+            ActionType.SKIP: "Skip overlay",
+            ActionType.UPDATE: "Update overlay for",
+            ActionType.REAPPLY: "Reapply",
+        },
+        Step.BUILD: {
+            ActionType.RUN: "Build",
+            ActionType.RERUN: "Rebuild",
+            ActionType.SKIP: "Skip build",
+            ActionType.UPDATE: "Update build for",
+        },
+        Step.STAGE: {
+            ActionType.RUN: "Stage",
+            ActionType.RERUN: "Restage",
+            ActionType.SKIP: "Skip stage",
+        },
+        Step.PRIME: {
+            ActionType.RUN: "Prime",
+            ActionType.RERUN: "Re-prime",
+            ActionType.SKIP: "Skip prime",
+        },
+    }
+
+    message = f"{msg[action.step][action.action_type]} {action.part_name}"
+
+    if action.reason:
+        message += f" ({action.reason})"
+
+    return message

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,21 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+import pytest
+
+linux_only = pytest.mark.skipif(sys.platform != "linux", reason="platform is not linux")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import pytest
+import xdg  # type: ignore
+
+
+@pytest.fixture
+def new_dir(tmpdir):
+    """Change to a new temporary directory."""
+
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
+
+    yield tmpdir
+
+    os.chdir(cwd)
+
+
+@pytest.fixture(autouse=True)
+def temp_xdg(tmpdir, mocker):
+    """Use a temporary location for XDG directories."""
+
+    mocker.patch(
+        "xdg.BaseDirectory.xdg_config_home", new=os.path.join(tmpdir, ".config")
+    )
+    mocker.patch("xdg.BaseDirectory.xdg_data_home", new=os.path.join(tmpdir, ".local"))
+    mocker.patch("xdg.BaseDirectory.xdg_cache_home", new=os.path.join(tmpdir, ".cache"))
+    mocker.patch(
+        "xdg.BaseDirectory.xdg_config_dirs", new=[xdg.BaseDirectory.xdg_config_home]
+    )
+    mocker.patch(
+        "xdg.BaseDirectory.xdg_data_dirs", new=[xdg.BaseDirectory.xdg_data_home]
+    )
+    mocker.patch.dict(os.environ, {"XDG_CONFIG_HOME": os.path.join(tmpdir, ".config")})

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -1,0 +1,73 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2021 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+
+import tests
+from rockcraft import parts
+
+
+@tests.linux_only
+def test_parts_lifecycle_prime_dir(emit_mock):
+    parts_data = {
+        "foo": {
+            "plugin": "nil",
+        }
+    }
+
+    lifecycle = parts.PartsLifecycle(
+        all_parts=parts_data,
+        work_dir=Path("/some/workdir"),
+    )
+    assert lifecycle.prime_dir == Path("/some/workdir/prime")
+
+
+@tests.linux_only
+def test_parts_lifecycle_run(emit_mock, new_dir):
+    parts_data = {
+        "foo": {
+            "plugin": "dump",
+            "source": "dir1",
+        }
+    }
+
+    Path("dir1").mkdir()
+    Path("dir1/foo.txt").touch()
+
+    lifecycle = parts.PartsLifecycle(
+        all_parts=parts_data,
+        work_dir=Path("."),
+    )
+    lifecycle.run(parts.Step.PRIME)
+
+    assert Path(lifecycle.prime_dir, "foo.txt").is_file()
+
+
+@tests.linux_only
+def test_parts_lifecycle_error(emit_mock):
+    parts_data = {
+        "foo": {
+            "invalid": True,
+        }
+    }
+
+    with pytest.raises(parts.PartsLifecycleError):
+        parts.PartsLifecycle(
+            all_parts=parts_data,
+            work_dir=Path("."),
+        )

--- a/tools/freeze-requirements.sh
+++ b/tools/freeze-requirements.sh
@@ -1,17 +1,37 @@
 #!/bin/bash -eux
 
+requirements_fixups() {
+  req_file="$1"
+
+  # Python apt library pinned to source.
+  sed -i '/^python-apt==/d' "$req_file"
+
+  echo "git+https://github.com/canonical/craft-cli.git@616673f9312338c841e0da5de6417056aac88aa5#egg=craft_cli" >> "$req_file"
+  echo "git+https://github.com/canonical/craft-parts.git@47ce20b75a7074dff7f64dbda03b62d5740d5b60#egg=craft_parts" >> "$req_file"
+}
+
 venv_dir="$(mktemp -d)"
 
 python3 -m venv "$venv_dir"
 . "$venv_dir/bin/activate"
 
+# Pull in host python3-apt site package to avoid installation.
+site_pkgs="$(readlink -f "$venv_dir"/lib/python3.*/site-packages/)"
+temp_dir="$(mktemp -d)"
+pushd "$temp_dir"
+apt download python3-apt
+dpkg -x ./*.deb .
+cp -r usr/lib/python3/dist-packages/* "$site_pkgs"
+popd
+
 pip install git+https://github.com/canonical/craft-cli.git@616673f9312338c841e0da5de6417056aac88aa5#egg=craft_cli
+pip install git+https://github.com/canonical/craft-parts.git@47ce20b75a7074dff7f64dbda03b62d5740d5b60#egg=craft_parts
 pip install -e .
-pip freeze --exclude-editable |grep -v ^craft-cli > requirements.txt
-echo "git+https://github.com/canonical/craft-cli.git@616673f9312338c841e0da5de6417056aac88aa5#egg=craft_cli" >> requirements.txt
+pip freeze --exclude-editable | egrep -v "^craft-(cli|parts)" > requirements.txt
+requirements_fixups "requirements.txt"
 
 pip install -e .[dev]
-pip freeze --exclude-editable | grep -v ^craft-cli > requirements-dev.txt
-echo "git+https://github.com/canonical/craft-cli.git@616673f9312338c841e0da5de6417056aac88aa5#egg=craft_cli" >> requirements-dev.txt
+pip freeze --exclude-editable | egrep -v "^craft-(cli|parts)" > requirements-dev.txt
+requirements_fixups "requirements-dev.txt"
 
 rm -rf "$venv_dir"


### PR DESCRIPTION
Integrate with craft-parts to add initial parts processing support
to Rockcraft.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
