### PR TITLE
providers: move `confirm_with_user()` call to providers.py

### DIFF
--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -31,6 +31,7 @@ from .project import Project, load_project
 from .providers.providers import (
     ROCKCRAFT_BASE_TO_PROVIDER_BASE,
     capture_logs_from_instance,
+    ensure_provider_is_available,
     get_base_configuration,
     get_instance_name,
 )
@@ -175,7 +176,7 @@ def run_in_provider(
 ):
     """Run lifecycle command in provider instance."""
     provider = providers.get_provider()
-    provider.ensure_provider_is_available()
+    ensure_provider_is_available(provider)
 
     cmd = ["rockcraft", command_name]
 

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -24,8 +24,6 @@ from typing import Generator, List
 from craft_providers import Executor, ProviderError, base, bases, multipass
 from craft_providers.multipass.errors import MultipassError
 
-from rockcraft.utils import confirm_with_user
-
 from ._provider import Provider
 
 logger = logging.getLogger(__name__)
@@ -63,7 +61,7 @@ class MultipassProvider(Provider):
         deleted: List[str] = []
 
         # Nothing to do if provider is not installed.
-        if not self.is_provider_available():
+        if not self.is_provider_installed():
             return deleted
 
         inode = project_path.stat().st_ino
@@ -97,23 +95,13 @@ class MultipassProvider(Provider):
         :raises ProviderError: if provider is not available.
         """
         if not multipass.is_installed():
-            if confirm_with_user(
-                "Multipass is required, but not installed. Do you wish to install Multipass "
-                "and configure it with the defaults?",
-                default=False,
-            ):
-                try:
-                    multipass.install()
-                except multipass.MultipassInstallationError as error:
-                    raise ProviderError(
-                        "Failed to install Multipass. Visit https://multipass.run/ for "
-                        "instructions on installing Multipass for your operating system.",
-                    ) from error
-            else:
+            try:
+                multipass.install()
+            except multipass.MultipassInstallationError as error:
                 raise ProviderError(
-                    "Multipass is required, but not installed. Visit https://multipass.run/ for "
+                    "Failed to install Multipass. Visit https://multipass.run/ for "
                     "instructions on installing Multipass for your operating system.",
-                )
+                ) from error
 
         try:
             multipass.ensure_multipass_is_ready()
@@ -121,8 +109,8 @@ class MultipassProvider(Provider):
             raise ProviderError(str(error)) from error
 
     @classmethod
-    def is_provider_available(cls) -> bool:
-        """Check if provider is installed and available for use.
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
 
         :returns: True if installed.
         """

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -66,8 +66,8 @@ class Provider(ABC):
 
     @classmethod
     @abstractmethod
-    def is_provider_available(cls) -> bool:
-        """Check if provider is installed and available for use.
+    def is_provider_installed(cls) -> bool:
+        """Check if provider is installed.
 
         :returns: True if installed.
         """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -46,7 +46,7 @@ def fake_provider(mock_instance):
             pass
 
         @classmethod
-        def is_provider_available(cls) -> bool:
+        def is_provider_installed(cls) -> bool:
             return True
 
         @contextlib.contextmanager

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -45,15 +45,6 @@ def mock_configure_buildd_image_remote():
 
 
 @pytest.fixture
-def mock_confirm_with_user():
-    with mock.patch(
-        "rockcraft.providers._lxd.confirm_with_user",
-        return_value=False,
-    ) as mock_confirm:
-        yield mock_confirm
-
-
-@pytest.fixture
 def mock_lxc(monkeypatch):
     with mock.patch("craft_providers.lxd.LXC", autospec=True) as mock_lxc:
         yield mock_lxc.return_value
@@ -199,36 +190,10 @@ def test_ensure_provider_is_available_ok_when_installed(mock_lxd_is_installed):
     provider.ensure_provider_is_available()
 
 
-def test_ensure_provider_is_available_errors_when_user_declines(
-    mock_confirm_with_user, mock_lxd_is_installed
-):
-    mock_confirm_with_user.return_value = False
-    mock_lxd_is_installed.return_value = False
-    provider = providers.LXDProvider()
-
-    with pytest.raises(
-        ProviderError,
-        match=re.escape(
-            "LXD is required, but not installed. Visit https://snapcraft.io/lxd for "
-            "instructions on how to install the LXD snap for your distribution"
-        ),
-    ):
-        provider.ensure_provider_is_available()
-
-    assert mock_confirm_with_user.mock_calls == [
-        mock.call(
-            "LXD is required, but not installed. "
-            "Do you wish to install LXD and configure it with the defaults?",
-            default=False,
-        )
-    ]
-
-
 def test_ensure_provider_is_available_errors_when_lxd_install_fails(
-    mock_confirm_with_user, mock_lxd_is_installed, mock_lxd_install
+    mock_lxd_is_installed, mock_lxd_install
 ):
     error = LXDInstallationError("foo")
-    mock_confirm_with_user.return_value = True
     mock_lxd_is_installed.return_value = False
     mock_lxd_install.side_effect = error
     provider = providers.LXDProvider()
@@ -242,18 +207,10 @@ def test_ensure_provider_is_available_errors_when_lxd_install_fails(
     ) as raised:
         provider.ensure_provider_is_available()
 
-    assert mock_confirm_with_user.mock_calls == [
-        mock.call(
-            "LXD is required, but not installed. "
-            "Do you wish to install LXD and configure it with the defaults?",
-            default=False,
-        )
-    ]
     assert raised.value.__cause__ is error
 
 
 def test_ensure_provider_is_available_errors_when_lxd_not_ready(
-    mock_confirm_with_user,
     mock_lxd_is_installed,
     mock_lxd_install,
     mock_lxd_ensure_lxd_is_ready,
@@ -261,7 +218,6 @@ def test_ensure_provider_is_available_errors_when_lxd_not_ready(
     error = LXDError(
         brief="some error", details="some details", resolution="some resolution"
     )
-    mock_confirm_with_user.return_value = True
     mock_lxd_is_installed.return_value = True
     mock_lxd_ensure_lxd_is_ready.side_effect = error
     provider = providers.LXDProvider()
@@ -276,11 +232,11 @@ def test_ensure_provider_is_available_errors_when_lxd_not_ready(
 
 
 @pytest.mark.parametrize("is_installed", [True, False])
-def test_is_provider_available(is_installed, mock_lxd_is_installed):
+def test_is_provider_installed(is_installed, mock_lxd_is_installed):
     mock_lxd_is_installed.return_value = is_installed
     provider = providers.LXDProvider()
 
-    assert provider.is_provider_available() == is_installed
+    assert provider.is_provider_installed() == is_installed
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -34,15 +34,6 @@ def mock_buildd_base_configuration():
 
 
 @pytest.fixture
-def mock_confirm_with_user():
-    with mock.patch(
-        "rockcraft.providers._multipass.confirm_with_user",
-        return_value=False,
-    ) as mock_confirm:
-        yield mock_confirm
-
-
-@pytest.fixture
 def mock_multipass(monkeypatch):
     with mock.patch(
         "craft_providers.multipass.Multipass", autospec=True
@@ -187,34 +178,10 @@ def test_ensure_provider_is_available_ok_when_installed(mock_multipass_is_instal
     provider.ensure_provider_is_available()
 
 
-def test_ensure_provider_is_available_errors_when_user_declines(
-    mock_confirm_with_user, mock_multipass_is_installed
-):
-    mock_confirm_with_user.return_value = False
-    mock_multipass_is_installed.return_value = False
-    provider = providers.MultipassProvider()
-
-    match = re.escape(
-        "Multipass is required, but not installed. Visit https://multipass.run/ for "
-        "instructions on installing Multipass for your operating system."
-    )
-    with pytest.raises(ProviderError, match=match):
-        provider.ensure_provider_is_available()
-
-    assert mock_confirm_with_user.mock_calls == [
-        mock.call(
-            "Multipass is required, but not installed. "
-            "Do you wish to install Multipass and configure it with the defaults?",
-            default=False,
-        )
-    ]
-
-
 def test_ensure_provider_is_available_errors_when_multipass_install_fails(
-    mock_confirm_with_user, mock_multipass_is_installed, mock_multipass_install
+    mock_multipass_is_installed, mock_multipass_install
 ):
     error = MultipassInstallationError("foo")
-    mock_confirm_with_user.return_value = True
     mock_multipass_is_installed.return_value = False
     mock_multipass_install.side_effect = error
     provider = providers.MultipassProvider()
@@ -226,18 +193,10 @@ def test_ensure_provider_is_available_errors_when_multipass_install_fails(
     with pytest.raises(ProviderError, match=match) as raised:
         provider.ensure_provider_is_available()
 
-    assert mock_confirm_with_user.mock_calls == [
-        mock.call(
-            "Multipass is required, but not installed. "
-            "Do you wish to install Multipass and configure it with the defaults?",
-            default=False,
-        )
-    ]
     assert raised.value.__cause__ is error
 
 
 def test_ensure_provider_is_available_errors_when_multipass_not_ready(
-    mock_confirm_with_user,
     mock_multipass_is_installed,
     mock_multipass_install,
     mock_multipass_ensure_multipass_is_ready,
@@ -245,7 +204,6 @@ def test_ensure_provider_is_available_errors_when_multipass_not_ready(
     error = MultipassError(
         brief="some error", details="some details", resolution="some resolution"
     )
-    mock_confirm_with_user.return_value = True
     mock_multipass_is_installed.return_value = True
     mock_multipass_ensure_multipass_is_ready.side_effect = error
     provider = providers.MultipassProvider()
@@ -260,11 +218,11 @@ def test_ensure_provider_is_available_errors_when_multipass_not_ready(
 
 
 @pytest.mark.parametrize("is_installed", [True, False])
-def test_is_provider_available(is_installed, mock_multipass_is_installed):
+def test_is_provider_installed(is_installed, mock_multipass_is_installed):
     mock_multipass_is_installed.return_value = is_installed
     provider = providers.MultipassProvider()
 
-    assert provider.is_provider_available() == is_installed
+    assert provider.is_provider_installed() == is_installed
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -81,6 +81,9 @@ def test_lifecycle_run_in_provider(
     mock_capture_logs_from_instance = mocker.patch(
         "rockcraft.lifecycle.capture_logs_from_instance"
     )
+    mock_ensure_provider_is_available = mocker.patch(
+        "rockcraft.lifecycle.ensure_provider_is_available"
+    )
     mock_project.build_base = rockcraft_base
 
     cwd = Path().absolute()
@@ -94,7 +97,7 @@ def test_lifecycle_run_in_provider(
         parsed_args=argparse.Namespace(),
     )
 
-    mock_provider.ensure_provider_is_available.assert_called_once()
+    mock_ensure_provider_is_available.assert_called_once_with(mock_provider)
     mock_get_instance_name.assert_called_once_with(
         project_name="test-name",
         project_path=cwd,


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Two changes:
1. `confirm_with_user()` is a rockcraft-specific call, so it is moved out of the craft-providers interface.
    - The user confirmation logic was split out to `providers.py`
    - `lxd.py` and `multipass.py` still handle the installation and ensure the provider is available
3. Rename `is_provider_available()` to `is_provider_installed()`

(CRAFT-1387)

