### PR TITLE
spread: add log output when docker fails to run

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -45,7 +45,11 @@ prepare: |
 
   # make sure docker is working
   sleep 5
-  docker run hello-world
+  if ! docker run hello-world; then
+    snap logs docker
+    echo "docker is not running, exiting"
+    exit 1
+  fi
   sleep 5
 
   snap install lxd


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

About 10-15% of the time, I have been [getting an error](https://github.com/canonical/rockcraft/actions/runs/3109389776/jobs/5039611458) during the spread test `prepare` step saying `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`

Perhaps the 5 second sleep after installing docker isn't long enough.  Perhaps it's something else.  I'm adding some debug messaging to investigate.