### PR TITLE
ci: move to latest snapcore/action-build

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Build rockcraft snap
         id: build-rockcraft
-        uses: snapcore/action-build@v1.0.9
+        uses: snapcore/action-build@v1
 
       - name: Upload rockcraft snap
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This is to fix incompatibilities between Docker and LXD.
Ref this snapcraft PR: https://github.com/snapcore/snapcraft/pull/3995

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
