### PR TITLE
project: add entrypoint, cmd and env properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ Snapcraft and Charmcraft. It is currently under heavy development.
 
    tutorials
 
+   reference
+
 
 Indices and tables
 ==================

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,66 @@
+*********
+Reference
+*********
+
+Rockcraft.yaml format
+=====================
+
+A Rockcraft project is defined in a YAML file named ``rockcraft.yaml``
+at the root of the project tree in the filesystem.
+
+
+Format specification
+--------------------
+
+.. code-block:: yaml
+
+  # The name of the ROCK project.
+  name: <name>
+  
+  # The project version, used as the container tag.
+  version: <version>
+  
+  # The system image and version the application will be layered on.
+  base: ubuntu:18.04 | ubuntu:20.04
+  
+  # (Optional) The system and version on top of which the application
+  # will be built. Defaults to base.
+  build-base: <base>
+  
+  # (Optional) The container entry point.
+  entrypoint: [<path>, ...]
+  
+  # (Optional) The container command line, used as arguments for
+  # entrypoint. If the entrypoint is not defined, the first item in
+  # the cmd list the command to execute.
+  cmd: [<arg>, ...]
+  
+  # (Optional) A list of keys and values defining the container's
+  # runtime environment variables.
+  env:
+    - <var name>: <value>
+  
+  # The parts used to build the application.
+  parts:
+    <part name>:
+      ...
+  
+
+Example
+-------
+
+.. code-block:: yaml
+
+  name: hello 
+  version: latest
+  base: ubuntu:20.04
+  entrypoint: [/usr/bin/hello, -t]
+  env:
+    - VAR1: value
+    - VAR2: "other value"
+  
+  parts:
+    hello:
+      plugin: nil
+      overlay-packages:
+        - hello

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -35,6 +35,7 @@ save it as ``rockcraft.yaml``:
   name: hello
   version: "1.0"
   base: ubuntu:20.04
+  cmd: [/usr/bin/hello, -t]
 
   parts:
       hello:
@@ -56,10 +57,17 @@ The output should look as follows:
 
 .. code-block:: sh
 
-  Retrieved base ubuntu:20.04                                                                                                   
-  Extracted ubuntu:20.04                                                                                                        
-  Executed parts lifecycle                                                                                                      
-  Created new layer                                                                                                             
+  Launching instance...
+  Retrieved base ubuntu:20.04
+  Extracted ubuntu:20.04
+  Executed: pull hello
+  Executed: overlay hello
+  Executed: build hello
+  Executed: stage hello
+  Executed: prime hello
+  Executed parts lifecycle
+  Created new layer
+  Cmd set to ['/usr/bin/hello', '-t']
   Exported to OCI archive 'hello_1.0.rock'
 
 At the end of the process, a file named ``hello_1.0.rock`` should be
@@ -78,14 +86,10 @@ Now run the ``hello`` command from the OCI image:
 
 .. code-block:: sh
 
-  $ docker run  --entrypoint /usr/bin/hello hello:1.0
+  $ docker run hello:1.0
 
 Which should print:
 
 .. code-block:: sh
 
-  Hello, world!
-
-
-Overriding steps
-================
+  hello, world

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -23,7 +23,7 @@ import subprocess
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 from craft_cli import CraftError, emit
 
@@ -185,18 +185,23 @@ class Image:
         _config_image(image_path, params)
         emit.message(f"Cmd set to {cmd}", intermediate=True)
 
-    def set_env(self, env: List[str]) -> None:
+    def set_env(self, env: List[Dict[str, str]]) -> None:
         """Set the OCI image environment.
 
-        :param env: A list of environment variables in ``NAME=VALUE`` format.
+        :param env: A list of dictionaries mapping environment variables to
+            their values.
         """
         emit.progress("Configuring env...")
         image_path = self.path / self.image_name
         params = ["--clear=config.env"]
+        env_list = []
         for entry in env:
-            params.extend(["--config.env", entry])
+            for name, value in entry.items():
+                env_item = f"{name}={value}"
+                env_list.append(env_item)
+                params.extend(["--config.env", env_item])
         _config_image(image_path, params)
-        emit.message(f"Environment set to {env}", intermediate=True)
+        emit.message(f"Environment set to {env_list}", intermediate=True)
 
 
 def _copy_image(source: str, destination: str) -> None:

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -16,7 +16,6 @@
 
 """OCI image manipulation helpers."""
 
-
 import logging
 import os
 import shutil
@@ -84,7 +83,7 @@ class Image:
 
         return bundle_path / "rootfs"
 
-    def add_layer(self, tag: str, layer_path: Path) -> None:
+    def add_layer(self, tag: str, layer_path: Path) -> "Image":
         """Add a layer to the image.
 
         :param tag: The tag of the image containing the new layer.
@@ -123,13 +122,15 @@ class Image:
         finally:
             temp_file.unlink(missing_ok=True)
 
+        name = self.image_name.split(":", 1)[0]
+        return self.__class__(image_name=f"{name}:{tag}", path=self.path)
+
     def to_docker_daemon(self, tag: str) -> None:
         """Export the current image to the local docker daemon.
 
         :param tag: The tag to export.
         """
-        parts = self.image_name.split(":", 1)
-        name = parts[0]
+        name = self.image_name.split(":", 1)[0]
         src_path = self.path / f"{name}:{tag}"
         _copy_image(f"oci:{str(src_path)}", f"docker-daemon:{name}:{tag}")
 
@@ -138,8 +139,7 @@ class Image:
 
         :param tag: The tag to export.
         """
-        parts = self.image_name.split(":", 1)
-        name = parts[0]
+        name = self.image_name.split(":", 1)[0]
         src_path = self.path / f"{name}:{tag}"
         _copy_image(f"oci:{str(src_path)}", f"oci-archive:{filename}:{tag}")
 
@@ -156,15 +156,62 @@ class Image:
         parts = output.split(":", 1)
         return bytes.fromhex(parts[-1])
 
+    def set_entrypoint(self, entrypoint: List[str]) -> None:
+        """Set the OCI image entrypoint.
+
+        :param entrypoint: The default list of arguments to use as the command to
+            execute when the container starts.
+        """
+        emit.progress("Configuring entrypoint...")
+        image_path = self.path / self.image_name
+        params = ["--clear=config.entrypoint"]
+        for entry in entrypoint:
+            params.extend(["--config.entrypoint", entry])
+        _config_image(image_path, params)
+        emit.message(f"Entrypoint set to {entrypoint}", intermediate=True)
+
+    def set_cmd(self, cmd: List[str]) -> None:
+        """Set the OCI image default command parameters.
+
+        :param cmd: The default arguments to the entrypoint of the container. If
+            entrypoint is not defined, the first entry of cmd is the executable to
+            run when the container starts.
+        """
+        emit.progress("Configuring cmd...")
+        image_path = self.path / self.image_name
+        params = ["--clear=config.cmd"]
+        for entry in cmd:
+            params.extend(["--config.cmd", entry])
+        _config_image(image_path, params)
+        emit.message(f"Cmd set to {cmd}", intermediate=True)
+
+    def set_env(self, env: List[str]) -> None:
+        """Set the OCI image environment.
+
+        :param env: A list of environment variables in ``NAME=VALUE`` format.
+        """
+        emit.progress("Configuring env...")
+        image_path = self.path / self.image_name
+        params = ["--clear=config.env"]
+        for entry in env:
+            params.extend(["--config.env", entry])
+        _config_image(image_path, params)
+        emit.message(f"Environment set to {env}", intermediate=True)
+
 
 def _copy_image(source: str, destination: str) -> None:
     """Transfer images from source to destination."""
     _process_run(["skopeo", "--insecure-policy", "copy", source, destination])
 
 
-# XXX: update to use craft-cli output stream
+def _config_image(image_path: Path, params: List[str]) -> None:
+    """Configure the OCI image."""
+    _process_run(["umoci", "config", "--image", str(image_path)] + params)
+
+
 def _process_run(command: List[str], **kwargs) -> None:
     """Run a command and handle its output."""
+    emit.trace(f"Execute process: {command!r}, kwargs={kwargs!r}")
     try:
         subprocess.run(
             command,

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -16,7 +16,7 @@
 
 """Project definition and helpers."""
 
-from typing import Any, Dict, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import pydantic
 import yaml
@@ -40,6 +40,9 @@ class Project(pydantic.BaseModel):
     version: str
     base: Literal["ubuntu:18.04", "ubuntu:20.04"]
     build_base: Optional[str]
+    entrypoint: Optional[List[str]]
+    cmd: Optional[List[str]]
+    env: Optional[List[str]]
     parts: Dict[str, Any]
 
     class Config:  # pylint: disable=too-few-public-methods

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -42,7 +42,7 @@ class Project(pydantic.BaseModel):
     build_base: Optional[str]
     entrypoint: Optional[List[str]]
     cmd: Optional[List[str]]
-    env: Optional[List[str]]
+    env: Optional[List[Dict[str, str]]]
     parts: Dict[str, Any]
 
     class Config:  # pylint: disable=too-few-public-methods

--- a/tests/spread/general/craftctl/task.yaml
+++ b/tests/spread/general/craftctl/task.yaml
@@ -1,4 +1,4 @@
-summary: craftctl test for the retry tool
+summary: craftctl tool test
 
 execute: |
   rockcraft pack

--- a/tests/spread/general/entrypoint/rockcraft.yaml
+++ b/tests/spread/general/entrypoint/rockcraft.yaml
@@ -1,7 +1,9 @@
-name: smoke-test
+name: entrypoint-test
 version: latest
 base: ubuntu:20.04
-cmd: [/usr/bin/hello, -t]
+entrypoint: [/usr/bin/hello]
+cmd: [-g, "ship it!"]
+
 parts:
   hello:
     plugin: nil

--- a/tests/spread/general/entrypoint/task.yaml
+++ b/tests/spread/general/entrypoint/task.yaml
@@ -1,0 +1,13 @@
+summary: container entrypoint test
+
+execute: |
+  rockcraft pack
+
+  test -f entrypoint-test_latest.rock
+  test ! -d work
+
+  # test container execution
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:entrypoint-test_latest.rock docker-daemon:entrypoint-test:latest
+  docker images
+  docker run entrypoint-test | grep "ship it!"

--- a/tests/spread/general/environment/rockcraft.yaml
+++ b/tests/spread/general/environment/rockcraft.yaml
@@ -1,0 +1,9 @@
+name: environment-test
+version: latest
+base: ubuntu:20.04
+cmd: [/bin/true]
+env: ["X=ship it!"]
+
+parts:
+  part1:
+    plugin: nil

--- a/tests/spread/general/environment/rockcraft.yaml
+++ b/tests/spread/general/environment/rockcraft.yaml
@@ -2,7 +2,8 @@ name: environment-test
 version: latest
 base: ubuntu:20.04
 cmd: [/bin/true]
-env: ["X=ship it!"]
+env:
+  - X: "ship it!"
 
 parts:
   part1:

--- a/tests/spread/general/environment/task.yaml
+++ b/tests/spread/general/environment/task.yaml
@@ -1,0 +1,13 @@
+summary: container environment test
+
+execute: |
+  rockcraft pack
+
+  test -f environment-test_latest.rock
+  test ! -d work
+
+  # test container execution
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:environment-test_latest.rock docker-daemon:environment-test:latest
+  docker images
+  docker run environment-test bash -c 'echo $X' | grep "ship it!"

--- a/tests/spread/tutorials/basic/task.yaml
+++ b/tests/spread/tutorials/basic/task.yaml
@@ -13,4 +13,4 @@ execute: |
   docker images
   sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:smoke-test_latest.rock docker-daemon:smoke-test:latest
   docker images
-  docker run --entrypoint /usr/bin/hello smoke-test:latest
+  docker run smoke-test:latest | grep "hello, world"

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -153,3 +153,78 @@ class TestImage:
             )
         ]
         assert digest == bytes([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+
+    def test_set_entrypoint(self, mocker):
+        mock_run = mocker.patch("subprocess.run")
+        image = oci.Image("a:b", Path("/c"))
+
+        image.set_entrypoint(["arg1", "arg2"])
+
+        assert mock_run.mock_calls == [
+            call(
+                [
+                    "umoci",
+                    "config",
+                    "--image",
+                    "/c/a:b",
+                    "--clear=config.entrypoint",
+                    "--config.entrypoint",
+                    "arg1",
+                    "--config.entrypoint",
+                    "arg2",
+                ],
+                capture_output=True,
+                check=True,
+                universal_newlines=True,
+            )
+        ]
+
+    def test_set_cmd(self, mocker):
+        mock_run = mocker.patch("subprocess.run")
+        image = oci.Image("a:b", Path("/c"))
+
+        image.set_cmd(["arg1", "arg2"])
+
+        assert mock_run.mock_calls == [
+            call(
+                [
+                    "umoci",
+                    "config",
+                    "--image",
+                    "/c/a:b",
+                    "--clear=config.cmd",
+                    "--config.cmd",
+                    "arg1",
+                    "--config.cmd",
+                    "arg2",
+                ],
+                capture_output=True,
+                check=True,
+                universal_newlines=True,
+            )
+        ]
+
+    def test_set_env(self, mocker):
+        mock_run = mocker.patch("subprocess.run")
+        image = oci.Image("a:b", Path("/c"))
+
+        image.set_env(["NAME1=VALUE1", "NAME2=VALUE2"])
+
+        assert mock_run.mock_calls == [
+            call(
+                [
+                    "umoci",
+                    "config",
+                    "--image",
+                    "/c/a:b",
+                    "--clear=config.env",
+                    "--config.env",
+                    "NAME1=VALUE1",
+                    "--config.env",
+                    "NAME2=VALUE2",
+                ],
+                capture_output=True,
+                check=True,
+                universal_newlines=True,
+            )
+        ]

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -208,7 +208,7 @@ class TestImage:
         mock_run = mocker.patch("subprocess.run")
         image = oci.Image("a:b", Path("/c"))
 
-        image.set_env(["NAME1=VALUE1", "NAME2=VALUE2"])
+        image.set_env([{"NAME1": "VALUE1"}, {"NAME2": "VALUE2"}])
 
         assert mock_run.mock_calls == [
             call(

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -35,7 +35,7 @@ def yaml_data():
         "base": "ubuntu:20.04",
         "entrypoint": ["/bin/hello"],
         "cmd": ["world"],
-        "env": ["NAME=VALUE"],
+        "env": [{"NAME": "VALUE"}],
         "parts": {
             "foo": {
                 "plugin": "nil",
@@ -54,7 +54,7 @@ def test_project_unmarshal(yaml_data):
     assert project.build_base == "ubuntu:20.04"
     assert project.entrypoint == ["/bin/hello"]
     assert project.cmd == ["world"]
-    assert project.env == ["NAME=VALUE"]
+    assert project.env == [{"NAME": "VALUE"}]
     assert project.parts == {
         "foo": {
             "plugin": "nil",

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -33,6 +33,9 @@ def yaml_data():
         "name": "mytest",
         "version": "latest",
         "base": "ubuntu:20.04",
+        "entrypoint": ["/bin/hello"],
+        "cmd": ["world"],
+        "env": ["NAME=VALUE"],
         "parts": {
             "foo": {
                 "plugin": "nil",
@@ -49,6 +52,9 @@ def test_project_unmarshal(yaml_data):
     assert project.version == "latest"
     assert project.base == "ubuntu:20.04"
     assert project.build_base == "ubuntu:20.04"
+    assert project.entrypoint == ["/bin/hello"]
+    assert project.cmd == ["world"]
+    assert project.env == ["NAME=VALUE"]
     assert project.parts == {
         "foo": {
             "plugin": "nil",


### PR DESCRIPTION
Allow rockcraft projects to specify the entrypoint and cmd of the
generated OCI images, and define the container environment.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
CRAFT-811