### PR TITLE
requirements: update craft-parts to 1.15.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,9 +13,7 @@ codespell==2.2.1
 commonmark==0.9.1
 coverage==6.4.4
 craft-cli==1.2.0
-#craft-parts==1.14.0
-# Temporarily use a specific craft-parts commit to have 'chisel' support
-git+https://github.com/canonical/craft-parts.git@2651f15855e184c1d8699efcfd1334#egg=craft_parts
+craft-parts==1.15.1
 craft-providers==1.6.0
 cryptography==37.0.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,7 @@ Babel==2.10.3
 certifi==2022.6.15
 charset-normalizer==2.1.1
 craft-cli==1.2.0
-#craft-parts==1.14.0
-# Temporarily use a specific craft-parts commit to have 'chisel' support
-git+https://github.com/canonical/craft-parts.git@2651f15855e184c1d8699efcfd1334#egg=craft_parts
+craft-parts==1.15.1
 craft-providers==1.6.0
 Deprecated==1.2.13
 docutils==0.17.1

--- a/tests/spread/general/entrypoint/rockcraft.yaml
+++ b/tests/spread/general/entrypoint/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: entrypoint-test
 title: Entrypoint Test
 version: latest
-base: ubuntu:20.04
+base: ubuntu:22.04
 summary: Hello World
 description: A ROCK with the simple purpose of demonstrating an Hello World entrypoint
 license: Apache-2.0


### PR DESCRIPTION
Craft-parts 1.15.1 fixes device nodes in the overlay base image. This should address issues related to package list updates when using base ubuntu:22.04. (Fixes #117)

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
