### PR TITLE
Add chisel to rockcraft

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,9 @@ codespell==2.2.1
 commonmark==0.9.1
 coverage==6.4.4
 craft-cli==1.2.0
-craft-parts==1.14.0
+#craft-parts==1.14.0
+# Temporarily use a specific craft-parts commit to have 'chisel' support
+git+https://github.com/canonical/craft-parts.git@2651f15855e184c1d8699efcfd1334#egg=craft_parts
 craft-providers==1.5.0
 cryptography==37.0.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,9 @@ Babel==2.10.3
 certifi==2022.6.15
 charset-normalizer==2.1.1
 craft-cli==1.2.0
-craft-parts==1.14.0
+#craft-parts==1.14.0
+# Temporarily use a specific craft-parts commit to have 'chisel' support
+git+https://github.com/canonical/craft-parts.git@2651f15855e184c1d8699efcfd1334#egg=craft_parts
 craft-providers==1.5.0
 Deprecated==1.2.13
 docutils==0.17.1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,3 +100,14 @@ parts:
         - libbtrfs-dev
         - libdevmapper-dev
         - pkg-config
+
+  chisel:
+    plugin: nil
+    source: https://github.com/canonical/chisel.git
+    build-snaps:
+      - go/1.18/stable
+    override-build: |
+      go mod download
+      CGO_ENABLED=0 GOOS=linux go build -o chisel ./cmd/chisel
+      mkdir "$SNAPCRAFT_PART_INSTALL"/bin
+      install -m755 chisel "$SNAPCRAFT_PART_INSTALL"/bin/chisel

--- a/tests/spread/general/chisel/rockcraft.yaml
+++ b/tests/spread/general/chisel/rockcraft.yaml
@@ -1,0 +1,29 @@
+name: chiseled-dotnet
+summary: A "bare" ROCK containing the .NET runtime
+description: A "bare" ROCK containing the .NET runtime
+license: Apache-2.0
+
+version: "0.0.1"
+base: bare
+build_base: "ubuntu:22.04"
+cmd: [/usr/lib/dotnet/dotnet-link/dotnet, --info]
+platforms:
+  amd64:
+
+env:
+  - DOTNET_ROOT: /usr/lib/dotnet/dotnet-link/dotnet
+  - TMPDIR: /
+
+parts:
+
+  chisel-part:
+    plugin: nil
+    stage-packages:
+      - dotnet-runtime-6.0_libs
+    override-prime: |
+      # Overridden to link the specific dotnet subdir into a more general "dotnet-link" 
+      cp -r $CRAFT_STAGE/* .
+      pushd usr/lib/dotnet
+      ln -s dotnet6-6* dotnet-link
+      popd
+      find .

--- a/tests/spread/general/chisel/task.yaml
+++ b/tests/spread/general/chisel/task.yaml
@@ -1,0 +1,19 @@
+summary: a test that checks ROCKs created with Chisel slices
+
+execute: |
+  rockcraft pack
+
+  ROCK=`ls *.rock`
+  IMG_NAME=chiselled-image
+
+  test -f $ROCK
+
+  # copy image to docker
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$IMG_NAME:latest
+  rm $ROCK
+  docker images
+
+  docker run --rm $IMG_NAME
+
+  docker system prune -a -f


### PR DESCRIPTION
This PR lets rockcraft support chisel slices in stage-packages. 
Notes:

- "chisel" is added directly on rockcraft's snap, just like skopeo and 
  umoci, as it's only an "image-build-time" dependency;
- We currently pin `craft-parts` to a specific commit on `main` because
  we don't yet have a release of craft-parts with chisel support, but 
  that should come soon;
- The added spread test uses the dotnet-runtime-6.0_libs slice, and 
  currently overrides `prime` to create symlinks because the internal 
  directory structure of the slice changes with new versions. This will
  be addressed/discussed in the future.

CRAFT-1333

