### PR TITLE
docs: remove build-base from tutorial

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -35,7 +35,6 @@ save it as ``rockcraft.yaml``:
   name: hello
   version: "1.0"
   base: ubuntu:20.04
-  build-base: ubuntu:20.04
 
   parts:
       hello:


### PR DESCRIPTION
The build base entry is now optional, defaulting to base.

This is a follow-up to PR #13.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
