### PR TITLE
spread: disable fedora due to squashfs bug

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -24,9 +24,11 @@ backends:
       - ubuntu-22.04-64:
           workers: 1
           storage: 40G
-      - fedora-35-64:
-          workers: 1
-          storage: 40G
+      # Fedora is disabled until it runs kernel 6.0.7 due to squashfs bug
+      # (https://forum.snapcraft.io/t/unsupported-version-0-of-verneed-record-linux-6-0/32160/14)
+      #- fedora-35-64:
+      #    workers: 1
+      #    storage: 40G
 
 prepare: |
   if os.query is-ubuntu; then


### PR DESCRIPTION
Disable spread runs on fedora until it runs kernel >=6.0.7 (currently in testing) because of the squashfs bug that affects snapd.

Refs:

- https://forum.snapcraft.io/t/unsupported-version-0-of-verneed-record-linux-6-0/32160/14
- https://bodhi.fedoraproject.org/updates/?packages=kernel

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
