### PR TITLE
providers: add `create_environment` method

### DIFF
--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -124,6 +124,19 @@ class LXDProvider(Provider):
         """
         return lxd.is_installed()
 
+    def create_environment(self, *, instance_name: str) -> Executor:
+        """Create a bare environment for specified base.
+
+        No initializing, launching, or cleaning up of the environment occurs.
+
+        :param instance_name: Name of the instance.
+        """
+        return lxd.LXDInstance(
+            name=instance_name,
+            project=self.lxd_project,
+            remote=self.lxd_remote,
+        )
+
     @contextlib.contextmanager
     def launched_environment(
         self,

--- a/rockcraft/providers/_multipass.py
+++ b/rockcraft/providers/_multipass.py
@@ -108,6 +108,15 @@ class MultipassProvider(Provider):
         except multipass.MultipassError as error:
             raise ProviderError(str(error)) from error
 
+    def create_environment(self, *, instance_name: str) -> Executor:
+        """Create a bare environment for specified base.
+
+        No initializing, launching, or cleaning up of the environment occurs.
+
+        :param name: Name of the instance.
+        """
+        return multipass.MultipassInstance(name=instance_name)
+
     @classmethod
     def is_provider_installed(cls) -> bool:
         """Check if provider is installed.

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -72,7 +72,14 @@ class Provider(ABC):
         :returns: True if installed.
         """
 
-    # TODO: migrate `create_environment()` from snapcraft or charmcraft
+    @abstractmethod
+    def create_environment(self, *, instance_name: str) -> Executor:
+        """Create a bare environment for specified base.
+
+        No initializing, launching, or cleaning up of the environment occurs.
+
+        :param instance_name: name of the instance to create
+        """
 
     @abstractmethod
     @contextlib.contextmanager

--- a/rockcraft/providers/providers.py
+++ b/rockcraft/providers/providers.py
@@ -55,11 +55,7 @@ def get_command_environment() -> Dict[str, Optional[str]]:
     return env
 
 
-def get_instance_name(
-    *,
-    project_name: str,
-    project_path: Path,
-) -> str:
+def get_instance_name(*, project_name: str, project_path: Path) -> str:
     """Formulate the name for an instance using each of the given parameters.
 
     Incorporate each of the parameters into the name to come up with a

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,6 +49,9 @@ def fake_provider(mock_instance):
         def is_provider_installed(cls) -> bool:
             return True
 
+        def create_environment(self, *, instance_name: str):
+            yield mock_instance
+
         @contextlib.contextmanager
         def launched_environment(
             self,

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -239,6 +239,17 @@ def test_is_provider_installed(is_installed, mock_lxd_is_installed):
     assert provider.is_provider_installed() == is_installed
 
 
+def test_create_environment(mocker):
+    mock_lxd_instance = mocker.patch("rockcraft.providers._lxd.lxd.LXDInstance")
+
+    provider = providers.LXDProvider()
+    provider.create_environment(instance_name="test-name")
+
+    mock_lxd_instance.assert_called_once_with(
+        name="test-name", project="rockcraft", remote="local"
+    )
+
+
 @pytest.mark.parametrize(
     "build_base, lxd_base",
     [

--- a/tests/unit/providers/test_multipass.py
+++ b/tests/unit/providers/test_multipass.py
@@ -225,6 +225,17 @@ def test_is_provider_installed(is_installed, mock_multipass_is_installed):
     assert provider.is_provider_installed() == is_installed
 
 
+def test_create_environment(mocker):
+    mock_multipass_instance = mocker.patch(
+        "rockcraft.providers._multipass.multipass.MultipassInstance"
+    )
+
+    provider = providers.MultipassProvider()
+    provider.create_environment(instance_name="test-name")
+
+    mock_multipass_instance.assert_called_once_with(name="test-name")
+
+
 @pytest.mark.parametrize(
     "build_base, multipass_base",
     [

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -38,12 +38,7 @@ def provider_class(request):
         ),
     ],
 )
-def test_is_base_available(
-    provider_class,
-    name,
-    expected_valid,
-    expected_reason,
-):
+def test_is_base_available(provider_class, name, expected_valid, expected_reason):
     provider = provider_class()
 
     valid, reason = provider.is_base_available(name)


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Add the `create_environment()` method, which will be used by `clean_project_environment()`.

A duplicate of [snapcraft](https://github.com/snapcore/snapcraft/blob/c3d4c8999f2091592d4ebbca8e35198880bb89c6/snapcraft/providers/_provider.py#L168) and [charmcraft](https://github.com/canonical/charmcraft/blob/b22fcdba3b894004468abfbf45caa54d93fbf7d0/charmcraft/providers/_provider.py#L169).