### PR TITLE
providers: move base configuration logic to providers.py

### DIFF
--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -27,7 +27,12 @@ from craft_cli import emit
 from . import oci, providers, utils
 from .parts import PartsLifecycle
 from .project import Project, load_project
-from .providers.providers import capture_logs_from_instance, get_instance_name
+from .providers.providers import (
+    BASE_TO_BUILDD_IMAGE_ALIAS,
+    capture_logs_from_instance,
+    get_base_configuration,
+    get_instance_name,
+)
 
 if TYPE_CHECKING:
     import argparse
@@ -190,10 +195,17 @@ def _run_in_provider(
         project_name=project.name, project_path=host_project_path
     )
 
+    base_configuration = get_base_configuration(
+        alias=BASE_TO_BUILDD_IMAGE_ALIAS[str(project.build_base)],
+        project_name=project.name,
+        project_path=host_project_path,
+    )
+
     emit.progress("Launching instance...")
     with provider.launched_environment(
         project_name=project.name,
         project_path=host_project_path,
+        base_configuration=base_configuration,
         build_base=str(project.build_base),
         instance_name=instance_name,
     ) as instance:

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -19,21 +19,15 @@
 import contextlib
 import logging
 import pathlib
-import sys
 from typing import Generator, List
 
-from craft_providers import Executor, bases, multipass
+from craft_providers import Executor, base, bases, multipass
 from craft_providers.multipass.errors import MultipassError
 
 from rockcraft.errors import ProviderError
-from rockcraft.utils import (
-    confirm_with_user,
-    get_managed_environment_project_path,
-    get_managed_environment_snap_channel,
-)
+from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
 
 from ._provider import Provider
-from .providers import BASE_TO_BUILDD_IMAGE_ALIAS, get_command_environment
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +128,7 @@ class MultipassProvider(Provider):
         *,
         project_name: str,
         project_path: pathlib.Path,
+        base_configuration: base.Base,
         build_base: str,
         instance_name: str,
     ) -> Generator[Executor, None, None]:
@@ -145,32 +140,10 @@ class MultipassProvider(Provider):
 
         :param project_name: Name of the project.
         :param project_path: Path to project.
+        :param base_configuration: Base configuration to apply to instance.
         :param build_base: Base to build from.
         :param instance_name: Name of the instance to launch.
         """
-        alias = BASE_TO_BUILDD_IMAGE_ALIAS[build_base]
-
-        # injecting a snap on a non-linux system is not supported, so default to
-        # install rockcraft from the store's stable channel
-        snap_channel = get_managed_environment_snap_channel()
-        if sys.platform != "linux" and not snap_channel:
-            snap_channel = "stable"
-
-        environment = get_command_environment()
-        base_configuration = bases.BuilddBase(
-            alias=alias,
-            compatibility_tag=f"rockcraft-{bases.BuilddBase.compatibility_tag}.0",
-            environment=environment,
-            hostname=instance_name,
-            snaps=[
-                bases.buildd.Snap(
-                    name="rockcraft",
-                    channel=snap_channel,
-                    classic=True,
-                )
-            ],
-        )
-
         try:
             instance = multipass.launch(
                 name=instance_name,

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -21,7 +21,7 @@ import pathlib
 from abc import ABC, abstractmethod
 from typing import Generator, List, Tuple, Union
 
-from craft_providers import Executor
+from craft_providers import Executor, base
 
 
 class Provider(ABC):
@@ -47,18 +47,19 @@ class Provider(ABC):
         """
 
     @classmethod
-    def is_base_available(cls, base: str) -> Tuple[bool, Union[str, None]]:
+    def is_base_available(cls, build_base: str) -> Tuple[bool, Union[str, None]]:
         """Check if provider can provide an environment matching given base.
 
-        :param base: Base to check.
+        :param build_base: Base to check.
 
         :returns: Tuple of bool indicating whether it is a match, with optional
                 reason if not a match.
         """
-        if base not in ["ubuntu:18.04", "ubuntu:20.04"]:
+        if build_base not in ["ubuntu:18.04", "ubuntu:20.04"]:
             return (
                 False,
-                f"Base {base!r} is not supported (must be 'ubuntu:18.04' or 'ubuntu:20.04')",
+                f"Base {build_base!r} is not supported "
+                "(must be 'ubuntu:18.04' or 'ubuntu:20.04')",
             )
 
         return True, None
@@ -80,6 +81,7 @@ class Provider(ABC):
         *,
         project_name: str,
         project_path: pathlib.Path,
+        base_configuration: base.Base,
         build_base: str,
         instance_name: str,
     ) -> Generator[Executor, None, None]:
@@ -91,6 +93,7 @@ class Provider(ABC):
 
         :param project_name: Name of project.
         :param project_path: Path to project.
+        :param base_configuration: Base configuration to apply to instance.
         :param build_base: Base to build from.
         :param instance_name: Name of the instance to launch.
         """

--- a/rockcraft/providers/providers.py
+++ b/rockcraft/providers/providers.py
@@ -95,7 +95,7 @@ def capture_logs_from_instance(instance: executor.Executor) -> None:
 
 def get_base_configuration(
     *, alias: bases.BuilddBaseAlias, project_name: str, project_path: Path
-):
+) -> bases.BuilddBase:
     """Create a BuilddBase configuration for rockcraft."""
     instance_name = get_instance_name(
         project_name=project_name,

--- a/rockcraft/providers/providers.py
+++ b/rockcraft/providers/providers.py
@@ -18,13 +18,17 @@
 """Rockcraft-specific code to interface with craft-providers."""
 
 import os
-import pathlib
+import sys
+from pathlib import Path
 from typing import Dict, Optional
 
 from craft_cli import emit
 from craft_providers import bases, executor
 
-from rockcraft.utils import get_managed_environment_log_path
+from rockcraft.utils import (
+    get_managed_environment_log_path,
+    get_managed_environment_snap_channel,
+)
 
 BASE_TO_BUILDD_IMAGE_ALIAS = {
     "ubuntu:18.04": bases.BuilddBaseAlias.BIONIC,
@@ -49,7 +53,7 @@ def get_command_environment() -> Dict[str, Optional[str]]:
 def get_instance_name(
     *,
     project_name: str,
-    project_path: pathlib.Path,
+    project_path: Path,
 ) -> str:
     """Formulate the name for an instance using each of the given parameters.
 
@@ -87,3 +91,33 @@ def capture_logs_from_instance(instance: executor.Executor) -> None:
             emit.trace(
                 f"Could not find log file {source_log_path.as_posix()} in instance."
             )
+
+
+def get_base_configuration(
+    *, alias: bases.BuilddBaseAlias, project_name: str, project_path: Path
+):
+    """Create a BuilddBase configuration for rockcraft."""
+    instance_name = get_instance_name(
+        project_name=project_name,
+        project_path=project_path,
+    )
+
+    # injecting a snap on a non-linux system is not supported, so default to
+    # install rockcraft from the store's stable channel
+    snap_channel = get_managed_environment_snap_channel()
+    if sys.platform != "linux" and not snap_channel:
+        snap_channel = "stable"
+
+    return bases.BuilddBase(
+        alias=alias,
+        compatibility_tag=f"rockcraft-{bases.BuilddBase.compatibility_tag}.0",
+        environment=get_command_environment(),
+        hostname=instance_name,
+        snaps=[
+            bases.buildd.Snap(
+                name="rockcraft",
+                channel=snap_channel,
+                classic=True,
+            )
+        ],
+    )

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -17,7 +17,6 @@
 import pathlib
 import re
 from unittest import mock
-from unittest.mock import call
 
 import pytest
 from craft_providers import bases
@@ -270,40 +269,20 @@ def test_is_provider_available(is_installed, mock_multipass_is_installed):
     assert provider.is_provider_available() == is_installed
 
 
-@pytest.mark.parametrize(
-    "channel,alias",
-    [
-        ("18.04", bases.BuilddBaseAlias.BIONIC),
-        ("20.04", bases.BuilddBaseAlias.FOCAL),
-        ("22.04", bases.BuilddBaseAlias.JAMMY),
-    ],
-)
+@pytest.mark.parametrize("channel", ["18.04", "20.04", "22.04"])
 def test_launched_environment(
     channel,
-    alias,
     mock_buildd_base_configuration,
     mock_multipass_launch,
-    monkeypatch,
     tmp_path,
     mock_path,
-    mocker,
 ):
-    expected_environment = {
-        "ROCKCRAFT_MANAGED_MODE": "1",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-    }
-
-    mocker.patch("sys.platform", "linux")
-    mocker.patch(
-        "rockcraft.providers._multipass.get_managed_environment_snap_channel",
-        return_value="edge",
-    )
-
     provider = providers.MultipassProvider()
 
     with provider.launched_environment(
         project_name="test-rock",
         project_path=mock_path,
+        base_configuration=mock_buildd_base_configuration,
         build_base=f"ubuntu:{channel}",
         instance_name="test-instance-name",
     ) as instance:
@@ -311,7 +290,7 @@ def test_launched_environment(
         assert mock_multipass_launch.mock_calls == [
             mock.call(
                 name="test-instance-name",
-                base_configuration=mock_buildd_base_configuration.return_value,
+                base_configuration=mock_buildd_base_configuration,
                 image_name=f"snapcraft:ubuntu-{channel}",
                 cpus=2,
                 disk_gb=64,
@@ -322,74 +301,12 @@ def test_launched_environment(
                 host_source=mock_path, target=pathlib.Path("/root/project")
             ),
         ]
-        assert mock_buildd_base_configuration.mock_calls == [
-            call(
-                alias=alias,
-                compatibility_tag="rockcraft-buildd-base-v0.0",
-                environment=expected_environment,
-                hostname="test-instance-name",
-                snaps=[
-                    bases.buildd.Snap(name="rockcraft", channel="edge", classic=True)
-                ],
-            )
-        ]
-
         mock_multipass_launch.reset_mock()
 
     assert mock_multipass_launch.mock_calls == [
         mock.call().unmount_all(),
         mock.call().stop(),
     ]
-
-
-@pytest.mark.parametrize(
-    "platform, snap_channel, expected_snap_channel",
-    [
-        ("linux", None, None),
-        ("linux", "edge", "edge"),
-        ("darwin", "edge", "edge"),
-        # default to stable on non-linux system
-        ("darwin", None, "stable"),
-    ],
-)
-def test_launched_environment_snap_channel(
-    mock_buildd_base_configuration,
-    mock_multipass_launch,
-    monkeypatch,
-    tmp_path,
-    mocker,
-    platform,
-    snap_channel,
-    expected_snap_channel,
-):
-    """Verify the rockcraft snap is installed from the correct channel."""
-    mocker.patch("sys.platform", platform)
-    mocker.patch(
-        "rockcraft.providers._multipass.get_managed_environment_snap_channel",
-        return_value=snap_channel,
-    )
-
-    provider = providers.MultipassProvider()
-
-    with provider.launched_environment(
-        project_name="test-rock",
-        project_path=tmp_path,
-        build_base="ubuntu:20.04",
-        instance_name="test-instance-name",
-    ):
-        assert mock_buildd_base_configuration.mock_calls == [
-            call(
-                alias=mock.ANY,
-                compatibility_tag=mock.ANY,
-                environment=mock.ANY,
-                hostname=mock.ANY,
-                snaps=[
-                    bases.buildd.Snap(
-                        name="rockcraft", channel=expected_snap_channel, classic=True
-                    )
-                ],
-            )
-        ]
 
 
 def test_launched_environment_unmounts_and_stops_after_error(
@@ -401,6 +318,7 @@ def test_launched_environment_unmounts_and_stops_after_error(
         with provider.launched_environment(
             project_name="test-rock",
             project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
             build_base="ubuntu:20.04",
             instance_name="test-instance-name",
         ):
@@ -424,6 +342,7 @@ def test_launched_environment_launch_base_configuration_error(
         with provider.launched_environment(
             project_name="test-rock",
             project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
             build_base="ubuntu:20.04",
             instance_name="test-instance-name",
         ):
@@ -443,6 +362,7 @@ def test_launched_environment_launch_multipass_error(
         with provider.launched_environment(
             project_name="test-rock",
             project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
             build_base="ubuntu:20.04",
             instance_name="test-instance-name",
         ):
@@ -462,6 +382,7 @@ def test_launched_environment_unmount_all_error(
         with provider.launched_environment(
             project_name="test-rock",
             project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
             build_base="ubuntu:20.04",
             instance_name="test-instance-name",
         ):
@@ -481,6 +402,7 @@ def test_launched_environment_stop_error(
         with provider.launched_environment(
             project_name="test-rock",
             project_path=tmp_path,
+            base_configuration=mock_buildd_base_configuration,
             build_base="ubuntu:20.04",
             instance_name="test-instance-name",
         ):


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Configuring a base is specific to rockcraft, so it is:
1. encapsulated in a function and moved to `providers.py` 
2. called by `lifecycle.py` instead of the Provider classes `lxd.py` and `multipass.py`

(CRAFT-1380)