### PR TITLE
spread: add a "big" spread test

### DIFF
--- a/tests/spread/general/big/rockcraft.yaml
+++ b/tests/spread/general/big/rockcraft.yaml
@@ -1,0 +1,24 @@
+name: big
+version: latest
+summary: A big ROCK to test many features
+description: |
+  A big ROCK whose purpose is to test many features while only paying the "setup"
+  and "teardown" price once. Feel free to add to this file and to "task.yaml", 
+  adding references to issues/PRs where appropriate.
+license: Apache-2.0
+base: ubuntu:22.04
+
+parts:
+  issue-44-dir-owner:
+    plugin: dump
+    source: files
+    organize:
+      a.txt: etc/newfiles/a.txt
+      b.txt: etc/newfiles/b.txt
+    stage:
+      - etc/newfiles/a.txt
+      - etc/newfiles/b.txt
+    override-prime: |
+      craftctl default
+      chown -R 9999:9999 etc/newfiles
+      chown 3333:3333 etc/newfiles/b.txt

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -1,0 +1,33 @@
+summary: a big test meant to check many aspects of rockcraft
+
+execute: |
+  echo "hi"
+  whoami
+
+  mkdir files
+  echo "a.txt" > files/a.txt
+  echo "b.txt" > files/b.txt
+
+  rockcraft pack
+
+  ROCK=`ls big*.rock`
+
+  test -f $ROCK
+  test ! -d work
+
+  # copy image to docker
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:big:latest
+  rm $ROCK
+
+  docker images
+  
+  ############################################################################################
+  # test ownership: "newfiles" and "a.txt" are owned by uid 9999, "b.txt" is owned by uid 3333
+  # (github issue #44)
+  ############################################################################################
+  docker run --rm big bash -c "stat -c %u /etc/newfiles | grep -q 9999"
+  docker run --rm big bash -c "stat -c %u /etc/newfiles/a.txt | grep -q 9999"
+  docker run --rm big bash -c "stat -c %u /etc/newfiles/b.txt | grep -q 3333"
+
+  docker system prune -a -f


### PR DESCRIPTION
This new test can be used to "house" multiple different checks without
having to "setup" and "teardown" the whole machinery multiple times.
This initial version tests bug #44, regarding permissions of added
directories.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

@sergiusens @cmatsuoka this is an attempt at adding a spread test that we can augment over time, as discussed last week. Thanksss