### PR TITLE
spread: restrict the files we package

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -5,6 +5,10 @@ environment:
   PROJECT_PATH: /rockcraft
   PATH: /snap/bin:$PATH:$PROJECT_PATH/tools/external/tools
 
+include:
+    - tests/
+    - tools/
+
 backends:
   google:
     key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'


### PR DESCRIPTION
The spread run only needs the 'test/' and 'tools/' dir. This change has little impact on CI runs because they start from a 'clean' checkout, but for local runs the behavior of adding everything can add hundreds of MB of local 'junk' (specially from the virtual environment). So this speeds up local runs a bit.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
