### PR TITLE
lifecycle: define new and default users for the ROCK

### DIFF
--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -1,0 +1,44 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Rockcraft error definitions."""
+
+from craft_cli import CraftError
+
+
+class ConfigurationError(CraftError):
+    """Error while configuring the ROCK"""
+    
+    
+class RockcraftInitError(CraftError):
+    """Error while initializing rockcraft project."""
+
+
+class PartsLifecycleError(CraftError):
+    """Error during parts processing."""
+    
+
+class ProviderError(CraftError):
+    """Error in provider operation."""
+    
+    
+class ProjectLoadError(CraftError):
+    """Error loading rockcraft.yaml."""
+
+
+class ProjectValidationError(CraftError):
+    """Error validatiing rockcraft.yaml."""
+

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -60,6 +60,16 @@ def pack():
     project_base_image = base_image.copy_to(
         f"{project.name}:rockcraft-base", image_dir=image_dir
     )
+    
+    if project.users:
+        emit.progress(f"Setting user accounts")
+        modified_user_files = project_base_image.create_users(project.users, rootfs)
+        for user_file in modified_user_files:
+            project_base_image.insert_content(
+                user_file,
+                Path(str(user_file).replace(str(rootfs), ''))
+                )
+        emit.progress(f"Configured {len(project.users)} user" + 's'[:len(project.users)^1])
 
     lifecycle = PartsLifecycle(
         project.parts,
@@ -85,6 +95,9 @@ def pack():
 
     if project.env:
         new_image.set_env(project.env)
+        
+    if project.default_user:
+        new_image.set_default_user(project.default_user)
 
     emit.progress("Exporting to OCI archive")
     archive_name = f"{project.name}_{project.version}.rock"

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -16,16 +16,26 @@
 
 """OCI image manipulation helpers."""
 
+from datetime import datetime
+from email.mime import base
 import logging
 import os
+import random
+from re import U
 import shutil
 import subprocess
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from craft_cli import CraftError, emit
+from pydantic import conlist
+
+from rockcraft.project import UserAccount, UserInfo
+from rockcraft.errors import ConfigurationError
+from . import utils
+
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +50,107 @@ class Image:
 
     image_name: str
     path: Path
+    # Allowed UID range in Rockcraft: 589824 - 655359 (0x90000-0x9ffff)
+    # (similar to snapd, which has (0x80000-0x8ffff))
+    allowed_uid_range: conlist(int) = range(589824, 655359 + 1)
 
+    @staticmethod
+    def _sanitize_new_user(existing_users: List[str], existing_uids: List[int], username: str, uid: int = None, uid_range: List[int] = None) -> Tuple[str, str]:
+        """Makes sure the new user account doesn't exist yet, and generated a UID if necessary
+
+        :param existing_users: List with all the users which already exist in the base image
+        :type existing_users: List[str]
+        :param existing_uids: List with all the user IDs which already exist in the base image
+        :type existing_uids: List[int]
+        :param username: name of the user account to be sanitized
+        :type username: str
+        :param uid: corresponding user ID, defaults to None
+        :type uid: int, optional
+        :param uid_range: allowed range of IDs to be used if there's a need to generate a new UID, defaults to None
+        :type uid_range: List[int], optional
+        :raises ConfigurationError: when either the username or UID already exist in the base image
+        :return: the sanitized username and corresponding user ID
+        :rtype: Tuple[str, str]
+        """
+        user_id = uid if uid else random.choice(list(set(uid_range) - set(existing_uids)))
+        if username in existing_users or uid in existing_uids:
+            raise ConfigurationError(f"The provided {username}:{uid} is already configured in the base image")
+
+        return username, user_id
+
+    @staticmethod
+    def _sanitize_new_group(existing_groups: List[str], existing_gids: List[int], group: str = None, gid: int = None, gid_range: List[int] = None) -> Tuple[str, str]:
+        """Sets the new user's group, making sure it doesn't conflict with existing groups, and creating it if needed
+
+        :param existing_groups: List with all the groups which already exist in the base image
+        :type existing_groups: List[str]
+        :param existing_gids: List with all the group IDs which already exist in the base image
+        :type existing_gids: List[int]
+        :param group: name of the group to sanitize, defaults to None
+        :type group: str, optional
+        :param gid: corresponding group ID, which takes precedence over "group" when cross-checking for existing matches, defaults to None
+        :type gid: int, optional
+        :param gid_range: allowed range of IDs to be used if there's a need to generate a new GID, defaults to None
+        :type gid_range: List[int], optional
+        :raises ConfigurationError: if the provided group name is different from the one the GID already belongs to
+        :return: the sanitized group and corresponding group ID
+        :rtype: Tuple[str, str]
+        """
+        if gid and gid in existing_gids:
+            group_from_gid = existing_groups[existing_gids.index(gid)]
+            if group and group != group_from_gid:
+                raise ConfigurationError(
+                    f'The pair {group}:{gid} does not match with '
+                    f'the existing group {group_from_gid} with the GID {gid}')
+            group = group_from_gid
+        elif group and group in existing_groups:
+            gid = existing_gids[existing_groups.index(group)]
+
+        if not gid:
+            gid = random.choice(list(set(gid_range) - set(existing_gids)))
+
+        if not group:
+            # group:gid not provided - random group name
+            group = f"unnamedgroup{gid}"
+
+        return group, gid
+
+    @staticmethod
+    def _sanitize_new_user_info(user_info: UserInfo) -> Tuple[str, str, str, str, str]:
+        """Extracts the new user's information
+
+        :param user_info: object of UserInfo, containing the optional user information
+        :type user_info: UserInfo
+        :return: the user's full name, room number, work phone, home phone, and other info
+        :rtype: Tuple[str, str, str, str, str]
+        """
+        full_name = str(getattr(user_info, "full_name", "") or "")
+        room_number = str(getattr(user_info, "room_number", "") or "")
+        work_phone = str(getattr(user_info, "work_phone", "") or "")
+        home_phone = str(getattr(user_info, "home_phone", "") or "")
+        other = str(getattr(user_info, "other", "") or "")
+
+        return full_name, room_number, work_phone, home_phone, other
+
+    def _sanitize_new_user_home(self, home: Path, base_rootfs: Path) -> str:
+        """Configures the new user's home directory, creating it if it doesn't exist
+
+        :param home: user's home directory
+        :type home: Path
+        :param base_rootfs: location of the base image filesystem, to check if "home" already exists
+        :type base_rootfs: Path
+        :return: the sanitized home directory
+        :rtype: str
+        """
+        home = home if home else Path("/nonexistent")
+
+        home_in_base_rootfs = base_rootfs / str(home).lstrip('/')
+        if not os.path.exists(home_in_base_rootfs):
+            os.mkdir(home_in_base_rootfs)
+            _insert_into_image(self.path / self.image_name, home_in_base_rootfs, home)
+
+        return str(home)
+    
     @classmethod
     def from_docker_registry(cls, image_name: str, *, image_dir: Path) -> "Image":
         """Obtain an image from a docker registry.
@@ -202,6 +312,127 @@ class Image:
                 params.extend(["--config.env", env_item])
         _config_image(image_path, params)
         emit.message(f"Environment set to {env_list}", intermediate=True)
+        
+    def set_default_user(self, user: str) -> None:
+        """Set the default runtime user for the OCI image.
+
+        :param user: name of the default user (must already exist)
+        :type user: str
+        """
+        emit.progress("Configuring default user...")
+        image_path = self.path / self.image_name
+        params = ["--config.user", user]
+        _config_image(image_path, params)
+        emit.message(f"Default user set to {user}", intermediate=True)
+        
+    def create_users(self, user_accounts: List[UserAccount], base_rootfs_path: Path) -> List[Path]:
+        """Scans the base image filesystems and manually creates new users and groups
+
+        :param user_accounts: list of user accounts to be created
+        :type user_accounts: List[UserAccount]
+        :param base_rootfs_path: Path to the base filesystem
+        :type base_rootfs_path: Path
+
+        :returns: the list of files that were changed in the base image 
+        :rtype: List[Path]
+        """
+        existing_passwd_file = base_rootfs_path / "etc/passwd"
+        existing_group_file = base_rootfs_path / "etc/group"
+        existing_shadow_file = base_rootfs_path / "etc/shadow"
+
+        existing_users, existing_uids = utils.extract_values_from_file(
+            existing_passwd_file,
+            ':',
+            {0: 'str', 2: 'int'},
+            always_return=True
+        )
+
+        existing_groups, existing_gids = utils.extract_values_from_file(
+            existing_group_file,
+            ':',
+            {0: 'str', 2: 'int'},
+            always_return=True
+        )
+
+        passwd_content, shadow_content, group_content = ([] for i in range(3))
+        for account in user_accounts:
+            username, *uid = account.username.split(':')
+            ## USERNAME + UID
+            username, uid = self._sanitize_new_user(existing_users,
+                                                    existing_uids,
+                                                    username,
+                                                    uid=int(uid[0]) if uid else None,
+                                                    uid_range=self.allowed_uid_range)
+
+            existing_uids.append(uid)
+            existing_users.append(username)
+
+            # GROUP + GID
+            group, *gid = str(getattr(account, 'group', "") or "").split(':')
+            group, gid = self._sanitize_new_group(existing_groups,
+                                                  existing_gids,
+                                                  group=group if group else username,
+                                                  gid=int(gid[0]) if gid else None,
+                                                  gid_range=self.allowed_uid_range)
+
+            group_content.append(f"{group}:x:{gid}:")
+            existing_gids.append(gid)
+            existing_groups.append(group)
+
+            # USER INFO
+            user_info = self._sanitize_new_user_info(account.user_info)
+
+            # USER HOME
+            home = self._sanitize_new_user_home(account.home, base_rootfs_path)
+
+            # USER COMMAND
+            command = account.command if account.command else "/usr/sbin/nologin"
+
+            passwd_new_line = f"{username}:x:{uid}:{gid}:{user_info[0]},{user_info[1]},{user_info[2]},{user_info[3]},{user_info[4]}:{home}:{command}"
+            passwd_content.append(passwd_new_line)
+
+        with open(existing_passwd_file, 'a+') as passwdf:
+            passwdf.write('\n'.join(map(str, passwd_content)) + '\n')
+
+        with open(existing_group_file, 'a+') as groupf:
+            groupf.write('\n'.join(map(str, group_content)) + '\n')
+
+        changed_files = [existing_passwd_file, existing_group_file]
+        if os.path.exists(existing_shadow_file):
+            # TODO: TBD - no password accepted at the moment
+            days_since_epoch = (datetime.utcnow() - datetime(1970, 1, 1)).days
+            shadow_content.append(f"{username}:*:{days_since_epoch}:0:99999:7:::")
+            # only add the shadow file is there's already one in the base image
+            with open(existing_shadow_file, 'a+') as shadowf:
+                shadowf.write('\n'.join(map(str, shadow_content)) + '\n')
+
+            changed_files.append(existing_shadow_file)
+
+        return changed_files
+
+    def insert_content(self, source: Path, target: Path) -> None:
+        """Inserts content into the OCI image
+
+        :param source: source to be inserted
+        :type source: Path
+        :param target: Path in the OCI image where to insert the source content
+        :type target: Path
+        """
+        image_path = self.path / self.image_name
+        _insert_into_image(image_path, source, target)
+
+
+def _insert_into_image(image_path: Path, source: Path, target: Path) -> None:
+    """Inserts content into the OCI image
+
+        :param image_path: where to find the OCI image
+        :type image_path: Path
+        :param source: source to be inserted
+        :type source: Path
+        :param target: Path in the OCI image where to insert the source content
+        :type target: Path
+        """
+    _process_run(["umoci", "insert", "--image", str(image_path), str(source), str(target)])
 
 
 def _copy_image(source: str, destination: str) -> None:

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -16,6 +16,7 @@
 
 """Project definition and helpers."""
 
+import pathlib
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import pydantic
@@ -33,6 +34,28 @@ class ProjectValidationError(CraftError):
     """Error validatiing rockcraft.yaml."""
 
 
+class UserInfo(pydantic.BaseModel):
+    """Schema for the 'user_info' sub property of 'users'"""
+    full_name: Optional[str] = pydantic.Field(alias='full-name')
+    room_number: Optional[str] = pydantic.Field(alias='room-number')
+    work_phone: Optional[str] = pydantic.Field(alias='work-phone')
+    home_phone: Optional[str] = pydantic.Field(alias='home-phone')
+    other: Optional[str]
+    
+    
+class UserAccount(pydantic.BaseModel):
+    """Schema for the 'users' property"""
+    username: str   # e.g. <user>[:<uid>]
+    # TODO: TBD whether to accept accounts with password
+    # this would mean encrypting and adding the provided
+    # password to /etc/shadow
+    # password: Optional[str]
+    group: Optional[str]    # e.g. <group>[:<gid>]
+    user_info: Optional[UserInfo] = pydantic.Field(alias='user-info')
+    home: Optional[pathlib.Path]
+    command: Optional[str]
+    
+    
 class Project(pydantic.BaseModel):
     """Rockcraft project definition."""
 
@@ -44,6 +67,8 @@ class Project(pydantic.BaseModel):
     cmd: Optional[List[str]]
     env: Optional[List[Dict[str, str]]]
     parts: Dict[str, Any]
+    users: Optional[List[UserAccount]]
+    default_user: Optional[str]
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""

--- a/rockcraft/utils.py
+++ b/rockcraft/utils.py
@@ -112,7 +112,7 @@ def extract_values_from_file(filename: pathlib.Path, separator: str, indexes: Di
                 for i, index in enumerate(indexes.keys()):
                     try:
                         values[i].append(locate(indexes[index])(line_values[index]))
-                    except ValueError:
+                    except (IndexError, ValueError):
                         if always_return:
                             values[i].append(None)
                             continue

--- a/tests/spread/general/users/rockcraft.yaml
+++ b/tests/spread/general/users/rockcraft.yaml
@@ -1,0 +1,29 @@
+name: users-test
+version: latest
+base: ubuntu:20.04
+users:
+ - username: foo:1234
+   group: foogroup:12345
+   home: /home/foo
+   command: /bin/bash
+   user-info:
+     full-name: Foo Bar
+     other: something else
+ - username: jon
+   group: jongroup
+   home: /
+   command: /usr/sbin/nologin
+   user-info:
+     full-name: Jon Doe
+     room-number: 0
+     home-phone: +1 111 11 11
+     work-phone: +0 000 00 00
+
+default_user: foo
+
+
+parts:
+  hello:
+    plugin: nil
+    overlay-packages:
+      - hello

--- a/tests/spread/general/users/rockcraft.yaml
+++ b/tests/spread/general/users/rockcraft.yaml
@@ -9,12 +9,12 @@ users:
    user-info:
      full-name: Foo Bar
      other: something else
- - username: jon
-   group: jongroup
+ - username: john
+   group: johngroup
    home: /
    command: /usr/sbin/nologin
    user-info:
-     full-name: Jon Doe
+     full-name: John Doe
      room-number: 0
      home-phone: +1 111 11 11
      work-phone: +0 000 00 00

--- a/tests/spread/general/users/task.yaml
+++ b/tests/spread/general/users/task.yaml
@@ -1,0 +1,13 @@
+summary: container users test
+
+execute: |
+  rockcraft pack
+
+  test -f users-test_latest.rock
+  test ! -d work
+
+  # test container execution
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:users-test_latest.rock docker-daemon:users-test:latest
+  docker images
+  docker run -u foo users-test sh -c 'whoami; id; echo $HOME'

--- a/tests/spread/general/users/task.yaml
+++ b/tests/spread/general/users/task.yaml
@@ -10,4 +10,5 @@ execute: |
   docker images
   sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:users-test_latest.rock docker-daemon:users-test:latest
   docker images
-  docker run -u foo users-test sh -c 'whoami; id; echo $HOME'
+  docker run -u john users-test sh -c 'whoami; id; echo $HOME'
+  docker run users-test sh -c 'whoami; id; echo $HOME'

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -14,12 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from email.mime import base
 import os
 import tarfile
+from datetime import datetime
 from pathlib import Path
-from unittest.mock import ANY, call
+from unittest.mock import ANY, call, mock_open, patch
 
 import pytest
+import rockcraft
+from rockcraft.errors import ConfigurationError
+from rockcraft.project import UserInfo, UserAccount
 
 import tests
 from rockcraft import oci
@@ -33,6 +38,92 @@ def mock_run(mocker):
 @tests.linux_only
 class TestImage:
     """OCI image manipulation."""
+
+    @pytest.mark.parametrize(
+        "user,uid,expected_output",
+        [
+            ("jon", 331, ("jon", 331)),
+            ("jon", None, ("jon", 3)),
+        ],
+    )
+    def test__sanitize_new_user(self, user, uid, expected_output):
+        existing_users = ["foo", "bar"]
+        existing_uids = [1, 2]
+        uid_range = range(3, 4)
+
+        assert oci.Image._sanitize_new_user(existing_users, existing_uids,
+                                            user, uid, uid_range) == expected_output
+
+    def test__sanitize_new_user_conflict(self):
+        existing_users = ["foo", "bar"]
+        existing_uids = [1, 2]
+        uid_range = range(1, 3)
+
+        with pytest.raises(ConfigurationError):
+            oci.Image._sanitize_new_user(existing_users, existing_uids, "foo", 111)
+
+        with pytest.raises(ConfigurationError):
+            oci.Image._sanitize_new_user(existing_users, existing_uids, "newfoo", 1)
+
+        with pytest.raises(ConfigurationError):
+            oci.Image._sanitize_new_user(existing_users, existing_uids, "newfoo", None, uid_range)
+
+    @pytest.mark.parametrize(
+        "group,gid,expected_output",
+        [
+            ("gjon", 331, ("gjon", 331)),
+            ("gjon", None, ("gjon", 3)),
+            (None, 5, ('unnamedgroup5', 5)),
+            (None, None, ('unnamedgroup3', 3)),
+            ("foo", None, ("foo", 1)),
+            (None, 2, ("bar", 2)),
+            ("bar", 2, ("bar", 2)),
+        ],
+    )
+    def test__sanitize_new_group(self, group, gid, expected_output):
+        existing_groups = ["foo", "bar"]
+        existing_gids = [1, 2]
+        gid_range = range(3, 4)
+
+        assert oci.Image._sanitize_new_group(existing_groups, existing_gids,
+                                             group, gid, gid_range) == expected_output
+
+    def test__sanitize_new_group_conflict(self):
+        existing_groups = ["foo", "bar"]
+        existing_gids = [1, 2]
+
+        with pytest.raises(ConfigurationError):
+            oci.Image._sanitize_new_group(existing_groups, existing_gids, "otherfoo", 1)
+
+    def test__sanitize_new_user_info(self):
+        user_info = {
+            "full-name": "John Doe",
+            "room-number": "0",
+            "work-phone": "54321",
+            "home-phone": "12345",
+            "other": "comments"
+        }
+
+        assert oci.Image._sanitize_new_user_info(rockcraft.project.UserInfo(**user_info)) == tuple(user_info.values())
+
+    @patch("rockcraft.oci._insert_into_image")
+    @patch("os.mkdir")
+    @patch("os.path.exists")
+    def test__sanitize_new_user_home(self, mock_exists, mock_mkdir, mock_insert_into_image):
+        # If home dir already exists, just return it back
+        mock_exists.return_value = True
+        image = oci.Image("a:b", Path("/c"))
+        assert image._sanitize_new_user_home(None, Path('')) == '/nonexistent'
+        assert image._sanitize_new_user_home(Path('/my_home'), Path('')) == '/my_home'
+        assert len(mock_exists.mock_calls) == 2
+        mock_mkdir.assert_not_called()
+        mock_insert_into_image.assert_not_called()
+
+        # otherwise, create it
+        mock_exists.return_value = False
+        assert image._sanitize_new_user_home(Path('/my_home'), Path('')) == '/my_home'
+        mock_mkdir.assert_called_with(Path('') / 'my_home')
+        mock_insert_into_image.assert_called_with(image.path / image.image_name, Path('') / 'my_home', Path('/my_home'))
 
     def test_attributes(self):
         image = oci.Image("a:b", Path("/c"))
@@ -228,3 +319,124 @@ class TestImage:
                 universal_newlines=True,
             )
         ]
+
+    @patch('rockcraft.oci._config_image')
+    def test_set_default_user(self, mock_config_img):
+        image = oci.Image("a:b", Path("/c"))
+
+        image.set_default_user("foo")
+
+        assert mock_config_img.mock_calls == [
+            call(
+                image.path / image.image_name,
+                ["--config.user", "foo"]
+            )
+        ]
+
+    @patch('os.path.exists')
+    @patch('rockcraft.oci.Image._sanitize_new_user_home')
+    @patch('rockcraft.utils.extract_values_from_file')
+    def test_create_users(self, mock_extractor, mock_sanitize_home, mock_exists):
+        image = oci.Image("a:b", Path("/c"))
+        base_rootfs_path = Path('/rootfs')
+        mock_sanitize_home.return_value = '/my_home'
+        days_since_epoch = (datetime.utcnow() - datetime(1970, 1, 1)).days
+        mock_extractor.side_effect = [
+            ["foo", "bar"],
+            [1, 2]
+        ]
+
+        users_input = [
+            UserAccount(**{
+                'username': 'foo:1',
+                'group': 'foogroup:1',
+                'user-info': UserInfo(),
+                'command': '/bin/bash'
+            }),
+            UserAccount(**{
+                'username': 'new_bar:2',
+                'group': 'bargroup:2',
+                'user-info': UserInfo(),
+            })
+        ]
+        
+        # because "foo" already exists, get an error
+        with pytest.raises(ConfigurationError):
+            image.create_users(users_input, base_rootfs_path)
+
+        existing_users_groups = (
+            [["other-foo", "bar"], [11, 22]],
+            [["other-foog", "barg"], [111, 222]]
+        )
+        mock_extractor.side_effect = existing_users_groups
+        
+        mock_exists.return_value = False  # /etc/shadow not in base
+        m = mock_open()
+        with patch("builtins.open", m):
+            
+            assert image.create_users(users_input, base_rootfs_path) == [base_rootfs_path / 'etc/passwd',
+                                                                         base_rootfs_path / 'etc/group']
+
+            assert m.call_count == 2
+            
+            mock_exists.return_value = True  # /etc/shadow in base
+            m.reset_mock()
+            # TODO: should avoid defining this side effect again
+            mock_extractor.side_effect = (
+                [["other-foo", "bar"], [11, 22]],
+                [["other-foog", "barg"], [111, 222]]
+            )
+            assert image.create_users(users_input, base_rootfs_path) == [base_rootfs_path / 'etc/passwd',
+                                                                         base_rootfs_path / 'etc/group',
+                                                                         base_rootfs_path / 'etc/shadow']
+            
+            assert m().write.mock_calls == [
+                call(
+                    'foo:x:1:1:,,,,:/my_home:/bin/bash\nnew_bar:x:2:2:,,,,:/my_home:/usr/sbin/nologin\n'
+                ),
+                call(
+                    'foogroup:x:1:\nbargroup:x:2:\n'
+                ),
+                call(
+                    f'foo:*:{days_since_epoch}:0:99999:7:::\nnew_bar:*:{days_since_epoch}:0:99999:7:::\n'
+                )
+            ]
+            
+        # if trying to create two user accounts with the same username, should also fail
+        users_input.append(UserAccount(**{'username': 'foo:2'}))
+        # TODO: same duplication issue as above
+        mock_extractor.side_effect = (
+            [["other-foo", "bar"], [11, 22]],
+            [["other-foog", "barg"], [111, 222]]
+        )
+        with pytest.raises(ConfigurationError):
+            image.create_users(users_input, base_rootfs_path)
+
+    @patch('rockcraft.oci._insert_into_image')
+    def test_insert_content(self, mock_insert_into_img):
+        image = oci.Image("a:b", Path("/c"))
+        assert image.insert_content(Path('source'), Path('target')) is None
+        mock_insert_into_img.assert_called_once_with(
+            image.path / image.image_name, Path('source'), Path('target')
+        )
+        
+
+@patch("subprocess.run")
+def test__insert_into_image(mock_run):
+    assert oci._insert_into_image(Path('image'), Path('source'), Path('target')) is None
+    
+    assert mock_run.mock_calls == [
+        call(
+            [
+                "umoci",
+                "insert",
+                "--image",
+                "image",
+                "source",
+                "target",
+            ],
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        )
+    ]

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -24,6 +24,8 @@ from rockcraft.project import (
     ProjectLoadError,
     ProjectValidationError,
     load_project,
+    UserAccount,
+    UserInfo
 )
 
 
@@ -133,7 +135,25 @@ def test_project_load(new_dir):
             version: latest
             base: ubuntu:20.04
             build-base: ubuntu:20.04
-
+            users:
+              - username: foo:1234
+                group: foogroup:12345
+                home: /home/foo
+                command: /bin/bash
+                user-info:
+                    full-name: Foo Bar
+                    other: something else
+              - username: john
+                group: johngroup
+                home: /
+                command: /usr/sbin/nologin
+                user-info:
+                    full-name: John Doe
+                    room-number: 0
+                    home-phone: +1 111 11 11
+                    work-phone: +0 000 00 00
+            default_user: foo
+            
             parts:
               foo:
                 plugin: nil
@@ -149,6 +169,31 @@ def test_project_load(new_dir):
     assert project.version == "latest"
     assert project.base == "ubuntu:20.04"
     assert project.build_base == "ubuntu:20.04"
+
+    assert project.users == [
+        UserAccount(**{
+            'username': 'foo:1234',
+            'group': 'foogroup:12345',
+            'home': '/home/foo',
+            'command': '/bin/bash',
+            'user-info': UserInfo(**{
+                'full-name': 'Foo Bar',
+                'other': 'something else'
+            })
+        }), UserAccount(**{
+            'username': 'john',
+            'group': 'johngroup',
+            'home': '/',
+            'command': '/usr/sbin/nologin',
+            'user-info': UserInfo(**{
+                'full-name': 'John Doe',
+                'room-number': '0',
+                'home-phone': '+1 111 11 11',
+                'work-phone': '+0 000 00 00'
+            })
+        })
+    ]
+    assert project.default_user == "foo"
     assert project.parts == {
         "foo": {
             "plugin": "nil",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -107,3 +107,6 @@ def test_confirm_with_user_errors_in_managed_mode(mock_is_managed_mode):
 
     with pytest.raises(RuntimeError):
         utils.confirm_with_user("prompt")
+
+
+def test_extract_values_from_file


### PR DESCRIPTION
Adds the properties `users` and `default_user` to rockcraft.yaml, allowing for the build-time creation of new users, as well as for the configuration of the default runtime user for the container image.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
fixes https://github.com/canonical/rockcraft/issues/23