### PR TITLE
commands: add lifecycle step commands

### DIFF
--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -30,6 +30,11 @@ COMMAND_GROUPS = [
     craft_cli.CommandGroup(
         "Lifecycle",
         [
+            commands.PullCommand,
+            commands.OverlayCommand,
+            commands.BuildCommand,
+            commands.StageCommand,
+            commands.PrimeCommand,
             commands.PackCommand,
         ],
     )

--- a/rockcraft/commands/__init__.py
+++ b/rockcraft/commands/__init__.py
@@ -16,4 +16,20 @@
 
 """Rockcraft commands."""
 
-from .lifecycle import PackCommand  # noqa: F401
+from .lifecycle import (
+    BuildCommand,
+    OverlayCommand,
+    PackCommand,
+    PrimeCommand,
+    PullCommand,
+    StageCommand,
+)
+
+__all__ = [
+    "PullCommand",
+    "OverlayCommand",
+    "BuildCommand",
+    "StageCommand",
+    "PrimeCommand",
+    "PackCommand",
+]

--- a/rockcraft/commands/lifecycle.py
+++ b/rockcraft/commands/lifecycle.py
@@ -58,7 +58,7 @@ class _LifecycleStepCommand(_LifecycleCommand):
 
 
 class PullCommand(_LifecycleStepCommand):
-    """The "pull" command."""
+    """Command to pull parts."""
 
     name = "pull"
     help_msg = "Download or retrieve artifacts defined for a part"
@@ -72,7 +72,7 @@ class PullCommand(_LifecycleStepCommand):
 
 
 class OverlayCommand(_LifecycleStepCommand):
-    """The "overlay" command."""
+    """Command to overlay parts."""
 
     name = "overlay"
     help_msg = "Create part layers over the base filesystem."
@@ -85,7 +85,7 @@ class OverlayCommand(_LifecycleStepCommand):
 
 
 class BuildCommand(_LifecycleStepCommand):
-    """The "build" command."""
+    """Command to build parts."""
 
     name = "build"
     help_msg = "Build artifacts defined for a part"
@@ -98,7 +98,7 @@ class BuildCommand(_LifecycleStepCommand):
 
 
 class StageCommand(_LifecycleStepCommand):
-    """The "stage" command."""
+    """Command to stage parts."""
 
     name = "stage"
     help_msg = "Stage built artifacts into a common staging area"
@@ -112,7 +112,7 @@ class StageCommand(_LifecycleStepCommand):
 
 
 class PrimeCommand(_LifecycleStepCommand):
-    """The "prime" command."""
+    """Command to prime parts."""
 
     name = "prime"
     help_msg = "Prime artifacts defined for a part"
@@ -126,7 +126,7 @@ class PrimeCommand(_LifecycleStepCommand):
 
 
 class PackCommand(_LifecycleCommand):
-    """The "pack" command."""
+    """Command to pack the final artifact."""
 
     name = "pack"
     help_msg = "Build artifacts defined for a part"

--- a/rockcraft/commands/lifecycle.py
+++ b/rockcraft/commands/lifecycle.py
@@ -43,7 +43,7 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
 
 
 class _LifecycleStepCommand(_LifecycleCommand):
-    """Run lifecycle step commands."""
+    """Lifecycle step commands."""
 
     @overrides
     def fill_parser(self, parser: "argparse.ArgumentParser") -> None:

--- a/rockcraft/commands/lifecycle.py
+++ b/rockcraft/commands/lifecycle.py
@@ -58,7 +58,7 @@ class _LifecycleStepCommand(_LifecycleCommand):
 
 
 class PullCommand(_LifecycleStepCommand):
-    """Run the lifecycle up to the pull step."""
+    """The "pull" command."""
 
     name = "pull"
     help_msg = "Download or retrieve artifacts defined for a part"
@@ -72,7 +72,7 @@ class PullCommand(_LifecycleStepCommand):
 
 
 class OverlayCommand(_LifecycleStepCommand):
-    """Run the lifecycle up to the overlay step."""
+    """The "overlay" command."""
 
     name = "overlay"
     help_msg = "Create part layers over the base filesystem."
@@ -85,7 +85,7 @@ class OverlayCommand(_LifecycleStepCommand):
 
 
 class BuildCommand(_LifecycleStepCommand):
-    """Run the lifecycle up to the build step."""
+    """The "build" command."""
 
     name = "build"
     help_msg = "Build artifacts defined for a part"
@@ -98,7 +98,7 @@ class BuildCommand(_LifecycleStepCommand):
 
 
 class StageCommand(_LifecycleStepCommand):
-    """Run the lifecycle up to the stage step."""
+    """The "stage" command."""
 
     name = "stage"
     help_msg = "Stage built artifacts into a common staging area"
@@ -112,7 +112,7 @@ class StageCommand(_LifecycleStepCommand):
 
 
 class PrimeCommand(_LifecycleStepCommand):
-    """Prepare the final payload for packing."""
+    """The "prime" command."""
 
     name = "prime"
     help_msg = "Prime artifacts defined for a part"
@@ -126,7 +126,7 @@ class PrimeCommand(_LifecycleStepCommand):
 
 
 class PackCommand(_LifecycleCommand):
-    """Prepare the final payload for packing."""
+    """The "pack" command."""
 
     name = "pack"
     help_msg = "Build artifacts defined for a part"

--- a/rockcraft/commands/lifecycle.py
+++ b/rockcraft/commands/lifecycle.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 class _LifecycleCommand(BaseCommand, abc.ABC):
-    """Run lifecycle-related commands."""
+    """Lifecycle-related commands."""
 
     @overrides
     def run(self, parsed_args):
@@ -72,7 +72,7 @@ class PullCommand(_LifecycleStepCommand):
 
 
 class OverlayCommand(_LifecycleStepCommand):
-    """Run the lifecycle up to the build step."""
+    """Run the lifecycle up to the overlay step."""
 
     name = "overlay"
     help_msg = "Create part layers over the base filesystem."

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -15,7 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from unittest.mock import call, patch
+from argparse import Namespace
+from unittest.mock import call
 
 import pytest
 from craft_cli import emit
@@ -23,18 +24,33 @@ from craft_cli import emit
 from rockcraft import cli
 
 
-@pytest.fixture
-def lifecycle_pack_mock():
-    """Mock for ui.init."""
-    patcher = patch("rockcraft.lifecycle.pack")
-    yield patcher.start()
-    patcher.stop()
+@pytest.mark.parametrize("cmd", ["pull", "overlay", "build", "stage", "prime"])
+def test_run_command(mocker, cmd):
+    run_mock = mocker.patch("rockcraft.lifecycle.run")
+    mock_ended_ok = mocker.spy(emit, "ended_ok")
+    mocker.patch.object(sys, "argv", ["rockcraft", cmd])
+    cli.run()
+
+    assert run_mock.mock_calls == [call(cmd, Namespace(parts=[]))]
+    assert mock_ended_ok.mock_calls == [call()]
 
 
-def test_run_defaults(mocker, lifecycle_pack_mock):
+@pytest.mark.parametrize("cmd", ["pull", "overlay", "build", "stage", "prime"])
+def test_run_command_parts(mocker, cmd):
+    run_mock = mocker.patch("rockcraft.lifecycle.run")
+    mock_ended_ok = mocker.spy(emit, "ended_ok")
+    mocker.patch.object(sys, "argv", ["rockcraft", cmd, "part1", "part2"])
+    cli.run()
+
+    assert run_mock.mock_calls == [call(cmd, Namespace(parts=["part1", "part2"]))]
+    assert mock_ended_ok.mock_calls == [call()]
+
+
+def test_run_pack(mocker):
+    run_mock = mocker.patch("rockcraft.lifecycle.run")
     mock_ended_ok = mocker.spy(emit, "ended_ok")
     mocker.patch.object(sys, "argv", ["rockcraft", "pack"])
     cli.run()
 
-    assert lifecycle_pack_mock.mock_calls == [call()]
+    assert run_mock.mock_calls == [call("pack", Namespace())]
     assert mock_ended_ok.mock_calls == [call()]

--- a/tests/unit/test_parts.py
+++ b/tests/unit/test_parts.py
@@ -33,6 +33,7 @@ def test_parts_lifecycle_prime_dir(new_dir):
     lifecycle = parts.PartsLifecycle(
         all_parts=parts_data,
         work_dir=Path("/some/workdir"),
+        part_names=None,
         base_layer_dir=new_dir,
         base_layer_hash=b"digest",
     )
@@ -54,10 +55,11 @@ def test_parts_lifecycle_run(new_dir):
     lifecycle = parts.PartsLifecycle(
         all_parts=parts_data,
         work_dir=Path("."),
+        part_names=None,
         base_layer_dir=new_dir,
         base_layer_hash=b"digest",
     )
-    lifecycle.run(parts.Step.PRIME)
+    lifecycle.run("prime")
 
     assert Path(lifecycle.prime_dir, "foo.txt").is_file()
 
@@ -74,6 +76,7 @@ def test_parts_lifecycle_error(new_dir):
         parts.PartsLifecycle(
             all_parts=parts_data,
             work_dir=Path("."),
+            part_names=None,
             base_layer_dir=new_dir,
             base_layer_hash=b"digest",
         )


### PR DESCRIPTION
Implement rockcraft commands for the parts lifecycle steps pull,
overlay, build, stage, and prime. Originally implemented to debug
problems related to OCI whiteout files in part layers.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
