### PR TITLE
requirements: update craft-providers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ commonmark==0.9.1
 coverage==6.3.2
 craft-cli==0.4.0
 craft-parts==1.4.2
-craft-providers==1.1.1
+craft-providers==1.2.0
 cryptography==36.0.2
 Deprecated==1.2.13
 dill==0.3.4

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -4,7 +4,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 craft-cli==0.4.0
 craft-parts==1.4.2
-craft-providers==1.1.1
+craft-providers==1.2.0
 Deprecated==1.2.13
 docutils==0.17.1
 idna==3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 craft-cli==0.4.0
 craft-parts==1.4.2
-craft-providers==1.1.1
+craft-providers==1.2.0
 Deprecated==1.2.13
 docutils==0.17.1
 idna==3.3


### PR DESCRIPTION
Build instances are significantly faster to warm-start using craft-providers 1.2.0.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
