### PR TITLE
project: make build-base optional, defaults to base (CRAFT-590)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -147,7 +147,6 @@ jobs:
           name: smoke-test
           version: latest
           base: ubuntu:20.04
-          build-base: ubuntu:20.04
           parts:
             foo:
               plugin: nil


### PR DESCRIPTION
Change the `build-base` attribute to be optional in rockcraft.yaml. If
not specified, default to the value set in `base`.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
