### PR TITLE
commands: add clean command

### DIFF
--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -32,6 +32,7 @@ COMMAND_GROUPS = [
     craft_cli.CommandGroup(
         "Lifecycle",
         [
+            commands.CleanCommand,
             commands.PullCommand,
             commands.OverlayCommand,
             commands.BuildCommand,

--- a/rockcraft/commands/__init__.py
+++ b/rockcraft/commands/__init__.py
@@ -18,6 +18,7 @@
 
 from .lifecycle import (
     BuildCommand,
+    CleanCommand,
     OverlayCommand,
     PackCommand,
     PrimeCommand,
@@ -26,6 +27,7 @@ from .lifecycle import (
 )
 
 __all__ = [
+    "CleanCommand",
     "PullCommand",
     "OverlayCommand",
     "BuildCommand",

--- a/rockcraft/commands/lifecycle.py
+++ b/rockcraft/commands/lifecycle.py
@@ -69,6 +69,19 @@ class _LifecycleStepCommand(_LifecycleCommand):
         )
 
 
+class CleanCommand(_LifecycleStepCommand):
+    """Command to remove part assets."""
+
+    name = "clean"
+    help_msg = "Remove a part's assets"
+    overview = textwrap.dedent(
+        """
+        Clean up artifacts belonging to parts. If no parts are specified,
+        remove the managed snap packing environment.
+        """
+    )
+
+
 class PullCommand(_LifecycleStepCommand):
     """Command to pull parts."""
 

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from craft_cli import EmitterMode, emit
+from craft_cli import CraftError, EmitterMode, emit
 from craft_providers.bases.buildd import BuilddBaseAlias
 
 from rockcraft import lifecycle
@@ -29,6 +29,12 @@ from rockcraft import lifecycle
 def mock_project():
     with patch("rockcraft.project") as _mock_project:
         _mock_project.name = "test-name"
+        _mock_project.platforms = {
+            "test-platform": {
+                "build_on": ["test-build-on"],
+                "build_for": ["test-build-for"],
+            }
+        }
         yield _mock_project
 
 
@@ -37,6 +43,76 @@ def mock_provider(mocker, mock_instance, fake_provider):
     _mock_provider = Mock(wraps=fake_provider)
     mocker.patch("rockcraft.lifecycle.get_provider", return_value=_mock_provider)
     yield _mock_provider
+
+
+@pytest.fixture()
+def mock_get_instance_name(mocker):
+    with patch(
+        "rockcraft.lifecycle.get_instance_name", return_value="test-instance-name"
+    ) as _mock_get_instance_name:
+        yield _mock_get_instance_name
+
+
+@pytest.mark.parametrize(
+    "command_name", ["pull", "overlay", "build", "stage", "prime", "pack"]
+)
+def test_run_run_in_provider(command_name, mocker, mock_project):
+    """Verify `run()` calls `run_in_provider()` when not in managed or destructive
+    mode.
+    """
+    mocker.patch("rockcraft.lifecycle.load_project", return_value=mock_project)
+    mocker.patch("rockcraft.lifecycle.utils.is_managed_mode", return_value=False)
+    mock_run_in_provider = mocker.patch("rockcraft.lifecycle.run_in_provider")
+    lifecycle.run(command_name=command_name, parsed_args=argparse.Namespace())
+
+    mock_run_in_provider.assert_called_once_with(
+        mock_project, command_name, argparse.Namespace()
+    )
+
+
+def test_run_clean_provider_error(mocker, mock_project):
+    """Verify `run()` calls `clean_provider()` when not in managed or destructive
+    mode.
+    """
+    mocker.patch("rockcraft.lifecycle.load_project", return_value=mock_project)
+    mocker.patch("rockcraft.lifecycle.utils.is_managed_mode", return_value=False)
+
+    with pytest.raises(CraftError) as error:
+        lifecycle.run(command_name="clean", parsed_args=argparse.Namespace())
+
+    assert str(error.value) == "`rockcraft clean` for an environment is not supported"
+
+
+def test_run_clean_part_error(mocker, mock_project):
+    """Verify cleaning a part raises an error."""
+    mocker.patch("rockcraft.lifecycle.load_project", return_value=mock_project)
+    mocker.patch("rockcraft.lifecycle.utils.is_managed_mode", return_value=True)
+    mocker.patch(
+        "rockcraft.lifecycle.oci.Image.from_docker_registry",
+        return_value=(Mock(), Mock()),
+    )
+
+    with pytest.raises(CraftError) as error:
+        lifecycle.run(
+            command_name="clean", parsed_args=argparse.Namespace(parts="test-part")
+        )
+
+    assert str(error.value) == "`rockcraft clean <part-name>` is not supported"
+
+
+def test_run_clean_destructive_mode_error(mocker, mock_project):
+    """Verify cleaning in destructive mode raises an error."""
+    mocker.patch("rockcraft.lifecycle.load_project", return_value=mock_project)
+    mocker.patch("rockcraft.lifecycle.utils.is_managed_mode", return_value=True)
+    mocker.patch(
+        "rockcraft.lifecycle.oci.Image.from_docker_registry",
+        return_value=(Mock(), Mock()),
+    )
+
+    with pytest.raises(CraftError) as error:
+        lifecycle.run(command_name="clean", parsed_args=argparse.Namespace())
+
+    assert str(error.value) == "`rockcraft clean` in destructive mode is not supported"
 
 
 @pytest.mark.parametrize(
@@ -58,6 +134,7 @@ def mock_provider(mocker, mock_instance, fake_provider):
     ],
 )
 def test_lifecycle_run_in_provider(
+    mock_get_instance_name,
     mock_instance,
     mock_provider,
     mock_project,
@@ -72,9 +149,6 @@ def test_lifecycle_run_in_provider(
     mock_get_base_configuration = mocker.patch(
         "rockcraft.lifecycle.get_base_configuration",
         return_value=mock_base_configuration,
-    )
-    mock_get_instance_name = mocker.patch(
-        "rockcraft.lifecycle.get_instance_name", return_value="test-instance-name"
     )
     mock_capture_logs_from_instance = mocker.patch(
         "rockcraft.lifecycle.capture_logs_from_instance"

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -16,7 +16,7 @@
 
 import argparse
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from craft_cli import CraftError, EmitterMode, emit
@@ -26,16 +26,16 @@ from rockcraft import lifecycle
 
 
 @pytest.fixture
-def mock_project():
-    with patch("rockcraft.project") as _mock_project:
-        _mock_project.name = "test-name"
-        _mock_project.platforms = {
-            "test-platform": {
-                "build_on": ["test-build-on"],
-                "build_for": ["test-build-for"],
-            }
+def mock_project(mocker):
+    _mock_project = mocker.patch("rockcraft.project")
+    _mock_project.name = "test-name"
+    _mock_project.platforms = {
+        "test-platform": {
+            "build_on": ["test-build-on"],
+            "build_for": ["test-build-for"],
         }
-        yield _mock_project
+    }
+    yield _mock_project
 
 
 @pytest.fixture()
@@ -47,10 +47,9 @@ def mock_provider(mocker, mock_instance, fake_provider):
 
 @pytest.fixture()
 def mock_get_instance_name(mocker):
-    with patch(
+    yield mocker.patch(
         "rockcraft.lifecycle.get_instance_name", return_value="test-instance-name"
-    ) as _mock_get_instance_name:
-        yield _mock_get_instance_name
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
#### Overview

Add command `rockcraft clean` with stubbed out TODOs.  This lays down groundwork needed to refactor `clean_project_environments()`.

There are 3 ways the `clean` command is used:
#### 1. `rockcraft clean <part>` 
- cleans a specific part
- added as a TODO to be implemented later


#### 2. `rockcraft clean --destructive-mode`
- cleans the local build environment
- added as a TODO, but users shouldn't encouter this, since `destructive mode` is also unsupported and labeled with a TODO


#### 3. `rockcraft clean`
- cleans a provider environment
- added as a TODO, but will be supported in my next PR

(CRAFT-1394)
