### PR TITLE
providers: move `get_instance_name()` call to lifecycle.py

### DIFF
--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -32,11 +32,7 @@ from rockcraft.utils import (
 )
 
 from ._provider import Provider
-from .providers import (
-    BASE_TO_BUILDD_IMAGE_ALIAS,
-    get_command_environment,
-    get_instance_name,
-)
+from .providers import BASE_TO_BUILDD_IMAGE_ALIAS, get_command_environment
 
 logger = logging.getLogger(__name__)
 
@@ -153,19 +149,20 @@ class LXDProvider(Provider):
         project_name: str,
         project_path: pathlib.Path,
         build_base: str,
+        instance_name: str,
     ) -> Generator[Executor, None, None]:
-        """Launch environment for specified base.
+        """Configure and launch environment for specified base.
+
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
 
         :param project_name: Name of project.
         :param project_path: Path to project.
         :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
         """
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[build_base]
-
-        instance_name = get_instance_name(
-            project_name=project_name,
-            project_path=project_path,
-        )
 
         environment = get_command_environment()
         try:

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -33,11 +33,7 @@ from rockcraft.utils import (
 )
 
 from ._provider import Provider
-from .providers import (
-    BASE_TO_BUILDD_IMAGE_ALIAS,
-    get_command_environment,
-    get_instance_name,
-)
+from .providers import BASE_TO_BUILDD_IMAGE_ALIAS, get_command_environment
 
 logger = logging.getLogger(__name__)
 
@@ -139,19 +135,20 @@ class MultipassProvider(Provider):
         project_name: str,
         project_path: pathlib.Path,
         build_base: str,
+        instance_name: str,
     ) -> Generator[Executor, None, None]:
-        """Launch environment for specified base.
+        """Configure and launch environment for specified base.
+
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
 
         :param project_name: Name of the project.
         :param project_path: Path to project.
         :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
         """
         alias = BASE_TO_BUILDD_IMAGE_ALIAS[build_base]
-
-        instance_name = get_instance_name(
-            project_name=project_name,
-            project_path=project_path,
-        )
 
         # injecting a snap on a non-linux system is not supported, so default to
         # install rockcraft from the store's stable channel

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -71,6 +71,8 @@ class Provider(ABC):
         :returns: True if installed.
         """
 
+    # TODO: migrate `create_environment()` from snapcraft or charmcraft
+
     @abstractmethod
     @contextlib.contextmanager
     def launched_environment(
@@ -79,10 +81,16 @@ class Provider(ABC):
         project_name: str,
         project_path: pathlib.Path,
         build_base: str,
+        instance_name: str,
     ) -> Generator[Executor, None, None]:
-        """Launch environment for specified base.
+        """Configure and launch environment for specified base.
 
-        :param project_name: Name of the project.
-        :param project_path: Path to the project.
+        When this method loses context, all directories are unmounted and the
+        environment is stopped. For more control of environment setup and teardown,
+        use `create_environment()` instead.
+
+        :param project_name: Name of project.
+        :param project_path: Path to project.
         :param build_base: Base to build from.
+        :param instance_name: Name of the instance to launch.
         """

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -322,12 +322,13 @@ def test_launched_environment(
         project_name="test-rock",
         project_path=mock_path,
         build_base=f"ubuntu:{channel}",
+        instance_name="test-instance-name",
     ) as instance:
         assert instance is not None
         assert mock_configure_buildd_image_remote.mock_calls == [mock.call()]
         assert mock_lxd_launch.mock_calls == [
             mock.call(
-                name="rockcraft-test-rock-445566",
+                name="test-instance-name",
                 base_configuration=mock_buildd_base_configuration.return_value,
                 image_name=channel,
                 image_remote="buildd-remote",
@@ -348,7 +349,7 @@ def test_launched_environment(
                 alias=alias,
                 compatibility_tag="rockcraft-buildd-base-v0.0",
                 environment=expected_environment,
-                hostname="rockcraft-test-rock-445566",
+                hostname="test-instance-name",
                 snaps=[
                     bases.buildd.Snap(name="rockcraft", channel="edge", classic=True)
                 ],
@@ -396,6 +397,7 @@ def test_launched_environment_snap_channel(
         project_name="test-rock",
         project_path=tmp_path,
         build_base="ubuntu:20.04",
+        instance_name="test-instance-name",
     ):
         assert mock_buildd_base_configuration.mock_calls == [
             call(
@@ -427,6 +429,7 @@ def test_launched_environment_launch_base_configuration_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 
@@ -448,6 +451,7 @@ def test_launched_environment_launch_lxd_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 
@@ -467,6 +471,7 @@ def test_launched_environment_unmounts_and_stops_after_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             mock_lxd_launch.reset_mock()
             raise RuntimeError("this is a test")
@@ -489,7 +494,10 @@ def test_launched_environment_unmount_all_error(
 
     with pytest.raises(ProviderError, match="fail") as raised:
         with provider.launched_environment(
-            project_name="test-rock", project_path=tmp_path, build_base="ubuntu:20.04"
+            project_name="test-rock",
+            project_path=tmp_path,
+            build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 
@@ -511,6 +519,7 @@ def test_launched_environment_stop_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:22.04",
+            instance_name="test-instance-name",
         ):
             pass
 

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -305,11 +305,12 @@ def test_launched_environment(
         project_name="test-rock",
         project_path=mock_path,
         build_base=f"ubuntu:{channel}",
+        instance_name="test-instance-name",
     ) as instance:
         assert instance is not None
         assert mock_multipass_launch.mock_calls == [
             mock.call(
-                name="rockcraft-test-rock-445566",
+                name="test-instance-name",
                 base_configuration=mock_buildd_base_configuration.return_value,
                 image_name=f"snapcraft:ubuntu-{channel}",
                 cpus=2,
@@ -326,7 +327,7 @@ def test_launched_environment(
                 alias=alias,
                 compatibility_tag="rockcraft-buildd-base-v0.0",
                 environment=expected_environment,
-                hostname="rockcraft-test-rock-445566",
+                hostname="test-instance-name",
                 snaps=[
                     bases.buildd.Snap(name="rockcraft", channel="edge", classic=True)
                 ],
@@ -374,6 +375,7 @@ def test_launched_environment_snap_channel(
         project_name="test-rock",
         project_path=tmp_path,
         build_base="ubuntu:20.04",
+        instance_name="test-instance-name",
     ):
         assert mock_buildd_base_configuration.mock_calls == [
             call(
@@ -400,6 +402,7 @@ def test_launched_environment_unmounts_and_stops_after_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             mock_multipass_launch.reset_mock()
             raise RuntimeError("this is a test")
@@ -422,6 +425,7 @@ def test_launched_environment_launch_base_configuration_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 
@@ -440,6 +444,7 @@ def test_launched_environment_launch_multipass_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 
@@ -458,6 +463,7 @@ def test_launched_environment_unmount_all_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 
@@ -476,6 +482,7 @@ def test_launched_environment_stop_error(
             project_name="test-rock",
             project_path=tmp_path,
             build_base="ubuntu:20.04",
+            instance_name="test-instance-name",
         ):
             pass
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Another bite-sized chunk of separating application-specific logic out of the `Provider` classes.

`get_instance_name()` is a rockcraft-specific function, so it is now called from `lifecycle.py`.

(CRAFT-1379)