### PR TITLE
providers: capture logs with debug-level logging

### DIFF
--- a/rockcraft/providers.py
+++ b/rockcraft/providers.py
@@ -82,12 +82,12 @@ def capture_logs_from_instance(instance: executor.Executor) -> None:
         source=source_log_path, missing_ok=True
     ) as log_path:
         if log_path:
-            emit.trace("Logs retrieved from managed instance:")
+            emit.debug("Logs retrieved from managed instance:")
             with open(log_path, "r") as log_file:
                 for line in log_file:
-                    emit.trace(":: " + line.rstrip())
+                    emit.debug(":: " + line.rstrip())
         else:
-            emit.trace(
+            emit.debug(
                 f"Could not find log file {source_log_path.as_posix()} in instance."
             )
 

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -76,10 +76,10 @@ def test_capture_logs_from_instance(mocker, emitter, mock_instance, new_dir):
         call.temporarily_pull_file(source=Path("/tmp/rockcraft.log"), missing_ok=True)
     ]
     expected = [
-        call("trace", "Logs retrieved from managed instance:"),
-        call("trace", ":: some"),
-        call("trace", ":: log data"),
-        call("trace", ":: here"),
+        call("debug", "Logs retrieved from managed instance:"),
+        call("debug", ":: some"),
+        call("debug", ":: log data"),
+        call("debug", ":: here"),
     ]
     emitter.assert_interactions(expected)
 
@@ -94,7 +94,7 @@ def test_capture_log_from_instance_not_found(mocker, emitter, mock_instance, new
 
     providers.capture_logs_from_instance(mock_instance)
 
-    emitter.assert_trace("Could not find log file /tmp/rockcraft.log in instance.")
+    emitter.assert_debug("Could not find log file /tmp/rockcraft.log in instance.")
     mock_instance.temporarily_pull_file.assert_called_with(
         source=Path("/tmp/rockcraft.log"), missing_ok=True
     )


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Captured logs were not being saved to the log file in quiet and brief modes because they were emitted as trace-level messages instead of debug-level.

This is an identical fix from snapcraft: https://github.com/snapcore/snapcraft/pull/3950

Resolves https://github.com/canonical/rockcraft/issues/140
