### PR TITLE
requirements: update craft-parts to 1.13.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ codespell==2.1.0
 commonmark==0.9.1
 coverage==6.4
 craft-cli==0.6.0
-craft-parts==1.7.1
+craft-parts==1.13.0
 craft-providers==1.3.0
 cryptography==37.0.2
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Babel==2.10.1
 certifi==2022.5.18.1
 charset-normalizer==2.0.12
 craft-cli==0.6.0
-craft-parts==1.7.1
+craft-parts==1.13.0
 craft-providers==1.3.0
 Deprecated==1.2.13
 docutils==0.17.1


### PR DESCRIPTION
Craft-parts 1.13.0 removes unnecessary whiteout files and should
fix #38.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
