### PR TITLE
providers: install rockcraft snap via craft-providers API

### DIFF
--- a/rockcraft/providers/_buildd.py
+++ b/rockcraft/providers/_buildd.py
@@ -16,14 +16,7 @@
 
 """Buildd-related helpers for Rockcraft."""
 
-import sys
-from typing import Optional
-
-from craft_providers import Executor, bases
-from craft_providers.actions import snap_installer
-from overrides import overrides
-
-from rockcraft import utils
+from craft_providers import bases
 
 BASE_TO_BUILDD_IMAGE_ALIAS = {
     "ubuntu:18.04": bases.BuilddBaseAlias.BIONIC,
@@ -44,91 +37,3 @@ class RockcraftBuilddBaseConfiguration(bases.BuilddBase):
     """
 
     compatibility_tag: str = f"rockcraft-{bases.BuilddBase.compatibility_tag}.0"
-
-    @staticmethod
-    def _setup_rockcraft(*, executor: Executor) -> None:
-        """Install Rockcraft in target environment.
-
-        On Linux, the default behavior is to inject the host snap into the target
-        environment.
-
-        On other platforms, the Rockcraft snap is installed from the Snap Store.
-
-        When installing the snap from the Store, we check if the user specifies a
-        channel, using ROCKCRAFT_INSTALL_SNAP_CHANNEL=<channel>.  If unspecified,
-        we use the "stable" channel on the default track.
-
-        On Linux, the user may specify this environment variable to force Rockcraft
-        to install the snap from the Store rather than inject the host snap.
-
-        :raises BaseConfigurationError: on error.
-        """
-        snap_channel = utils.get_managed_environment_snap_channel()
-        if snap_channel is None and sys.platform != "linux":
-            snap_channel = "stable"
-
-        if snap_channel:
-            try:
-                snap_installer.install_from_store(
-                    executor=executor,
-                    snap_name="rockcraft",
-                    channel=snap_channel,
-                    classic=True,
-                )
-            except snap_installer.SnapInstallationError as error:
-                raise bases.BaseConfigurationError(
-                    brief="Failed to install rockcraft snap from store channel "
-                    f"{snap_channel!r} into target environment."
-                ) from error
-        else:
-            try:
-                snap_installer.inject_from_host(
-                    executor=executor, snap_name="rockcraft", classic=True
-                )
-            except snap_installer.SnapInstallationError as error:
-                raise bases.BaseConfigurationError(
-                    brief="Failed to inject host rockcraft snap into target environment."
-                ) from error
-
-    @overrides
-    def setup(
-        self,
-        *,
-        executor: Executor,
-        retry_wait: float = 0.25,
-        timeout: Optional[float] = None,
-    ) -> None:
-        """Prepare base instance for use by the application.
-
-        :param executor: Executor for target container.
-        :param retry_wait: Duration to sleep() between status checks (if required).
-        :param timeout: Timeout in seconds.
-
-        :raises BaseCompatibilityError: if instance is incompatible.
-        :raises BaseConfigurationError: on other unexpected error.
-        """
-        super().setup(executor=executor, retry_wait=retry_wait, timeout=timeout)
-        self._setup_rockcraft(executor=executor)
-
-    @overrides
-    def warmup(
-        self,
-        *,
-        executor: Executor,
-        retry_wait: float = 0.25,
-        timeout: Optional[float] = None,
-    ) -> None:
-        """Prepare a previously created and setup instance for use by the application.
-
-        In addition to the guarantees provided by buildd:
-            - rockcraft installed
-
-        :param executor: Executor for target container.
-        :param retry_wait: Duration to sleep() between status checks (if required).
-        :param timeout: Timeout in seconds.
-
-        :raises BaseCompatibilityError: if instance is incompatible.
-        :raises BaseConfigurationError: on other unexpected error.
-        """
-        super().warmup(executor=executor, retry_wait=retry_wait, timeout=timeout)
-        self._setup_rockcraft(executor=executor)

--- a/tests/unit/providers/test_buildd.py
+++ b/tests/unit/providers/test_buildd.py
@@ -14,34 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-import sys
-from unittest import mock
-from unittest.mock import call
-
 import pytest
 from craft_providers import bases
-from craft_providers.actions import snap_installer
 
 from rockcraft import providers
 
 
-@pytest.fixture
-def mock_inject():
-    with mock.patch(
-        "craft_providers.actions.snap_installer.inject_from_host"
-    ) as mock_inject:
-        yield mock_inject
-
-
-@pytest.fixture
-def mock_install_from_store():
-    with mock.patch(
-        "craft_providers.actions.snap_installer.install_from_store"
-    ) as mock_install:
-        yield mock_install
-
-
 @pytest.mark.parametrize(
     "alias",
     [
@@ -50,115 +28,8 @@ def mock_install_from_store():
         bases.BuilddBaseAlias.JAMMY,
     ],
 )
-def test_base_configuration_setup_inject_from_host(
-    mock_instance, mock_inject, mock_install_from_store, monkeypatch, alias
-):
-    monkeypatch.setattr(sys, "platform", "linux")
-
+def test_base_configuration_compatibility_tag(mock_instance, monkeypatch, alias):
     config = providers.RockcraftBuilddBaseConfiguration(alias=alias)
     config.setup(executor=mock_instance)
 
-    assert mock_inject.mock_calls == [
-        call(executor=mock_instance, snap_name="rockcraft", classic=True)
-    ]
-    assert mock_install_from_store.mock_calls == []
-
     assert config.compatibility_tag == "rockcraft-buildd-base-v0.0"
-
-
-@pytest.mark.parametrize(
-    "alias",
-    [
-        bases.BuilddBaseAlias.BIONIC,
-        bases.BuilddBaseAlias.FOCAL,
-        bases.BuilddBaseAlias.JAMMY,
-    ],
-)
-def test_base_configuration_setup_from_store(
-    mock_instance, mock_inject, mock_install_from_store, monkeypatch, alias
-):
-    channel = "test-track/test-channel"
-    monkeypatch.setenv("ROCKCRAFT_INSTALL_SNAP_CHANNEL", channel)
-
-    config = providers.RockcraftBuilddBaseConfiguration(alias=alias)
-    config.setup(executor=mock_instance)
-
-    assert mock_inject.mock_calls == []
-    assert mock_install_from_store.mock_calls == [
-        call(
-            executor=mock_instance, snap_name="rockcraft", channel=channel, classic=True
-        )
-    ]
-
-    assert config.compatibility_tag == "rockcraft-buildd-base-v0.0"
-
-
-@pytest.mark.parametrize(
-    "alias",
-    [
-        bases.BuilddBaseAlias.BIONIC,
-        bases.BuilddBaseAlias.FOCAL,
-        bases.BuilddBaseAlias.JAMMY,
-    ],
-)
-def test_base_configuration_setup_from_store_default_for_windows(
-    mock_instance, mock_inject, mock_install_from_store, monkeypatch, alias
-):
-    monkeypatch.setattr(sys, "platform", "win32")
-
-    config = providers.RockcraftBuilddBaseConfiguration(alias=alias)
-    config.setup(executor=mock_instance)
-
-    assert mock_inject.mock_calls == []
-    assert mock_install_from_store.mock_calls == [
-        call(
-            executor=mock_instance,
-            snap_name="rockcraft",
-            channel="stable",
-            classic=True,
-        )
-    ]
-
-    assert config.compatibility_tag == "rockcraft-buildd-base-v0.0"
-
-
-def test_base_configuration_setup_snap_injection_error(
-    mock_instance, mock_inject, monkeypatch
-):
-    monkeypatch.setattr(sys, "platform", "linux")
-
-    alias = bases.BuilddBaseAlias.FOCAL
-    config = providers.RockcraftBuilddBaseConfiguration(alias=alias)
-    mock_inject.side_effect = snap_installer.SnapInstallationError(brief="foo error")
-
-    with pytest.raises(
-        bases.BaseConfigurationError,
-        match=r"Failed to inject host rockcraft snap into target environment.",
-    ) as raised:
-        config.setup(executor=mock_instance)
-
-    assert raised.value.__cause__ is not None
-
-
-def test_base_configuration_setup_snap_install_from_store_error(
-    mock_instance, mock_install_from_store, monkeypatch
-):
-    channel = "test-track/test-channel"
-    monkeypatch.setenv("ROCKCRAFT_INSTALL_SNAP_CHANNEL", channel)
-    alias = bases.BuilddBaseAlias.FOCAL
-    config = providers.RockcraftBuilddBaseConfiguration(alias=alias)
-    mock_install_from_store.side_effect = snap_installer.SnapInstallationError(
-        brief="foo error"
-    )
-    match = re.escape(
-        "Failed to install rockcraft snap from store channel "
-        "'test-track/test-channel' into target environment."
-    )
-
-    with pytest.raises(
-        bases.BaseConfigurationError,
-        match=match,
-    ) as raised:
-        config.setup(executor=mock_instance)
-
-    assert raised.value.__cause__ is not None

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -306,11 +306,18 @@ def test_launched_environment(
     monkeypatch,
     tmp_path,
     mock_path,
+    mocker,
 ):
     expected_environment = {
         "ROCKCRAFT_MANAGED_MODE": "1",
         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
     }
+
+    mocker.patch("sys.platform", "linux")
+    mocker.patch(
+        "rockcraft.providers._multipass.get_managed_environment_snap_channel",
+        return_value="edge",
+    )
 
     provider = providers.MultipassProvider()
 
@@ -339,6 +346,9 @@ def test_launched_environment(
                 alias=alias,
                 environment=expected_environment,
                 hostname="rockcraft-test-rock-445566",
+                snaps=[
+                    bases.buildd.Snap(name="rockcraft", channel="edge", classic=True)
+                ],
             )
         ]
 
@@ -348,6 +358,54 @@ def test_launched_environment(
         mock.call().unmount_all(),
         mock.call().stop(),
     ]
+
+
+@pytest.mark.parametrize(
+    "platform, snap_channel, expected_snap_channel",
+    [
+        ("linux", None, None),
+        ("linux", "edge", "edge"),
+        ("darwin", "edge", "edge"),
+        # default to stable on non-linux system
+        ("darwin", None, "stable"),
+    ],
+)
+def test_launched_environment_snap_channel(
+    mock_buildd_base_configuration,
+    mock_multipass_launch,
+    monkeypatch,
+    tmp_path,
+    mocker,
+    platform,
+    snap_channel,
+    expected_snap_channel,
+):
+    """Verify the rockcraft snap is installed from the correct channel."""
+    mocker.patch("sys.platform", platform)
+    mocker.patch(
+        "rockcraft.providers._multipass.get_managed_environment_snap_channel",
+        return_value=snap_channel,
+    )
+
+    provider = providers.MultipassProvider()
+
+    with provider.launched_environment(
+        project_name="test-rock",
+        project_path=tmp_path,
+        build_base="ubuntu:20.04",
+    ):
+        assert mock_buildd_base_configuration.mock_calls == [
+            call(
+                alias=mock.ANY,
+                environment=mock.ANY,
+                hostname=mock.ANY,
+                snaps=[
+                    bases.buildd.Snap(
+                        name="rockcraft", channel=expected_snap_channel, classic=True
+                    )
+                ],
+            )
+        ]
 
 
 def test_launched_environment_unmounts_and_stops_after_error(


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Use the new `craft-providers` API to install snaps inside a provider.  No functional changes.

(CRAFT-1347)