### PR TITLE
update craft-cli to 1.2.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,9 @@ jobs:
           sudo snap install --classic node
           sudo snap install --classic pyright
           make test-pyright
+      - name: Run pylint
+        run: |
+          make test-pylint          
 
   tests:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## Show this help.
 .PHONY: autoformat
 autoformat: ## Run automatic code formatters.
 	isort .
-	autoflake --remove-all-unused-imports --ignore-init-module-imports -ri .
+	autoflake rockcraft/ tests/
 	black .
 
 .PHONY: clean

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ click==8.1.3
 codespell==2.2.1
 commonmark==0.9.1
 coverage==6.4.4
-craft-cli==0.6.0
+craft-cli==1.2.0
 craft-parts==1.13.0
 craft-providers==1.4.1
 cryptography==37.0.4

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,7 +2,7 @@ alabaster==0.7.12
 Babel==2.10.3
 certifi==2022.6.15
 charset-normalizer==2.1.1
-craft-cli==0.6.0
+craft-cli==1.2.0
 craft-parts==1.13.0
 craft-providers==1.4.1
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alabaster==0.7.12
 Babel==2.10.3
 certifi==2022.6.15
 charset-normalizer==2.1.1
-craft-cli==0.6.0
+craft-cli==1.2.0
 craft-parts==1.13.0
 craft-providers==1.4.1
 Deprecated==1.2.13

--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -55,7 +55,7 @@ def run():
         logger.setLevel(logging.DEBUG)
 
     emit_args = {
-        "mode": EmitterMode.NORMAL,
+        "mode": EmitterMode.BRIEF,
         "appname": "rockcraft",
         "greeting": f"Starting Rockcraft {__version__}",
     }

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -79,13 +79,11 @@ def run(command_name: str, parsed_args: "argparse.Namespace"):
                 arch=build_for,
                 variant=build_for_variant,
             )
-        emit.message(
-            f"Retrieved base {project.base} for {build_for}", intermediate=True
-        )
+        emit.progress(f"Retrieved base {project.base} for {build_for}", permanent=True)
 
         emit.progress(f"Extracting {base_image.image_name}")
         rootfs = base_image.extract_to(bundle_dir)
-        emit.message(f"Extracted {base_image.image_name}", intermediate=True)
+        emit.progress(f"Extracted {base_image.image_name}", permanent=True)
 
         # TODO: check if destination image already exists, etc.
         project_base_image = base_image.copy_to(
@@ -133,7 +131,7 @@ def _pack(
     new_image = project_base_image.add_layer(
         tag=project.version, layer_path=lifecycle.prime_dir
     )
-    emit.message("Created new layer", intermediate=True)
+    emit.progress("Created new layer", permanent=True)
 
     if project.entrypoint:
         new_image.set_entrypoint(project.entrypoint)
@@ -163,7 +161,7 @@ def _pack(
     emit.progress("Exporting to OCI archive")
     archive_name = f"{project.name}_{project.version}_{rock_suffix}.rock"
     new_image.to_oci_archive(tag=project.version, filename=archive_name)
-    emit.message(f"Exported to OCI archive '{archive_name}'", intermediate=True)
+    emit.progress(f"Exported to OCI archive '{archive_name}'", permanent=True)
 
 
 def _run_in_provider(

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -196,7 +196,7 @@ class Image:
         for entry in entrypoint:
             params.extend(["--config.entrypoint", entry])
         _config_image(image_path, params)
-        emit.message(f"Entrypoint set to {entrypoint}", intermediate=True)
+        emit.progress(f"Entrypoint set to {entrypoint}", permanent=True)
 
     def set_cmd(self, cmd: List[str]) -> None:
         """Set the OCI image default command parameters.
@@ -211,7 +211,7 @@ class Image:
         for entry in cmd:
             params.extend(["--config.cmd", entry])
         _config_image(image_path, params)
-        emit.message(f"Cmd set to {cmd}", intermediate=True)
+        emit.progress(f"Cmd set to {cmd}", permanent=True)
 
     def set_env(self, env: List[Dict[str, str]]) -> None:
         """Set the OCI image environment.
@@ -229,7 +229,7 @@ class Image:
                 env_list.append(env_item)
                 params.extend(["--config.env", env_item])
         _config_image(image_path, params)
-        emit.message(f"Environment set to {env_list}", intermediate=True)
+        emit.progress(f"Environment set to {env_list}", permanent=True)
 
     def set_control_data(self, metadata: Dict[str, Any]) -> None:
         """Create and populate the ROCK's control data folder.
@@ -279,7 +279,7 @@ class Image:
         _config_image(image_path, label_params)
         # Set the annotations as a copy of these labels (for OCI compliance only)
         _config_image(image_path, annotation_params)
-        emit.message(f"Labels and annotations set to {labels_list}", intermediate=True)
+        emit.progress(f"Labels and annotations set to {labels_list}", permanent=True)
 
 
 def _copy_image(source: str, destination: str, *system_params) -> None:

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -118,12 +118,12 @@ class PartsLifecycle:
                     emit.progress(f"Executing parts lifecycle: {message}")
                     with emit.open_stream("Executing action") as stream:
                         aex.execute(action, stdout=stream, stderr=stream)
-                    emit.message(f"Executed: {message}", intermediate=True)
+                    emit.progress(f"Executed: {message}", permanent=True)
 
             if shell_after:
                 launch_shell()
 
-            emit.message("Executed parts lifecycle", intermediate=True)
+            emit.progress("Executed parts lifecycle", permanent=True)
         except RuntimeError as err:
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:
@@ -140,7 +140,7 @@ def launch_shell(*, cwd: Optional[pathlib.Path] = None) -> None:
 
     :param cwd: Working directory to start user in.
     """
-    emit.message("Launching shell on build environment...", intermediate=True)
+    emit.progress("Launching shell on build environment...", permanent=True)
     with emit.pause():
         subprocess.run(["bash"], check=False, cwd=cwd)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 packages = find:
 zip_safe = False
 install_requires =
-    craft-cli ==0.6.0 # Pinned until we update the code
+    craft-cli
     craft-parts
     craft-providers
     overrides

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,12 @@ max-line-length = 88
 # E501 line too long
 extend-ignore = E203,E501
 
+[autoflake]
+remove-all-unused-imports=true
+ignore-init-module-imports=true
+recursive=true
+in-place=true
+
 [mypy]
 python_version = 3.8
 plugins = pydantic.mypy

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -327,14 +327,12 @@ def test_project_load(yaml_data, yaml_loaded_data, tmp_path):
             attr = "rock_license"
         if attr == "platforms":
             # platforms get mutated at validation time
-            assert project.__getattribute__(attr).keys() == v.keys()
+            assert getattr(project, attr).keys() == v.keys()
             assert all(
-                "build_on" in platform
-                for platform in project.__getattribute__(attr).values()
+                "build_on" in platform for platform in getattr(project, attr).values()
             )
             assert all(
-                "build_for" in platform
-                for platform in project.__getattribute__(attr).values()
+                "build_for" in platform for platform in getattr(project, attr).values()
             )
             continue
 


### PR DESCRIPTION
Some minor code updates to reflect the Emitter changes, following the
steps taken in charmcraft's equivalent PR https://github.com/canonical/charmcraft/pull/801

Also did some minor housekeeping by enabling the 'pylint' linter in the linters CI job, and updating the 'autoformat' config to not _fix files in the virtualenv_ :scream: 
