### PR TITLE
providers: move mount logic to lifecycle.py

### DIFF
--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -213,6 +213,9 @@ def run_in_provider(
     ) as instance:
         try:
             with emit.pause():
+                instance.mount(
+                    host_source=host_project_path, target=instance_project_path
+                )
                 instance.execute_run(cmd, check=True, cwd=instance_project_path)
         except subprocess.CalledProcessError as err:
             raise ProviderError(

--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -23,7 +23,7 @@ from typing import Generator, List
 
 from craft_providers import Executor, ProviderError, base, bases, lxd
 
-from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
+from rockcraft.utils import confirm_with_user
 
 from ._provider import Provider
 
@@ -179,11 +179,6 @@ class LXDProvider(Provider):
             )
         except (bases.BaseConfigurationError, lxd.LXDError) as error:
             raise ProviderError(str(error)) from error
-
-        # Mount project.
-        instance.mount(
-            host_source=project_path, target=get_managed_environment_project_path()
-        )
 
         try:
             yield instance

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -24,7 +24,7 @@ from typing import Generator, List
 from craft_providers import Executor, ProviderError, base, bases, multipass
 from craft_providers.multipass.errors import MultipassError
 
-from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
+from rockcraft.utils import confirm_with_user
 
 from ._provider import Provider
 
@@ -161,14 +161,6 @@ class MultipassProvider(Provider):
                 auto_clean=True,
             )
         except (bases.BaseConfigurationError, MultipassError) as error:
-            raise ProviderError(str(error)) from error
-
-        try:
-            # Mount project.
-            instance.mount(
-                host_source=project_path, target=get_managed_environment_project_path()
-            )
-        except MultipassError as error:
             raise ProviderError(str(error)) from error
 
         try:

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pathlib
 import re
 from unittest import mock
 
@@ -325,9 +324,6 @@ def test_launched_environment(
                 use_snapshots=True,
                 project="rockcraft",
                 remote="local",
-            ),
-            mock.call().mount(
-                host_source=mock_path, target=pathlib.Path("/root/project")
             ),
         ]
 

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pathlib
 import re
 from unittest import mock
 
@@ -303,9 +302,6 @@ def test_launched_environment(
                 disk_gb=64,
                 mem_gb=2,
                 auto_clean=True,
-            ),
-            mock.call().mount(
-                host_source=mock_path, target=pathlib.Path("/root/project")
             ),
         ]
         mock_multipass_launch.reset_mock()

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -83,6 +83,8 @@ def test_lifecycle_run_in_provider(
     )
     mock_project.build_base = rockcraft_base
 
+    cwd = Path().absolute()
+
     # set emitter mode
     emit.set_mode(emit_mode)
 
@@ -95,19 +97,22 @@ def test_lifecycle_run_in_provider(
     mock_provider.ensure_provider_is_available.assert_called_once()
     mock_get_instance_name.assert_called_once_with(
         project_name="test-name",
-        project_path=Path().absolute(),
+        project_path=cwd,
     )
     mock_get_base_configuration.assert_called_once_with(
         alias=provider_base,
         project_name="test-name",
-        project_path=Path().absolute(),
+        project_path=cwd,
     )
     mock_provider.launched_environment.assert_called_once_with(
         project_name="test-name",
-        project_path=Path().absolute(),
+        project_path=cwd,
         base_configuration=mock_base_configuration,
         build_base=provider_base.value,
         instance_name="test-instance-name",
+    )
+    mock_instance.mount.assert_called_once_with(
+        host_source=cwd, target=Path("/root/project")
     )
     mock_instance.execute_run.assert_called_once_with(
         ["rockcraft", "test"] + verbosity,


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Mounting the project directory is a rockcraft-specific step, so it is moved out of the craft-providers interface.

Blocked by https://github.com/canonical/craft-providers/pull/154

(CRAFT-1381)