### PR TITLE
requirements: update craft-providers to v1.5.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ craft-cli==1.2.0
 #craft-parts==1.14.0
 # Temporarily use a specific craft-parts commit to have 'chisel' support
 git+https://github.com/canonical/craft-parts.git@2651f15855e184c1d8699efcfd1334#egg=craft_parts
-craft-providers==1.5.0
+craft-providers==1.5.1
 cryptography==37.0.4
 Deprecated==1.2.13
 dill==0.3.5.1

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -4,7 +4,7 @@ certifi==2022.6.15
 charset-normalizer==2.1.1
 craft-cli==1.2.0
 craft-parts==1.13.0
-craft-providers==1.5.0
+craft-providers==1.5.1
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.9.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ craft-cli==1.2.0
 #craft-parts==1.14.0
 # Temporarily use a specific craft-parts commit to have 'chisel' support
 git+https://github.com/canonical/craft-parts.git@2651f15855e184c1d8699efcfd1334#egg=craft_parts
-craft-providers==1.5.0
+craft-providers==1.5.1
 Deprecated==1.2.13
 docutils==0.17.1
 idna==3.3


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Building a ROCK with revision 309 produces the error:
```
craft-providers error: failed to inject host's snap 'rockcraft' into target environment.   
...                                                                                                                                                
error: cannot assert: assert failed: cannot resolve prerequisite assertion: account (pMLNwd28ezFdozetvrAOlLj3UqC9HKpe)
```

This error is fixed in https://github.com/canonical/craft-providers/pull/159 and `craft-providers` v1.5.1.