### PR TITLE
providers: move lxd project name out of craft-providers interface

### DIFF
--- a/rockcraft/providers/_lxd.py
+++ b/rockcraft/providers/_lxd.py
@@ -47,7 +47,7 @@ class LXDProvider(Provider):
         self,
         *,
         lxc: lxd.LXC = lxd.LXC(),
-        lxd_project: str = "rockcraft",
+        lxd_project: str = "default",
         lxd_remote: str = "local",
     ) -> None:
         self.lxc = lxc

--- a/rockcraft/providers/providers.py
+++ b/rockcraft/providers/providers.py
@@ -189,7 +189,7 @@ def get_provider() -> Provider:
 
     # return the chosen provider
     if chosen_provider == "lxd":
-        return LXDProvider()
+        return LXDProvider(lxd_project="rockcraft")
     if chosen_provider == "multipass":
         return MultipassProvider()
 

--- a/tests/unit/providers/test_lxd.py
+++ b/tests/unit/providers/test_lxd.py
@@ -246,7 +246,7 @@ def test_create_environment(mocker):
     provider.create_environment(instance_name="test-name")
 
     mock_lxd_instance.assert_called_once_with(
-        name="test-name", project="rockcraft", remote="local"
+        name="test-name", project="default", remote="local"
     )
 
 
@@ -289,7 +289,7 @@ def test_launched_environment(
                 map_user_uid=True,
                 uid=1234,
                 use_snapshots=True,
-                project="rockcraft",
+                project="default",
                 remote="local",
             ),
         ]

--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -261,7 +261,9 @@ def test_ensure_provider_is_available_unknown_error():
 def test_get_provider_default_lxd(emitter, mocker):
     """Verify lxd is the default provider when running on a linux system."""
     mocker.patch("sys.platform", "linux")
-    assert isinstance(providers.get_provider(), LXDProvider)
+    provider = providers.get_provider()
+    assert isinstance(provider, LXDProvider)
+    assert provider.lxd_project == "rockcraft"
     emitter.assert_debug("Using default provider 'lxd' on linux system")
 
 
@@ -276,7 +278,9 @@ def test_get_provider_default_multipass(emitter, mocker, system):
 def test_get_provider_environmental_variable(monkeypatch):
     """Verify the provider can be set by an environmental variable."""
     monkeypatch.setenv("ROCKCRAFT_PROVIDER", "lxd")
-    assert isinstance(providers.get_provider(), LXDProvider)
+    provider = providers.get_provider()
+    assert isinstance(provider, LXDProvider)
+    assert provider.lxd_project == "rockcraft"
 
     monkeypatch.setenv("ROCKCRAFT_PROVIDER", "multipass")
     assert isinstance(providers.get_provider(), MultipassProvider)


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
I promise this is my last `rockcraft` PR today :laughing: 

This PR pulls out rockcraft's project name out of `lxd.py` and moves it to `providers.py`.