### PR TITLE
parts: enable stage package dependency cutoff

### DIFF
--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -64,6 +64,7 @@ def pack():
     lifecycle = PartsLifecycle(
         project.parts,
         work_dir=work_dir,
+        base=project.base,
         base_layer_dir=rootfs,
         base_layer_hash=project_base_image.digest(),
     )

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -25,6 +25,15 @@ from craft_parts import ActionType, Step, plugins
 from craft_parts.parts import PartSpec
 from xdg import BaseDirectory  # type: ignore
 
+# XXX: craft-parts expects a core base to perform dependency cutoff for stage
+#      packages. A different strategy must be used to set the build base if
+#      building on top of an existing ROCK (currently not supported).
+_BASE_MAPPING = {
+    "ubuntu:18.04": "core18",
+    "ubuntu:20.04": "core20",
+    "ubuntu:22.04": "core22",
+}
+
 
 class PartsLifecycleError(CraftError):
     """Error during parts processing."""
@@ -46,6 +55,7 @@ class PartsLifecycle:
         all_parts: Dict[str, Any],
         *,
         work_dir: pathlib.Path,
+        base: str,
         base_layer_dir: pathlib.Path,
         base_layer_hash: bytes,
     ):
@@ -60,6 +70,7 @@ class PartsLifecycle:
                 application_name="rockcraft",
                 work_dir=work_dir,
                 cache_dir=cache_dir,
+                base=_BASE_MAPPING.get(base, ""),
                 base_layer_dir=base_layer_dir,
                 base_layer_hash=base_layer_hash,
                 ignore_local_sources=["*.rock"],

--- a/rockcraft/utils.py
+++ b/rockcraft/utils.py
@@ -16,7 +16,6 @@
 
 """Utilities for rockcraft."""
 
-import distutils.util
 import logging
 import os
 import pathlib
@@ -32,7 +31,7 @@ OSPlatform = namedtuple("OSPlatform", "system release machine")
 def is_managed_mode():
     """Check if rockcraft is running in a managed environment."""
     managed_flag = os.getenv("ROCKCRAFT_MANAGED_MODE", "n")
-    return distutils.util.strtobool(managed_flag) == 1
+    return strtobool(managed_flag) == 1
 
 
 def get_managed_environment_home_path():
@@ -85,3 +84,20 @@ def confirm_with_user(prompt, default=False) -> bool:
         return False
 
     return default
+
+
+def strtobool(value: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    :param value: a True value of 'y', 'yes', 't', 'true', 'on', and '1'
+        or a False value of 'n', 'no', 'f', 'false', 'off', and '0'.
+    :raises ValueError: if `value` is not a valid boolean value.
+    """
+    parsed_value = value.lower()
+
+    if parsed_value in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if parsed_value in ("n", "no", "f", "false", "off", "0"):
+        return False
+
+    raise ValueError(f"Invalid boolean value of {value!r}")

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -33,6 +33,7 @@ def test_parts_lifecycle_prime_dir(new_dir):
     lifecycle = parts.PartsLifecycle(
         all_parts=parts_data,
         work_dir=Path("/some/workdir"),
+        base="ubuntu:20.04",
         base_layer_dir=new_dir,
         base_layer_hash=b"digest",
     )
@@ -54,6 +55,7 @@ def test_parts_lifecycle_run(new_dir):
     lifecycle = parts.PartsLifecycle(
         all_parts=parts_data,
         work_dir=Path("."),
+        base="ubuntu:20.04",
         base_layer_dir=new_dir,
         base_layer_hash=b"digest",
     )
@@ -74,6 +76,7 @@ def test_parts_lifecycle_error(new_dir):
         parts.PartsLifecycle(
             all_parts=parts_data,
             work_dir=Path("."),
+            base="ubuntu:20.04",
             base_layer_dir=new_dir,
             base_layer_hash=b"digest",
         )


### PR DESCRIPTION
Pass a base to craft-parts to cut stage packages dependency resolution
to not include packages that are already part of the base.

Also replace distutils.util's strtobool with local implementation to address
linter issue.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
