### PR TITLE
project: expand global metadata properties in rockcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # snap
 rockcraft_*.snap
+
+# rock
+*.rock

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -59,7 +59,7 @@ class Project(pydantic.BaseModel):
     entrypoint: Optional[List[str]]
     env: Optional[List[Dict[str, str]]]
     source_code: Optional[str] = pydantic.Field(alias='source-code')
-    support: SupportInfo
+    support: Optional[SupportInfo]
     title: Optional[str]
     website: Optional[str]
     

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -24,8 +24,6 @@ from craft_cli.errors import CraftError
 
 from rockcraft.parts import validate_part
 
-from typing_extensions import TypedDict
-
 
 class ProjectLoadError(CraftError):
     """Error loading rockcraft.yaml."""

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -16,7 +16,7 @@
 
 """Project definition and helpers."""
 
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import pydantic
 import yaml
@@ -54,10 +54,11 @@ class Project(pydantic.BaseModel):
     # optional
     build_base: Optional[str] = pydantic.Field(alias='build-base')
     cmd: Optional[List[str]]
-    contact: Optional[List[str]]
-    documentation: Optional[str]
+    contact: Optional[Union[str, List[str]]]
+    docs: Optional[str]
     entrypoint: Optional[List[str]]
     env: Optional[List[Dict[str, str]]]
+    issues: Optional[Union[str, List[str]]]
     source_code: Optional[str] = pydantic.Field(alias='source-code')
     support: Optional[SupportInfo]
     title: Optional[str]

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -24,6 +24,8 @@ from craft_cli.errors import CraftError
 
 from rockcraft.parts import validate_part
 
+from typing_extensions import TypedDict
+
 
 class ProjectLoadError(CraftError):
     """Error loading rockcraft.yaml."""
@@ -33,17 +35,36 @@ class ProjectValidationError(CraftError):
     """Error validatiing rockcraft.yaml."""
 
 
+class SupportInfo(pydantic.BaseModel):
+    """Schema for the 'support' property"""
+    end_of_life: Optional[str] = pydantic.Field(alias='end-of-life')
+    end_of_support: Optional[str] = pydantic.Field(alias='end-of-support')
+    info: Optional[str]
+    
+    
 class Project(pydantic.BaseModel):
     """Rockcraft project definition."""
 
+    # required
     name: str
-    version: str
     base: Literal["ubuntu:18.04", "ubuntu:20.04"]
-    build_base: Optional[str]
-    entrypoint: Optional[List[str]]
-    cmd: Optional[List[str]]
-    env: Optional[List[Dict[str, str]]]
+    description: str
+    license: str
     parts: Dict[str, Any]
+    summary: str
+    version: str
+    # optional
+    build_base: Optional[str] = pydantic.Field(alias='build-base')
+    cmd: Optional[List[str]]
+    contact: Optional[List[str]]
+    documentation: Optional[str]
+    entrypoint: Optional[List[str]]
+    env: Optional[List[Dict[str, str]]]
+    source_code: Optional[str] = pydantic.Field(alias='source-code')
+    support: SupportInfo
+    title: Optional[str]
+    website: Optional[str]
+    
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""

--- a/tests/spread/general/entrypoint/rockcraft.yaml
+++ b/tests/spread/general/entrypoint/rockcraft.yaml
@@ -4,3 +4,8 @@ base: ubuntu:20.04
 entrypoint: [/usr/bin/hello]
 cmd: [-g, "ship it!"]
 
+parts:
+  hello:
+    plugin: nil
+    overlay-packages:
+      - hello

--- a/tests/spread/general/entrypoint/rockcraft.yaml
+++ b/tests/spread/general/entrypoint/rockcraft.yaml
@@ -4,8 +4,3 @@ base: ubuntu:20.04
 entrypoint: [/usr/bin/hello]
 cmd: [-g, "ship it!"]
 
-parts:
-  hello:
-    plugin: nil
-    overlay-packages:
-      - hello

--- a/tests/spread/general/metadata/rockcraft.yaml
+++ b/tests/spread/general/metadata/rockcraft.yaml
@@ -1,0 +1,21 @@
+name: metadata-test
+version: latest
+base: ubuntu:20.04
+title: My Metadata
+summary: Summary of the ROCK
+description: |
+  Long description of the ROCK
+  being built in this example
+contact: [foo@bar.com]
+source-code: https://github.com/canonical/rockcraft
+website: https://github.com/canonical/rockcraft
+documentation: https://rockcraft.readthedocs.io/en/latest/index.html
+license: GPL-3.0 license
+support:
+  end-of-life: "2027-04-01"
+  end-of-support: "2027-04-01T00:00:00Z"
+  info: https://ubuntu.com/support
+
+parts:
+  part1:
+    plugin: nil

--- a/tests/spread/general/metadata/rockcraft.yaml
+++ b/tests/spread/general/metadata/rockcraft.yaml
@@ -8,8 +8,9 @@ description: |
   being built in this example
 contact: [foo@bar.com]
 source-code: https://github.com/canonical/rockcraft
+issues: https://github.com/canonical/rockcraft/issues
 website: https://github.com/canonical/rockcraft
-documentation: https://rockcraft.readthedocs.io/en/latest/index.html
+docs: https://rockcraft.readthedocs.io/en/latest/index.html
 license: GPL-3.0 license
 support:
   end-of-life: "2027-04-01"

--- a/tests/spread/general/metadata/task.yaml
+++ b/tests/spread/general/metadata/task.yaml
@@ -1,0 +1,13 @@
+summary: container metadata test
+
+execute: |
+  rockcraft pack
+
+  test -f metadata-test_latest.rock
+  test ! -d work
+
+  # test container execution
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:metadata-test_latest.rock docker-daemon:metadata-test:latest
+  docker images
+  docker run metadata-test echo Hello

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -38,9 +38,10 @@ def yaml_data():
             and entirely dedicated to Rockcraft's \
             unit tests",
         "contact": ["foo@bar.com", "https://me.i/contact"],
+        "issues": "https://github.com/canonical/rockcraft/issues",
         "source-code": "https://github.com/canonical/rockcraft",
         "website": "https://github.com/canonical/rockcraft",
-        "documentation": "https://rockcraft.readthedocs.io/en/latest/index.html",
+        "docs": "https://rockcraft.readthedocs.io/en/latest/index.html",
         "license": "Apache-2.0",
         "support": {
             "end-of-life": "2027-04-01",
@@ -155,9 +156,10 @@ def test_project_load(new_dir):
                 and entirely dedicated to Rockcraft's
                 unit tests
             contact: [foo@bar.com, https://me.i/contact]
+            issues: https://github.com/canonical/rockcraft/issues
             source-code: https://github.com/canonical/rockcraft
             website: https://github.com/canonical/rockcraft
-            documentation: https://rockcraft.readthedocs.io/en/latest/index.html
+            docs: https://rockcraft.readthedocs.io/en/latest/index.html
             license: Apache-2.0
             support:
                 end-of-life: "2027-04-01"
@@ -185,9 +187,10 @@ and entirely dedicated to Rockcraft's
 unit tests
 '''
     assert project.contact == ["foo@bar.com", "https://me.i/contact"]
+    assert project.issues == "https://github.com/canonical/rockcraft/issues"
     assert project.source_code == "https://github.com/canonical/rockcraft"
     assert project.website == "https://github.com/canonical/rockcraft"
-    assert project.documentation == "https://rockcraft.readthedocs.io/en/latest/index.html"
+    assert project.docs == "https://rockcraft.readthedocs.io/en/latest/index.html"
     assert project.license == "Apache-2.0"
     assert project.support.end_of_life == "2027-04-01"
     assert project.support.end_of_support == "2027-04-01T00:00:00Z"

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -32,6 +32,21 @@ def yaml_data():
     return {
         "name": "mytest",
         "version": "latest",
+        "title": "My Test ROCK",
+        "summary": "This is a test ROCK",
+        "description": "This ROCK is non functional \
+            and entirely dedicated to Rockcraft's \
+            unit tests",
+        "contact": ["foo@bar.com", "https://me.i/contact"],
+        "source-code": "https://github.com/canonical/rockcraft",
+        "website": "https://github.com/canonical/rockcraft",
+        "documentation": "https://rockcraft.readthedocs.io/en/latest/index.html",
+        "license": "Apache-2.0",
+        "support": {
+            "end-of-life": "2027-04-01",
+            "end-of-support": "2027-04-01T00:00:00Z",
+            "info": "https://ubuntu.com/support"
+        },
         "base": "ubuntu:20.04",
         "entrypoint": ["/bin/hello"],
         "cmd": ["world"],
@@ -133,7 +148,21 @@ def test_project_load(new_dir):
             version: latest
             base: ubuntu:20.04
             build-base: ubuntu:20.04
-
+            title: My Test ROCK
+            summary: This is a test ROCK
+            description: |
+                This ROCK is non functional
+                and entirely dedicated to Rockcraft's
+                unit tests
+            contact: [foo@bar.com, https://me.i/contact]
+            source-code: https://github.com/canonical/rockcraft
+            website: https://github.com/canonical/rockcraft
+            documentation: https://rockcraft.readthedocs.io/en/latest/index.html
+            license: Apache-2.0
+            support:
+                end-of-life: "2027-04-01"
+                end-of-support: "2027-04-01T00:00:00Z"
+                info: https://ubuntu.com/support
             parts:
               foo:
                 plugin: nil
@@ -149,6 +178,20 @@ def test_project_load(new_dir):
     assert project.version == "latest"
     assert project.base == "ubuntu:20.04"
     assert project.build_base == "ubuntu:20.04"
+    assert project.title == "My Test ROCK"
+    assert project.summary == "This is a test ROCK"
+    assert project.description == '''This ROCK is non functional
+and entirely dedicated to Rockcraft's
+unit tests
+'''
+    assert project.contact == ["foo@bar.com", "https://me.i/contact"]
+    assert project.source_code == "https://github.com/canonical/rockcraft"
+    assert project.website == "https://github.com/canonical/rockcraft"
+    assert project.documentation == "https://rockcraft.readthedocs.io/en/latest/index.html"
+    assert project.license == "Apache-2.0"
+    assert project.support.end_of_life == "2027-04-01"
+    assert project.support.end_of_support == "2027-04-01T00:00:00Z"
+    assert project.support.info == "https://ubuntu.com/support"
     assert project.parts == {
         "foo": {
             "plugin": "nil",


### PR DESCRIPTION
Brings a new set of metadata properties to the rockcraft.yaml input schema.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----