### PR TITLE
tests: test lifecycle.py::_run_in_provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint rockcraft
-	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,redefined-outer-name,too-many-arguments
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,redefined-outer-name,too-many-arguments,protected-access
 
 .PHONY: test-pyright
 test-pyright:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test-pydocstyle:
 .PHONY: test-pylint
 test-pylint:
 	pylint rockcraft
-	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,redefined-outer-name,too-many-arguments,protected-access
+	pylint tests --disable=invalid-name,missing-module-docstring,missing-function-docstring,redefined-outer-name,too-many-arguments
 
 .PHONY: test-pyright
 test-pyright:

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -49,7 +49,7 @@ def run(command_name: str, parsed_args: "argparse.Namespace"):
 
     managed_mode = utils.is_managed_mode()
     if not managed_mode and not destructive_mode:
-        _run_in_provider(project, command_name, parsed_args)
+        run_in_provider(project, command_name, parsed_args)
         return
 
     if managed_mode:
@@ -169,7 +169,7 @@ def _pack(
     emit.progress(f"Exported to OCI archive '{archive_name}'", permanent=True)
 
 
-def _run_in_provider(
+def run_in_provider(
     project: Project, command_name: str, parsed_args: "argparse.Namespace"
 ):
     """Run lifecycle command in provider instance."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,13 +14,51 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
+from pathlib import Path
 from unittest import mock
 
 import pytest
-from craft_providers import Executor
+from craft_providers import Executor, base
+
+from rockcraft.providers import Provider
 
 
 @pytest.fixture
 def mock_instance():
     """Provide a mock instance (Executor)."""
-    yield mock.Mock(spec=Executor)
+    _mock_instance = mock.Mock(spec=Executor)
+    yield _mock_instance
+
+
+@pytest.fixture(autouse=True)
+def fake_provider(mock_instance):
+    """Fixture to provide a minimal fake provider."""
+
+    class FakeProvider(Provider):
+        """Fake provider."""
+
+        def clean_project_environments(self, *, project_name: str, project_path: Path):
+            pass
+
+        @classmethod
+        def ensure_provider_is_available(cls) -> None:
+            pass
+
+        @classmethod
+        def is_provider_available(cls) -> bool:
+            return True
+
+        @contextlib.contextmanager
+        def launched_environment(
+            self,
+            *,
+            project_name: str,
+            project_path: Path,
+            base_configuration: base.Base,
+            build_base: str,
+            instance_name: str,
+        ):
+            yield mock_instance
+
+    return FakeProvider()

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -71,7 +71,7 @@ def test_lifecycle_run_in_provider(
     # set emitter mode
     emit.set_mode(emit_mode)
 
-    lifecycle._run_in_provider(
+    lifecycle.run_in_provider(
         project=mock_project,
         command_name="test",
         parsed_args=argparse.Namespace(),

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -1,0 +1,102 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+from pathlib import Path
+from unittest.mock import ANY, Mock, patch
+
+import pytest
+from craft_cli import EmitterMode, emit
+from craft_providers.bases.buildd import BuilddBaseAlias
+
+from rockcraft import lifecycle
+
+
+@pytest.fixture
+def mock_project():
+    with patch("rockcraft.project") as _mock_project:
+        _mock_project.name = "test-name"
+        _mock_project.build_base = "ubuntu:20.04"
+        yield _mock_project
+
+
+@pytest.fixture()
+def mock_provider(mocker, mock_instance, fake_provider):
+    _mock_provider = Mock(wraps=fake_provider)
+    mocker.patch(
+        "rockcraft.lifecycle.providers.get_provider", return_value=_mock_provider
+    )
+    yield _mock_provider
+
+
+@pytest.mark.parametrize(
+    "emit_mode,verbosity",
+    [
+        (EmitterMode.VERBOSE, ["--verbosity=verbose"]),
+        (EmitterMode.QUIET, ["--verbosity=quiet"]),
+        (EmitterMode.DEBUG, ["--verbosity=debug"]),
+        (EmitterMode.TRACE, ["--verbosity=trace"]),
+        (EmitterMode.BRIEF, ["--verbosity=brief"]),
+    ],
+)
+def test_lifecycle_run_in_provider(
+    mock_instance, mock_provider, mock_project, mocker, emit_mode, verbosity
+):
+    # mock provider calls
+    mock_base_configuration = Mock()
+    mock_get_base_configuration = mocker.patch(
+        "rockcraft.lifecycle.get_base_configuration",
+        return_value=mock_base_configuration,
+    )
+    mock_get_instance_name = mocker.patch(
+        "rockcraft.lifecycle.get_instance_name", return_value="test-instance-name"
+    )
+    mock_capture_logs_from_instance = mocker.patch(
+        "rockcraft.lifecycle.capture_logs_from_instance"
+    )
+
+    # set emitter mode
+    emit.set_mode(emit_mode)
+
+    lifecycle._run_in_provider(
+        project=mock_project,
+        command_name="test",
+        parsed_args=argparse.Namespace(),
+    )
+
+    mock_provider.ensure_provider_is_available.assert_called_once()
+    mock_get_instance_name.assert_called_once_with(
+        project_name="test-name",
+        project_path=Path().absolute(),
+    )
+    mock_get_base_configuration.assert_called_once_with(
+        alias=BuilddBaseAlias.FOCAL,
+        project_name="test-name",
+        project_path=Path().absolute(),
+    )
+    mock_provider.launched_environment.assert_called_once_with(
+        project_name="test-name",
+        project_path=ANY,
+        base_configuration=mock_base_configuration,
+        build_base="ubuntu:20.04",
+        instance_name="test-instance-name",
+    )
+    mock_instance.execute_run.assert_called_once_with(
+        ["rockcraft", "test"] + verbosity,
+        check=True,
+        cwd=Path("/root/project"),
+    )
+    mock_capture_logs_from_instance.assert_called_once_with(mock_instance)


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
New unit tests for `lifecycle.py::_run_in_provider()`.  I referenced `charmcraft`'s unit testing, but it was still quite challenging to mock.

Before:
```
Name                     Stmts   Miss  Cover
--------------------------------------------
rockcraft/lifecycle.py      90     76    16%
```

After:
```
Name                     Stmts   Miss  Cover
--------------------------------------------
rockcraft/lifecycle.py      90     58    36%
```