### PR TITLE
cleanup: don't write test files in cwd

### DIFF
--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -17,7 +17,6 @@
 import datetime
 import json
 import textwrap
-from pathlib import Path
 
 import pytest
 
@@ -164,13 +163,14 @@ def test_project_parts_validation(yaml_data):
     )
 
 
-def test_project_load(yaml_data):
-    Path("rockcraft.yaml").write_text(
+def test_project_load(yaml_data, tmp_path):
+    rockcraft_file = tmp_path / "rockcraft.yaml"
+    rockcraft_file.write_text(
         textwrap.dedent(json.dumps(yaml_data)),
         encoding="utf-8",
     )
 
-    project = load_project("rockcraft.yaml")
+    project = load_project(str(rockcraft_file))
 
     for attr, v in yaml_data.items():
         if attr == "license":


### PR DESCRIPTION
Use "tmp_path" to isolate test data and keep the result of "make
test-units" clean.

I want to do some more cleaning-up but I figured I'd get this 'easy' fix out of the way
