### PR TITLE
spread: add 'global' clean-up calls

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -44,9 +44,7 @@ prepare: |
   snap install docker
 
   # make sure docker is working
-  sleep 5
-  docker run hello-world
-  sleep 5
+  retry -n 10 --wait 2 sh -c 'docker run --rm hello-world'
 
   snap install lxd
 
@@ -68,6 +66,12 @@ prepare: |
     echo "Expected a snap to exist in /rockcraft/"
     exit 1
   fi
+
+restore-each: |
+  # Cleanup after each task.
+  docker system prune -a -f
+  lxc --project=rockcraft stop --all
+  lxc --project=rockcraft delete $(lxc --project=rockcraft list -c n --format csv)
 
 suites:
   tests/spread/tutorials/:

--- a/tests/spread/general/bare-base/task.yaml
+++ b/tests/spread/general/bare-base/task.yaml
@@ -12,4 +12,3 @@ execute: |
   rm bare-base-test_latest_amd64.rock
   docker images
   docker run --rm bare-base-test
-  docker system prune -a -f

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -29,5 +29,3 @@ execute: |
   docker run --rm big bash -c "stat -c %u /etc/newfiles | grep -q 9999"
   docker run --rm big bash -c "stat -c %u /etc/newfiles/a.txt | grep -q 9999"
   docker run --rm big bash -c "stat -c %u /etc/newfiles/b.txt | grep -q 3333"
-
-  docker system prune -a -f

--- a/tests/spread/general/chisel/task.yaml
+++ b/tests/spread/general/chisel/task.yaml
@@ -15,5 +15,3 @@ execute: |
   docker images
 
   docker run --rm $IMG_NAME
-
-  docker system prune -a -f

--- a/tests/spread/general/craftctl/task.yaml
+++ b/tests/spread/general/craftctl/task.yaml
@@ -15,4 +15,3 @@ execute: |
   rm craftctl-test_latest_craftctl.rock
   docker images
   docker run --rm --entrypoint /usr/bin/hello craftctl-test:latest
-  docker system prune -a -f

--- a/tests/spread/general/entrypoint/task.yaml
+++ b/tests/spread/general/entrypoint/task.yaml
@@ -12,4 +12,3 @@ execute: |
   rm entrypoint-test_latest_amd64.rock
   docker images
   docker run --rm entrypoint-test | grep "ship it!"
-  docker system prune -a -f

--- a/tests/spread/general/environment/task.yaml
+++ b/tests/spread/general/environment/task.yaml
@@ -13,4 +13,3 @@ execute: |
   rm environment-test_latest*.rock  
   docker images
   docker run --rm environment-test bash -c 'echo $X' | grep "ship it!"
-  docker system prune -a -f

--- a/tests/spread/tutorials/basic/task.yaml
+++ b/tests/spread/tutorials/basic/task.yaml
@@ -15,5 +15,4 @@ execute: |
   rm smoke-test_latest_amd64.rock
   docker images
   docker run --rm smoke-test:latest | grep "hello, world"
-  docker system prune -a -f
 


### PR DESCRIPTION
The commands in `restore-each` are run after each task, which lets us cleanup docker images/lxc containers/etc without having to "remember" to do it per-task.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
