### PR TITLE
providers: fix id mapping in lxd project mount

### DIFF
--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -172,6 +172,7 @@ class LXDProvider(Provider):
                 auto_clean=True,
                 auto_create_project=True,
                 map_user_uid=True,
+                uid=project_path.stat().st_uid,
                 use_snapshots=True,
                 project=self.lxd_project,
                 remote=self.lxd_remote,

--- a/tests/unit/providers/conftest.py
+++ b/tests/unit/providers/conftest.py
@@ -15,8 +15,7 @@
 # For further info, check https://github.com/canonical/charmcraft
 
 import os
-import pathlib
-from unittest import mock
+import stat
 
 import pytest
 from craft_providers import bases
@@ -34,7 +33,9 @@ def clear_environment(monkeypatch):
 
 
 @pytest.fixture
-def mock_path():
-    mock_path = mock.Mock(spec=pathlib.Path)
-    mock_path.stat.return_value.st_ino = 445566
-    yield mock_path
+def mock_path(tmp_path, mocker):
+    stat_list = list(tmp_path.stat())
+    stat_list[stat.ST_INO] = 445566
+    stat_list[stat.ST_UID] = 1234
+    mocker.patch("pathlib.Path.stat", return_value=os.stat_result(stat_list))
+    yield tmp_path

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -388,6 +388,7 @@ def test_launched_environment(
                 auto_clean=True,
                 auto_create_project=True,
                 map_user_uid=True,
+                uid=1234,
                 use_snapshots=True,
                 project="rockcraft",
                 remote="local",


### PR DESCRIPTION
Map the directory owner when mounting project from host instead of
using the uid of the current user, otherwise file creation will fail in hosts
where the directory owner and user id are different (like in gce spread
tests).

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
