### PR TITLE
providers: use ProviderError from craft-providers

### DIFF
--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -21,6 +21,7 @@ import sys
 
 import craft_cli
 from craft_cli import ArgumentParsingError, EmitterMode, ProvideHelpException, emit
+from craft_providers import ProviderError
 
 from rockcraft import __version__
 
@@ -93,4 +94,10 @@ def run():
         sys.exit(1)
     except craft_cli.CraftError as err:  # TODO: define RockcraftError
         emit.error(err)
+        sys.exit(1)
+    except ProviderError as err:
+        emit.error(craft_cli.CraftError(f"craft-providers error: {err}"))
+        sys.exit(1)
+    except Exception as err:  # pylint: disable=broad-except
+        emit.error(craft_cli.CraftError(f"rockcraft internal error: {err!r}"))
         sys.exit(1)

--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -27,10 +27,6 @@ class PartsLifecycleError(CraftError):
     """Error during parts processing."""
 
 
-class ProviderError(CraftError):
-    """Error in provider operation."""
-
-
 class ProjectLoadError(CraftError):
     """Error loading rockcraft.yaml."""
 

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from craft_cli import emit
+from craft_providers import ProviderError
 
 from . import oci, providers, utils
 from .parts import PartsLifecycle
@@ -213,7 +214,7 @@ def run_in_provider(
             with emit.pause():
                 instance.execute_run(cmd, check=True, cwd=instance_project_path)
         except subprocess.CalledProcessError as err:
-            raise providers.ProviderError(
+            raise ProviderError(
                 f"Failed to execute {command_name} in instance."
             ) from err
         finally:

--- a/rockcraft/providers/__init__.py
+++ b/rockcraft/providers/__init__.py
@@ -16,8 +16,6 @@
 
 """Build provider support."""
 
-from rockcraft.errors import ProviderError  # noqa: F401
-
 from ._get_provider import get_provider  # noqa: F401
 from ._lxd import LXDProvider  # noqa: F401
 from ._multipass import MultipassProvider  # noqa: F401

--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -21,9 +21,8 @@ import logging
 import pathlib
 from typing import Generator, List
 
-from craft_providers import Executor, base, bases, lxd
+from craft_providers import Executor, ProviderError, base, bases, lxd
 
-from rockcraft.errors import ProviderError
 from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
 
 from ._provider import Provider

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -21,10 +21,9 @@ import logging
 import pathlib
 from typing import Generator, List
 
-from craft_providers import Executor, base, bases, multipass
+from craft_providers import Executor, ProviderError, base, bases, multipass
 from craft_providers.multipass.errors import MultipassError
 
-from rockcraft.errors import ProviderError
 from rockcraft.utils import confirm_with_user, get_managed_environment_project_path
 
 from ._provider import Provider

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -19,11 +19,10 @@ import re
 from unittest import mock
 
 import pytest
-from craft_providers import bases
+from craft_providers import ProviderError, bases
 from craft_providers.lxd import LXDError, LXDInstallationError
 
 from rockcraft import providers
-from rockcraft.providers import ProviderError
 
 # pylint: disable=duplicate-code
 

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -19,11 +19,10 @@ import re
 from unittest import mock
 
 import pytest
-from craft_providers import bases
+from craft_providers import ProviderError, bases
 from craft_providers.multipass import MultipassError, MultipassInstallationError
 
 from rockcraft import providers
-from rockcraft.providers import ProviderError
 
 
 @pytest.fixture()


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Use `ProviderError` from craft-providers.