### PR TITLE
feat: refactor all errors into reusable module

### DIFF
--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -1,0 +1,39 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Rockcraft error definitions."""
+
+from craft_cli import CraftError
+
+
+class RockcraftInitError(CraftError):
+    """Error while initializing rockcraft project."""
+
+
+class PartsLifecycleError(CraftError):
+    """Error during parts processing."""
+
+
+class ProviderError(CraftError):
+    """Error in provider operation."""
+
+
+class ProjectLoadError(CraftError):
+    """Error loading rockcraft.yaml."""
+
+
+class ProjectValidationError(CraftError):
+    """Error validating rockcraft.yaml."""

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -20,14 +20,12 @@ import pathlib
 from typing import Any, Dict
 
 import craft_parts
-from craft_cli import CraftError, emit
+from craft_cli import emit
 from craft_parts import ActionType, Step, plugins
 from craft_parts.parts import PartSpec
 from xdg import BaseDirectory  # type: ignore
 
-
-class PartsLifecycleError(CraftError):
-    """Error during parts processing."""
+from rockcraft.errors import PartsLifecycleError
 
 
 class PartsLifecycle:

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -21,17 +21,9 @@ from typing import Any, Dict, List, Literal, Optional, Tuple
 import pydantic
 import spdx_license_list  # type: ignore
 import yaml
-from craft_cli.errors import CraftError
 
+from rockcraft.errors import ProjectLoadError, ProjectValidationError
 from rockcraft.parts import validate_part
-
-
-class ProjectLoadError(CraftError):
-    """Error loading rockcraft.yaml."""
-
-
-class ProjectValidationError(CraftError):
-    """Error validatiing rockcraft.yaml."""
 
 
 class Project(pydantic.BaseModel):

--- a/rockcraft/providers/__init__.py
+++ b/rockcraft/providers/__init__.py
@@ -16,10 +16,11 @@
 
 """Build provider support."""
 
+from rockcraft.errors import ProviderError  # noqa: F401
+
 from ._buildd import RockcraftBuilddBaseConfiguration  # noqa: F401
 from ._get_provider import get_provider  # noqa: F401
 from ._logs import capture_logs_from_instance  # noqa: F401
 from ._lxd import LXDProvider  # noqa: F401
 from ._multipass import MultipassProvider  # noqa: F401
 from ._provider import Provider  # noqa: F401
-from ._provider import ProviderError  # noqa: F401

--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -23,10 +23,11 @@ from typing import Generator, List
 
 from craft_providers import Executor, bases, lxd
 
+from rockcraft.errors import ProviderError
 from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
 
 from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, RockcraftBuilddBaseConfiguration
-from ._provider import Provider, ProviderError
+from ._provider import Provider
 
 logger = logging.getLogger(__name__)
 

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -24,10 +24,11 @@ from typing import Generator, List
 from craft_providers import Executor, bases, multipass
 from craft_providers.multipass.errors import MultipassError
 
+from rockcraft.errors import ProviderError
 from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
 
 from ._buildd import BASE_TO_BUILDD_IMAGE_ALIAS, RockcraftBuilddBaseConfiguration
-from ._provider import Provider, ProviderError
+from ._provider import Provider
 
 logger = logging.getLogger(__name__)
 

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -22,12 +22,7 @@ import pathlib
 from abc import ABC, abstractmethod
 from typing import Dict, Generator, List, Optional, Tuple, Union
 
-from craft_cli.errors import CraftError
 from craft_providers import Executor, bases
-
-
-class ProviderError(CraftError):
-    """Error in provider operation."""
 
 
 class Provider(ABC):

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -20,12 +20,8 @@ import textwrap
 
 import pytest
 
-from rockcraft.project import (
-    Project,
-    ProjectLoadError,
-    ProjectValidationError,
-    load_project,
-)
+from rockcraft.errors import ProjectLoadError, ProjectValidationError
+from rockcraft.project import Project, load_project
 
 
 @pytest.fixture


### PR DESCRIPTION
Instead of having the definition of custom exceptions spread out through different files, this refactoring brings all the Rockcraft exceptions into a single and common error.py file.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
