### PR TITLE
tests: update macos from 10.15 to latest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,12 +46,12 @@ jobs:
           make test-pyright
       - name: Run pylint
         run: |
-          make test-pylint          
+          make test-pylint
 
   tests:
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04, ubuntu-20.04, windows-2019]
+        os: [macos-latest, ubuntu-18.04, ubuntu-20.04, windows-2019]
         python-version: [3.8, 3.9, "3.10"]
         exclude:
           - os: ubuntu-18.04


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The `macos-10.15` action runner is [being deprecated on 2022-Dec-01](https://github.com/actions/runner-images/issues/5583).

There are scheduled brown-outs to warn developers, which I encountered [here](https://github.com/canonical/rockcraft/actions/runs/3113458595)

Valid replacements are `macos-11`, `macos-12`, and `macos-latest`.  I chose `macos-latest`.