### PR TITLE
parts: use part validator from craft-parts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ codespell==2.2.1
 commonmark==0.9.1
 coverage==6.4.4
 craft-cli==1.2.0
-craft-parts==1.13.0
+craft-parts==1.14.0
 craft-providers==1.4.1
 cryptography==37.0.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Babel==2.10.3
 certifi==2022.6.15
 charset-normalizer==2.1.1
 craft-cli==1.2.0
-craft-parts==1.13.0
+craft-parts==1.14.0
 craft-providers==1.4.1
 Deprecated==1.2.13
 docutils==0.17.1

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -22,8 +22,7 @@ from typing import Any, Dict, List, Optional
 
 import craft_parts
 from craft_cli import emit
-from craft_parts import ActionType, Step, plugins
-from craft_parts.parts import PartSpec
+from craft_parts import ActionType, Step
 from xdg import BaseDirectory  # type: ignore
 
 from rockcraft.errors import PartsLifecycleError
@@ -191,21 +190,4 @@ def validate_part(data: Dict[str, Any]) -> None:
 
     :param data: The part data to validate.
     """
-    if not isinstance(data, dict):
-        raise TypeError("value must be a dictionary")
-
-    # copy the original data, we'll modify it
-    spec = data.copy()
-
-    plugin_name = spec.get("plugin")
-    if not plugin_name:
-        raise ValueError("'plugin' not defined")
-
-    plugin_class = plugins.get_plugin_class(plugin_name)
-
-    # validate plugin properties
-    plugin_class.properties_class.unmarshal(spec)
-
-    # validate common part properties
-    part_spec = plugins.extract_part_properties(spec, plugin_name=plugin_name)
-    PartSpec(**part_spec)
+    craft_parts.validate_part(data)


### PR DESCRIPTION
Use the common part validator implemented in craft-parts to validate part data against part and plugin models, and drop the local implementation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
