### PR TITLE
providers: move get_instance_name() to providers.py

### DIFF
--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -32,7 +32,7 @@ from rockcraft.utils import (
 )
 
 from ._provider import Provider
-from .providers import BASE_TO_BUILDD_IMAGE_ALIAS
+from .providers import BASE_TO_BUILDD_IMAGE_ALIAS, get_instance_name
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +158,7 @@ class LXDProvider(Provider):
         """
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[build_base]
 
-        instance_name = self.get_instance_name(
+        instance_name = get_instance_name(
             project_name=project_name,
             project_path=project_path,
         )

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -33,7 +33,7 @@ from rockcraft.utils import (
 )
 
 from ._provider import Provider
-from .providers import BASE_TO_BUILDD_IMAGE_ALIAS
+from .providers import BASE_TO_BUILDD_IMAGE_ALIAS, get_instance_name
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +144,7 @@ class MultipassProvider(Provider):
         """
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[build_base]
 
-        instance_name = self.get_instance_name(
+        instance_name = get_instance_name(
             project_name=project_name,
             project_path=project_path,
         )

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -60,29 +60,6 @@ class Provider(ABC):
 
         return env
 
-    @staticmethod
-    def get_instance_name(
-        *,
-        project_name: str,
-        project_path: pathlib.Path,
-    ) -> str:
-        """Formulate the name for an instance using each of the given parameters.
-
-        Incorporate each of the parameters into the name to come up with a
-        predictable naming schema that avoids name collisions across multiple
-        projects.
-
-        :param project_name: Name of the project.
-        :param project_path: Directory of the project.
-        """
-        return "-".join(
-            [
-                "rockcraft",
-                project_name,
-                str(project_path.stat().st_ino),
-            ]
-        )
-
     @classmethod
     def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:
         """Check if provider can provide an environment matching given base.

--- a/rockcraft/providers/providers.py
+++ b/rockcraft/providers/providers.py
@@ -17,6 +17,8 @@
 
 """Rockcraft-specific code to interface with craft-providers."""
 
+import pathlib
+
 from craft_providers import bases
 
 BASE_TO_BUILDD_IMAGE_ALIAS = {
@@ -24,3 +26,26 @@ BASE_TO_BUILDD_IMAGE_ALIAS = {
     "ubuntu:20.04": bases.BuilddBaseAlias.FOCAL,
     "ubuntu:22.04": bases.BuilddBaseAlias.JAMMY,
 }
+
+
+def get_instance_name(
+    *,
+    project_name: str,
+    project_path: pathlib.Path,
+) -> str:
+    """Formulate the name for an instance using each of the given parameters.
+
+    Incorporate each of the parameters into the name to come up with a
+    predictable naming schema that avoids name collisions across multiple
+    projects.
+
+    :param project_name: Name of the project.
+    :param project_path: Directory of the project.
+    """
+    return "-".join(
+        [
+            "rockcraft",
+            project_name,
+            str(project_path.stat().st_ino),
+        ]
+    )

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -291,18 +291,6 @@ def test_get_command_environment_minimal(monkeypatch):
     }
 
 
-def test_get_instance_name(mock_path):
-    provider = providers.LXDProvider()
-
-    assert (
-        provider.get_instance_name(
-            project_name="my-project-name",
-            project_path=mock_path,
-        )
-        == "rockcraft-my-project-name-445566"
-    )
-
-
 @pytest.mark.parametrize("is_installed", [True, False])
 def test_is_provider_available(is_installed, mock_lxd_is_installed):
     mock_lxd_is_installed.return_value = is_installed

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -275,18 +275,6 @@ def test_get_command_environment_minimal(monkeypatch):
     }
 
 
-def test_get_instance_name(mock_path):
-    provider = providers.MultipassProvider()
-
-    assert (
-        provider.get_instance_name(
-            project_name="my-project-name",
-            project_path=mock_path,
-        )
-        == "rockcraft-my-project-name-445566"
-    )
-
-
 @pytest.mark.parametrize("is_installed", [True, False])
 def test_is_provider_available(is_installed, mock_multipass_is_installed):
     mock_multipass_is_installed.return_value = is_installed

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -58,18 +58,6 @@ def test_get_command_environment_all_opts(provider_class, monkeypatch):
     }
 
 
-def test_get_instance_name(mock_path):
-    provider = providers.LXDProvider()
-
-    assert (
-        provider.get_instance_name(
-            project_name="my-project-name",
-            project_path=mock_path,
-        )
-        == "rockcraft-my-project-name-445566"
-    )
-
-
 @pytest.mark.parametrize(
     "name,expected_valid,expected_reason",
     [

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -1,0 +1,27 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from rockcraft.providers import providers
+
+
+def test_get_instance_name(mock_path):
+    assert (
+        providers.get_instance_name(
+            project_name="my-project-name",
+            project_path=mock_path,
+        )
+        == "rockcraft-my-project-name-445566"
+    )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

`get_instance_name()` is a rockcraft-specific function, so it is moved to providers.py

(CRAFT-1350)