### PR TITLE
Revert "spread: disable fedora due to squashfs bug (#142)"

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -24,11 +24,9 @@ backends:
       - ubuntu-22.04-64:
           workers: 1
           storage: 40G
-      # Fedora is disabled until it runs kernel 6.0.7 due to squashfs bug
-      # (https://forum.snapcraft.io/t/unsupported-version-0-of-verneed-record-linux-6-0/32160/14)
-      #- fedora-35-64:
-      #    workers: 1
-      #    storage: 40G
+      - fedora-35-64:
+          workers: 1
+          storage: 40G
 
 prepare: |
   if os.query is-ubuntu; then


### PR DESCRIPTION
This reverts commit 5a78d6dd86892b86a02344e13db4d2c36b7c4772.

Kernel 6.0.7 is now available on the Fedora images used by spread.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
