### PR TITLE
providers: translate rockcraft base to provider base

### DIFF
--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -28,7 +28,7 @@ from . import oci, providers, utils
 from .parts import PartsLifecycle
 from .project import Project, load_project
 from .providers.providers import (
-    BASE_TO_BUILDD_IMAGE_ALIAS,
+    ROCKCRAFT_BASE_TO_PROVIDER_BASE,
     capture_logs_from_instance,
     get_base_configuration,
     get_instance_name,
@@ -194,9 +194,10 @@ def run_in_provider(
     instance_name = get_instance_name(
         project_name=project.name, project_path=host_project_path
     )
+    build_base = ROCKCRAFT_BASE_TO_PROVIDER_BASE[str(project.build_base)]
 
     base_configuration = get_base_configuration(
-        alias=BASE_TO_BUILDD_IMAGE_ALIAS[str(project.build_base)],
+        alias=build_base,
         project_name=project.name,
         project_path=host_project_path,
     )
@@ -206,7 +207,7 @@ def run_in_provider(
         project_name=project.name,
         project_path=host_project_path,
         base_configuration=base_configuration,
-        build_base=str(project.build_base),
+        build_base=build_base.value,
         instance_name=instance_name,
     ) as instance:
         try:

--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -30,10 +30,11 @@ from ._provider import Provider
 
 logger = logging.getLogger(__name__)
 
-_BASE_IMAGE = {
-    "ubuntu:18.04": "18.04",
-    "ubuntu:20.04": "20.04",
-    "ubuntu:22.04": "22.04",
+
+PROVIDER_BASE_TO_LXD_BASE = {
+    bases.BuilddBaseAlias.BIONIC.value: "core18",
+    bases.BuilddBaseAlias.FOCAL.value: "core20",
+    bases.BuilddBaseAlias.JAMMY.value: "core22",
 }
 
 
@@ -167,7 +168,7 @@ class LXDProvider(Provider):
             instance = lxd.launch(
                 name=instance_name,
                 base_configuration=base_configuration,
-                image_name=_BASE_IMAGE[build_base],
+                image_name=PROVIDER_BASE_TO_LXD_BASE[build_base],
                 image_remote=image_remote,
                 auto_clean=True,
                 auto_create_project=True,

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -32,6 +32,13 @@ from ._provider import Provider
 logger = logging.getLogger(__name__)
 
 
+PROVIDER_BASE_TO_MULTIPASS_BASE = {
+    bases.BuilddBaseAlias.BIONIC.value: "snapcraft:18.04",
+    bases.BuilddBaseAlias.FOCAL.value: "snapcraft:20.04",
+    bases.BuilddBaseAlias.JAMMY.value: "snapcraft:22.04",
+}
+
+
 class MultipassProvider(Provider):
     """Multipass build environment provider.
 
@@ -148,8 +155,7 @@ class MultipassProvider(Provider):
             instance = multipass.launch(
                 name=instance_name,
                 base_configuration=base_configuration,
-                # XXX: replace with appropriate rockcraft base image
-                image_name=f"snapcraft:{build_base.replace(':', '-')}",
+                image_name=PROVIDER_BASE_TO_MULTIPASS_BASE[build_base],
                 cpus=2,
                 disk_gb=64,
                 mem_gb=2,

--- a/rockcraft/providers/providers.py
+++ b/rockcraft/providers/providers.py
@@ -30,7 +30,7 @@ from rockcraft.utils import (
     get_managed_environment_snap_channel,
 )
 
-BASE_TO_BUILDD_IMAGE_ALIAS = {
+ROCKCRAFT_BASE_TO_PROVIDER_BASE = {
     "ubuntu:18.04": bases.BuilddBaseAlias.BIONIC,
     "ubuntu:20.04": bases.BuilddBaseAlias.FOCAL,
     "ubuntu:22.04": bases.BuilddBaseAlias.JAMMY,

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -285,9 +285,17 @@ def test_is_provider_available(is_installed, mock_lxd_is_installed):
     assert provider.is_provider_available() == is_installed
 
 
-@pytest.mark.parametrize("channel", ["18.04", "20.04", "22.04"])
+@pytest.mark.parametrize(
+    "build_base, lxd_base",
+    [
+        (bases.BuilddBaseAlias.BIONIC.value, "core18"),
+        (bases.BuilddBaseAlias.FOCAL.value, "core20"),
+        (bases.BuilddBaseAlias.JAMMY.value, "core22"),
+    ],
+)
 def test_launched_environment(
-    channel,
+    build_base,
+    lxd_base,
     mock_buildd_base_configuration,
     mock_configure_buildd_image_remote,
     mock_lxd_launch,
@@ -300,7 +308,7 @@ def test_launched_environment(
         project_name="test-rock",
         project_path=mock_path,
         base_configuration=mock_buildd_base_configuration,
-        build_base=f"ubuntu:{channel}",
+        build_base=build_base,
         instance_name="test-instance-name",
     ) as instance:
         assert instance is not None
@@ -309,7 +317,7 @@ def test_launched_environment(
             mock.call(
                 name="test-instance-name",
                 base_configuration=mock_buildd_base_configuration,
-                image_name=channel,
+                image_name=lxd_base,
                 image_remote="buildd-remote",
                 auto_clean=True,
                 auto_create_project=True,
@@ -347,7 +355,7 @@ def test_launched_environment_launch_base_configuration_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -370,7 +378,7 @@ def test_launched_environment_launch_lxd_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -391,7 +399,7 @@ def test_launched_environment_unmounts_and_stops_after_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             mock_lxd_launch.reset_mock()
@@ -418,7 +426,7 @@ def test_launched_environment_unmount_all_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -441,7 +449,7 @@ def test_launched_environment_stop_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:22.04",
+            build_base=bases.BuilddBaseAlias.JAMMY.value,
             instance_name="test-instance-name",
         ):
             pass

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -269,9 +269,17 @@ def test_is_provider_available(is_installed, mock_multipass_is_installed):
     assert provider.is_provider_available() == is_installed
 
 
-@pytest.mark.parametrize("channel", ["18.04", "20.04", "22.04"])
+@pytest.mark.parametrize(
+    "build_base, multipass_base",
+    [
+        (bases.BuilddBaseAlias.BIONIC.value, "snapcraft:18.04"),
+        (bases.BuilddBaseAlias.FOCAL.value, "snapcraft:20.04"),
+        (bases.BuilddBaseAlias.JAMMY.value, "snapcraft:22.04"),
+    ],
+)
 def test_launched_environment(
-    channel,
+    build_base,
+    multipass_base,
     mock_buildd_base_configuration,
     mock_multipass_launch,
     tmp_path,
@@ -283,7 +291,7 @@ def test_launched_environment(
         project_name="test-rock",
         project_path=mock_path,
         base_configuration=mock_buildd_base_configuration,
-        build_base=f"ubuntu:{channel}",
+        build_base=build_base,
         instance_name="test-instance-name",
     ) as instance:
         assert instance is not None
@@ -291,7 +299,7 @@ def test_launched_environment(
             mock.call(
                 name="test-instance-name",
                 base_configuration=mock_buildd_base_configuration,
-                image_name=f"snapcraft:ubuntu-{channel}",
+                image_name=multipass_base,
                 cpus=2,
                 disk_gb=64,
                 mem_gb=2,
@@ -319,7 +327,7 @@ def test_launched_environment_unmounts_and_stops_after_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             mock_multipass_launch.reset_mock()
@@ -343,7 +351,7 @@ def test_launched_environment_launch_base_configuration_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -363,7 +371,7 @@ def test_launched_environment_launch_multipass_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -383,7 +391,7 @@ def test_launched_environment_unmount_all_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass
@@ -403,7 +411,7 @@ def test_launched_environment_stop_error(
             project_name="test-rock",
             project_path=tmp_path,
             base_configuration=mock_buildd_base_configuration,
-            build_base="ubuntu:20.04",
+            build_base=bases.BuilddBaseAlias.FOCAL.value,
             instance_name="test-instance-name",
         ):
             pass


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
### Overview
*craft applications have a concept of a "base".  This base is translated a `craft-providers` base and is passed to `craft-providers` so it can choose which base image (OS and release) to use for the instance.

### Problem

Currently, each application translates its own base inside `_lxd.py` and `_multipass.py`.  This application-specific code needs to be removed from these files.

### Solution
To support this, I created a list of what bases `craft-providers` can accept.  Right now, `18.04`, `20.04`, and `22.04` are supported.  Other OSs and releases can be added in the future without breaking backwards compatibility.

The image below shows how an application can translates its base to a `craft-providers` base.   It also shows `craft-providers` translating it to the specific name needed for LXD and Multipass to download the base image.

![image](https://user-images.githubusercontent.com/60674096/191814611-e05cfcbd-7cd3-45a7-b544-8580d4746b79.png)

---
CRAFT-1382