### PR TITLE
providers: support `rockcraft clean` for a rockcraft environment

### DIFF
--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -53,9 +53,9 @@ def run(command_name: str, parsed_args: "argparse.Namespace"):
 
     if not managed_mode and not destructive_mode:
         if command_name == "clean":
-            # TODO: support `rockcraft clean` for a environment
-            raise CraftError("`rockcraft clean` for an environment is not supported")
-        run_in_provider(project, command_name, parsed_args)
+            clean_provider(project_name=project.name, project_path=Path().absolute())
+        else:
+            run_in_provider(project, command_name, parsed_args)
         return
 
     if managed_mode:
@@ -235,3 +235,19 @@ def run_in_provider(
             ) from err
         finally:
             capture_logs_from_instance(instance)
+
+
+def clean_provider(project_name: str, project_path: Path) -> None:
+    """Clean the provider environment.
+
+    :param project_name: name of the project
+    :param project_path: path of the project
+    """
+    emit.progress("Cleaning build provider")
+    provider = get_provider()
+    instance_name = get_instance_name(
+        project_name=project_name, project_path=project_path
+    )
+    emit.debug(f"Cleaning instance {instance_name}")
+    provider.clean_project_environments(instance_name=instance_name)
+    emit.progress("Cleaned build provider", permanent=True)

--- a/rockcraft/providers/_provider.py
+++ b/rockcraft/providers/_provider.py
@@ -17,26 +17,34 @@
 """Build environment provider support for rockcraft."""
 
 import contextlib
+import logging
 import pathlib
 from abc import ABC, abstractmethod
-from typing import Generator, List, Tuple, Union
+from typing import Generator, Tuple, Union
 
 from craft_providers import Executor, base
+
+logger = logging.getLogger(__name__)
 
 
 class Provider(ABC):
     """Rockcraft's build environment provider."""
 
-    @abstractmethod
-    def clean_project_environments(
-        self, *, project_name: str, project_path: pathlib.Path
-    ) -> List[str]:
-        """Clean up any environments created for project.
+    def clean_project_environments(self, *, instance_name: str) -> None:
+        """Clean the provider environment.
 
-        :param project_name: Name of project.
-
-        :returns: List of containers deleted.
+        :param instance_name: name of the instance to clean
         """
+        # Nothing to do if provider is not installed.
+        if not self.is_provider_installed():
+            logger.debug(
+                "Not cleaning environment because the provider is not installed."
+            )
+            return
+
+        environment = self.create_environment(instance_name=instance_name)
+        if environment.exists():
+            environment.delete()
 
     @classmethod
     @abstractmethod

--- a/tests/spread/general/clean/rockcraft.yaml
+++ b/tests/spread/general/clean/rockcraft.yaml
@@ -1,0 +1,13 @@
+name: clean
+base: ubuntu:22.04
+version: '0.1'
+summary: A minimal hello world ROCK
+description: A minimal hello world ROCK
+license: GPL-3.0
+platforms:
+    amd64:
+
+parts:
+    my-part:
+        plugin: nil
+

--- a/tests/spread/general/clean/task.yaml
+++ b/tests/spread/general/clean/task.yaml
@@ -1,0 +1,15 @@
+summary: rockcraft init test
+
+execute: |
+  rockcraft pull
+
+  # verify instance was created
+  lxc --project=rockcraft list | grep rockcraft-clean
+
+  rockcraft clean
+
+  # verify instance was removed
+  if lxc --project=rockcraft list | grep rockcraft-clean; then
+    echo "instance not removed"
+    exit 1
+  fi

--- a/tests/spread/general/clean/task.yaml
+++ b/tests/spread/general/clean/task.yaml
@@ -1,4 +1,4 @@
-summary: rockcraft init test
+summary: rockcraft clean test
 
 execute: |
   rockcraft pull

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,7 +38,7 @@ def fake_provider(mock_instance):
     class FakeProvider(Provider):
         """Fake provider."""
 
-        def clean_project_environments(self, *, project_name: str, project_path: Path):
+        def clean_project_environments(self, *, instance_name: str):
             pass
 
         @classmethod

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -26,161 +26,46 @@ from rockcraft import providers
 # pylint: disable=duplicate-code
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_buildd_base_configuration(mocker):
-    with mock.patch(
+    mock_base_config = mocker.patch(
         "rockcraft.providers._lxd.bases.BuilddBase", autospec=True
-    ) as mock_base_config:
-        mock_base_config.compatibility_tag = "buildd-base-v0"
-        yield mock_base_config
+    )
+    mock_base_config.compatibility_tag = "buildd-base-v0"
+    yield mock_base_config
 
 
-@pytest.fixture()
-def mock_configure_buildd_image_remote():
-    with mock.patch(
+@pytest.fixture
+def mock_configure_buildd_image_remote(mocker):
+    yield mocker.patch(
         "craft_providers.lxd.configure_buildd_image_remote",
         return_value="buildd-remote",
-    ) as mock_remote:
-        yield mock_remote
+    )
 
 
 @pytest.fixture
-def mock_lxc(monkeypatch):
-    with mock.patch("craft_providers.lxd.LXC", autospec=True) as mock_lxc:
-        yield mock_lxc.return_value
+def mock_lxc(mocker):
+    yield mocker.patch("craft_providers.lxd.LXC", autospec=True)
 
 
 @pytest.fixture(autouse=True)
-def mock_lxd_ensure_lxd_is_ready():
-    with mock.patch(
-        "craft_providers.lxd.ensure_lxd_is_ready", return_value=None
-    ) as mock_is_ready:
-        yield mock_is_ready
-
-
-@pytest.fixture()
-def mock_lxd_install():
-    with mock.patch("craft_providers.lxd.install") as mock_install:
-        yield mock_install
-
-
-@pytest.fixture(autouse=True)
-def mock_lxd_is_installed():
-    with mock.patch(
-        "craft_providers.lxd.is_installed", return_value=True
-    ) as mock_is_installed:
-        yield mock_is_installed
+def mock_lxd_ensure_lxd_is_ready(mocker):
+    yield mocker.patch("craft_providers.lxd.ensure_lxd_is_ready", return_value=None)
 
 
 @pytest.fixture
-def mock_lxd_launch():
-    with mock.patch("craft_providers.lxd.launch", autospec=True) as mock_lxd_launch:
-        yield mock_lxd_launch
+def mock_lxd_install(mocker):
+    yield mocker.patch("craft_providers.lxd.install")
 
 
-def test_clean_project_environments_without_lxd(
-    mock_lxc, mock_lxd_is_installed, mock_path
-):
-    mock_lxd_is_installed.return_value = False
-    provider = providers.LXDProvider(
-        lxc=mock_lxc, lxd_project="test-project", lxd_remote="test-remote"
-    )
-
-    assert (
-        provider.clean_project_environments(
-            project_name="my-rock",
-            project_path=mock_path,
-        )
-        == []
-    )
-
-    assert mock_lxd_is_installed.mock_calls == [mock.call()]
-    assert mock_lxc.mock_calls == []
+@pytest.fixture(autouse=True)
+def mock_lxd_is_installed(mocker):
+    yield mocker.patch("craft_providers.lxd.is_installed", return_value=True)
 
 
-def test_clean_project_environments(mock_lxc, mock_path):
-    mock_lxc.list_names.return_value = [
-        "do-not-delete-me-please",
-        "rockcraft-testrock-445566",
-        "rockcraft-my-rock-",
-        "rockcraft-my-rock-445566",
-        "rockcraft-my-rock-project-445566",
-        "rockcraft_445566_a",
-    ]
-    provider = providers.LXDProvider(
-        lxc=mock_lxc, lxd_project="test-project", lxd_remote="test-remote"
-    )
-
-    assert provider.clean_project_environments(
-        project_name="my-rock-project",
-        project_path=mock_path,
-    ) == ["rockcraft-my-rock-project-445566"]
-
-    assert mock_lxc.mock_calls == [
-        mock.call.list_names(project="test-project", remote="test-remote"),
-        mock.call.delete(
-            instance_name="rockcraft-my-rock-project-445566",
-            force=True,
-            project="test-project",
-            remote="test-remote",
-        ),
-    ]
-
-    mock_lxc.reset_mock()
-
-    assert provider.clean_project_environments(
-        project_name="testrock",
-        project_path=mock_path,
-    ) == ["rockcraft-testrock-445566"]
-
-    assert mock_lxc.mock_calls == [
-        mock.call.list_names(project="test-project", remote="test-remote"),
-        mock.call.delete(
-            instance_name="rockcraft-testrock-445566",
-            force=True,
-            project="test-project",
-            remote="test-remote",
-        ),
-    ]
-
-    mock_lxc.reset_mock()
-
-    assert (
-        provider.clean_project_environments(
-            project_name="unknown-rock",
-            project_path=mock_path,
-        )
-        == []
-    )
-    assert mock_lxc.mock_calls == [
-        mock.call.list_names(project="test-project", remote="test-remote"),
-    ]
-
-
-def test_clean_project_environments_list_failure(mock_lxc, mock_path):
-    mock_lxc.list_names.side_effect = LXDError(brief="fail")
-    provider = providers.LXDProvider(lxc=mock_lxc)
-
-    with pytest.raises(ProviderError, match="fail"):
-        provider.clean_project_environments(
-            project_name="rock",
-            project_path=mock_path,
-        )
-
-
-def test_clean_project_environments_delete_failure(mock_lxc, mock_path):
-    error = LXDError("fail")
-    mock_lxc.list_names.return_value = ["rockcraft-testrock-445566"]
-    mock_lxc.delete.side_effect = error
-    provider = providers.LXDProvider(lxc=mock_lxc)
-
-    with pytest.raises(ProviderError, match="fail") as raised:
-        provider.clean_project_environments(
-            project_name="testrock",
-            project_path=mock_path,
-        )
-
-    assert raised.value.__cause__ is error
+@pytest.fixture
+def mock_lxd_launch(mocker):
+    yield mocker.patch("craft_providers.lxd.launch", autospec=True)
 
 
 def test_ensure_provider_is_available_ok_when_installed(mock_lxd_is_installed):

--- a/tests/unit/providers/test_provider.py
+++ b/tests/unit/providers/test_provider.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
 import pytest
+from craft_providers import ProviderError, lxd, multipass
 
 from rockcraft import providers
 
@@ -24,6 +26,140 @@ known_provider_classes = [providers.LXDProvider, providers.MultipassProvider]
 @pytest.fixture(params=known_provider_classes)
 def provider_class(request):
     return request.param
+
+
+@pytest.fixture()
+def mock_lxd_is_installed(mocker):
+    yield mocker.patch("craft_providers.lxd.is_installed", return_value=True)
+
+
+@pytest.fixture()
+def mock_lxd_delete(mocker):
+    yield mocker.patch("craft_providers.lxd.LXDInstance.delete")
+
+
+@pytest.fixture()
+def mock_lxd_exists(mocker):
+    yield mocker.patch("craft_providers.lxd.LXDInstance.exists", return_value=True)
+
+
+@pytest.fixture()
+def mock_multipass_is_installed(mocker):
+    yield mocker.patch("craft_providers.multipass.is_installed", return_value=True)
+
+
+@pytest.fixture()
+def mock_multipass_delete(mocker):
+    yield mocker.patch("craft_providers.multipass.MultipassInstance.delete")
+
+
+@pytest.fixture()
+def mock_multipass_exists(mocker):
+    yield mocker.patch(
+        "craft_providers.multipass.MultipassInstance.exists", return_value=True
+    )
+
+
+def test_clean_project_environment_exists(
+    mock_lxd_exists,
+    mock_lxd_delete,
+    mock_lxd_is_installed,
+    mock_multipass_exists,
+    mock_multipass_delete,
+    mock_multipass_is_installed,
+    new_dir,
+    provider_class,
+):
+    """Assert instance is deleted if it exists."""
+    provider = provider_class()
+    provider.clean_project_environments(instance_name="test-name")
+
+    if isinstance(provider, providers.LXDProvider):
+        mock_lxd_delete.assert_called_once()
+    else:
+        mock_multipass_delete.assert_called_once()
+
+
+def test_clean_project_environment_does_not_exist(
+    mock_lxd_exists,
+    mock_lxd_delete,
+    mock_lxd_is_installed,
+    mock_multipass_exists,
+    mock_multipass_delete,
+    mock_multipass_is_installed,
+    new_dir,
+    provider_class,
+):
+    """Assert instance is not deleted if it does not exist."""
+    mock_lxd_exists.return_value = False
+    mock_multipass_exists.return_value = False
+
+    provider = provider_class()
+    provider.clean_project_environments(instance_name="test-name")
+
+    mock_lxd_delete.assert_not_called()
+    mock_multipass_delete.assert_not_called()
+
+
+def test_clean_project_environment_lxd_not_installed(
+    mock_lxd_delete,
+    mock_lxd_is_installed,
+    mock_multipass_delete,
+    mock_multipass_is_installed,
+    new_dir,
+    provider_class,
+):
+    """Assert instance is not deleted if LXD is not installed."""
+    mock_lxd_is_installed.return_value = False
+    mock_multipass_is_installed.return_value = False
+
+    provider = provider_class()
+    provider.clean_project_environments(instance_name="test-name")
+
+    mock_lxd_delete.assert_not_called()
+    mock_multipass_delete.assert_not_called()
+
+
+def test_clean_project_environment_exists_error(
+    mock_lxd_exists,
+    mock_lxd_delete,
+    mock_lxd_is_installed,
+    mock_multipass_exists,
+    mock_multipass_delete,
+    mock_multipass_is_installed,
+    new_dir,
+    provider_class,
+):
+    """Assert error on `exists` call is caught."""
+    mock_lxd_exists.side_effect = lxd.LXDError("fail")
+    mock_multipass_exists.side_effect = multipass.MultipassError("fail")
+    provider = provider_class()
+
+    with pytest.raises(ProviderError) as raised:
+        provider.clean_project_environments(instance_name="test-name")
+
+    assert str(raised.value) == "fail"
+
+
+def test_clean_project_environment_delete_error(
+    mock_lxd_exists,
+    mock_lxd_delete,
+    mock_lxd_is_installed,
+    mock_multipass_exists,
+    mock_multipass_delete,
+    mock_multipass_is_installed,
+    new_dir,
+    provider_class,
+):
+    """Assert error on `delete` call is caught."""
+    mock_lxd_delete.side_effect = lxd.LXDError("fail")
+    mock_multipass_delete.side_effect = multipass.MultipassError("fail")
+    provider = provider_class()
+
+    with pytest.raises(ProviderError) as raised:
+        provider.clean_project_environments(instance_name="test-name")
+
+    assert str(raised.value) == "fail"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
Support the command `rockcraft clean` to clean a rockcraft environment (i.e. delete a LXD instance).

I'm following the same implementation recently done in [snapcraft](https://github.com/snapcore/snapcraft/pull/3875) and [charmcraft](https://github.com/canonical/charmcraft/pull/835), where instances are deleted via the `Executor` object.

(CRAFT-1373)