### PR TITLE
project: install pebble's go without aliases setup

### DIFF
--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -500,7 +500,7 @@ def _add_pebble_data(yaml_data: Dict[str, Any]) -> None:
         "override-pull": (
             "craftctl default\n"
             "snap set system experimental.parallel-instances=true\n"
-            "snap install go_pebble --channel 1.19/stable --classic\n"
+            "snap install --unaliased go_pebble --channel 1.19/stable --classic\n"
         ),
         "override-build": (
             "go_pebble mod download\n"

--- a/tests/spread/general/plugin-go/go.mod
+++ b/tests/spread/general/plugin-go/go.mod
@@ -1,0 +1,3 @@
+module canonical.com/hello
+
+go 1.18

--- a/tests/spread/general/plugin-go/hello.go
+++ b/tests/spread/general/plugin-go/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello world")
+}

--- a/tests/spread/general/plugin-go/rockcraft.yaml
+++ b/tests/spread/general/plugin-go/rockcraft.yaml
@@ -1,0 +1,18 @@
+name: go-pebble
+summary: A ROCK built with go
+description: The go version used does not interfere with the one used for pebble
+license: Apache-2.0
+
+version: "0.0.1"
+base: bare
+build_base: "ubuntu:22.04"
+platforms:
+  amd64:
+
+
+parts:
+  go:
+    plugin: go
+    source: .
+    build-snaps:
+      - go/1.15/stable

--- a/tests/spread/general/plugin-go/task.yaml
+++ b/tests/spread/general/plugin-go/task.yaml
@@ -1,0 +1,5 @@
+summary: check that the build-snap used by the go plugin does not interfere with the one used by pebble
+
+execute: |
+  rockcraft prime
+

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -89,7 +89,7 @@ def pebble_part():
             "override-pull": (
                 "craftctl default\n"
                 "snap set system experimental.parallel-instances=true\n"
-                "snap install go_pebble --channel 1.19/stable --classic\n"
+                "snap install --unaliased go_pebble --channel 1.19/stable --classic\n"
             ),
             "override-build": (
                 "go_pebble mod download\n"


### PR DESCRIPTION
This avoids a conflict when the user's go is installed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
