### PR TITLE
tests: use tmp_path instead of mock_path

### DIFF
--- a/tests/unit/providers/test_providers.py
+++ b/tests/unit/providers/test_providers.py
@@ -49,13 +49,13 @@ def test_get_command_environment_all_opts(monkeypatch):
     }
 
 
-def test_get_instance_name(mock_path):
+def test_get_instance_name(tmp_path):
     assert (
         providers.get_instance_name(
             project_name="my-project-name",
-            project_path=mock_path,
+            project_path=tmp_path,
         )
-        == "rockcraft-my-project-name-445566"
+        == f"rockcraft-my-project-name-{tmp_path.stat().st_ino}"
     )
 
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Tiny change to a unit test.

The test fixture `providers/conftest.py::mock_path` is leaving rockcraft, so I removed the only reference to it inside rockcraft's test suite.