### PR TITLE
cli: capture logs in logfile

### DIFF
--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -25,6 +25,7 @@ from craft_cli import ArgumentParsingError, EmitterMode, ProvideHelpException, e
 from rockcraft import __version__
 
 from . import commands
+from .utils import get_managed_environment_log_path, is_managed_mode
 
 COMMAND_GROUPS = [
     craft_cli.CommandGroup(
@@ -54,10 +55,15 @@ def run():
         logger = logging.getLogger(lib_name)
         logger.setLevel(logging.DEBUG)
 
+    # Capture debug-level log output in a file in managed mode, even if rockcraft is
+    # executing with a lower log level
+    log_filepath = get_managed_environment_log_path() if is_managed_mode() else None
+
     emit_args = {
         "mode": EmitterMode.BRIEF,
         "appname": "rockcraft",
         "greeting": f"Starting Rockcraft {__version__}",
+        "log_filepath": log_filepath,
     }
 
     emit.init(**emit_args)


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

When `rockcraft` is running in managed mode (i.e. inside an instance), then save the log file.

Referenced from [snapcraft](https://github.com/snapcore/snapcraft/blob/9e10fd1b658df80c35e1996cd92a077e831a8d51/snapcraft/cli.py#L166).