### PR TITLE
oci: handle opaque whiteouts in new layer (usrmerge) 

### DIFF
--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -26,7 +26,7 @@ import tarfile
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
 from craft_cli import CraftError, emit
@@ -375,16 +375,17 @@ def _archive_layer(
             # - The directory's exists on ``base_layer_dir`` as a symlink to another
             #   directory (like in usrmerge).
             if upper_subpath != new_layer_dir:
-                is_not_opaque_dir = not overlays.is_oci_opaque_dir(upper_subpath)
+                upper_is_not_opaque_dir = not overlays.is_oci_opaque_dir(upper_subpath)
                 lower_symlink_target = _symlink_target_in_base_layer(
                     relative_path, base_layer_dir
                 )
+                lower_is_symlink = lower_symlink_target is not None
 
-                if is_not_opaque_dir and lower_symlink_target is not None:
+                if upper_is_not_opaque_dir and lower_is_symlink:
                     emit.debug(
                         f"Skipping {upper_subpath} because it exists as a symlink on the lower layer"
                     )
-                    archive_subdir = lower_symlink_target
+                    archive_subdir = cast(Path, lower_symlink_target)
                 else:
                     emit.debug(f"Adding to layer: {upper_subpath}")
                     tar_file.add(

--- a/tests/spread/general/big/rockcraft.yaml
+++ b/tests/spread/general/big/rockcraft.yaml
@@ -47,3 +47,19 @@ parts:
       rm lib32
       mkdir lib32
       touch lib32/new_lib32_file
+
+  overlay-remove-dir-part:
+    plugin: nil
+    overlay-script: |
+      # this part REMOVES the /libx32 symlink
+      cd ${CRAFT_OVERLAY}
+      rm libx32
+
+  overlay-recreate-dir-part:
+    after: [overlay-remove-dir-part]
+    plugin: nil
+    overlay-script: |
+      # this part CREATES /libx32 as a regular dir
+      cd ${CRAFT_OVERLAY}
+      mkdir libx32
+      touch libx32/new_libx32_file

--- a/tests/spread/general/big/rockcraft.yaml
+++ b/tests/spread/general/big/rockcraft.yaml
@@ -38,5 +38,12 @@ parts:
   usrmerge-part:
     plugin: nil
     override-build: |
+      # This build script adds a file in bin/ - the symlink in the base should be preserved.
       mkdir ${CRAFT_PART_INSTALL}/bin
       touch ${CRAFT_PART_INSTALL}/bin/new_bin_file
+    overlay-script: |
+      # explicitly remove a base layer symlink and create a dir instead
+      cd ${CRAFT_OVERLAY}
+      rm lib32
+      mkdir lib32
+      touch lib32/new_lib32_file

--- a/tests/spread/general/big/rockcraft.yaml
+++ b/tests/spread/general/big/rockcraft.yaml
@@ -48,18 +48,12 @@ parts:
       mkdir lib32
       touch lib32/new_lib32_file
 
-  overlay-remove-dir-part:
+  rock-symlink-part:
     plugin: nil
-    overlay-script: |
-      # this part REMOVES the /libx32 symlink
-      cd ${CRAFT_OVERLAY}
-      rm libx32
+    override-build: |
+      # Add a .rock symlink, to see if the metadata layer preserves it.
+      cd ${CRAFT_PART_INSTALL}
+      mkdir fake_rock_dir
+      touch fake_rock_dir/fake_rock_file
+      ln -s fake_rock_dir .rock
 
-  overlay-recreate-dir-part:
-    after: [overlay-remove-dir-part]
-    plugin: nil
-    overlay-script: |
-      # this part CREATES /libx32 as a regular dir
-      cd ${CRAFT_OVERLAY}
-      mkdir libx32
-      touch libx32/new_libx32_file

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -52,7 +52,13 @@ execute: |
   docker rm -f big-container
 
   ############################################################################################
-  # check that the /bin symlink to /usr/bin wasn't broken by the /bin/new_bin_file addition
+  # check that the /bin symlink to /usr/bin *was not* broken by the /bin/new_bin_file addition
   ############################################################################################
   docker run --rm big readlink /bin | MATCH usr/bin
   docker run --rm big ls /bin/bash /bin/new_bin_file
+
+  ############################################################################################
+  # check that the /lib32 symlink to /usr/lib32 *was* broken by the overlay-script
+  ############################################################################################
+  docker run --rm big readlink /lib32 | NOMATCH usr/lib32
+  docker run --rm big ls /lib32/new_lib32_file

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -62,3 +62,10 @@ execute: |
   ############################################################################################
   docker run --rm big readlink /lib32 | NOMATCH usr/lib32
   docker run --rm big ls /lib32/new_lib32_file
+
+  ############################################################################################
+  # check that the /libx32 symlink to /usr/libx32 *was* broken by the overlay-script
+  # (done in two steps, by two separate parts)
+  ############################################################################################
+  docker run --rm big readlink /libx32 | NOMATCH usr/libx32
+  docker run --rm big ls /libx32/new_libx32_file

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -64,7 +64,8 @@ execute: |
   docker run --rm big ls /lib32/new_lib32_file
 
   ############################################################################################
-  # check that the /.rock symlink to /fake_rock_dir is preserved
+  # This check documents the fact that we currently don't preserve/observe symlinks between
+  # layers - we only take the base on which the ROCK was built into account. If the behavior
+  # changes, this check will break and then can be removed/updated.
   ############################################################################################
-  docker run --rm big readlink /.rock | MATCH fake_rock_dir
-  docker run --rm big ls /.rock/fake_rock_file /.rock/metadata.yaml
+  docker run --rm big readlink /.rock | NOMATCH fake_rock_dir

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -64,8 +64,7 @@ execute: |
   docker run --rm big ls /lib32/new_lib32_file
 
   ############################################################################################
-  # check that the /libx32 symlink to /usr/libx32 *was* broken by the overlay-script
-  # (done in two steps, by two separate parts)
+  # check that the /.rock symlink to /fake_rock_dir is preserved
   ############################################################################################
-  docker run --rm big readlink /libx32 | NOMATCH usr/libx32
-  docker run --rm big ls /libx32/new_libx32_file
+  docker run --rm big readlink /.rock | MATCH fake_rock_dir
+  docker run --rm big ls /.rock/fake_rock_file /.rock/metadata.yaml


### PR DESCRIPTION
Now that add_layer() looks at the base, improve its logic to support
*explicit* removals/hiding of base layer symlinks. With this change,
regular directories created by lifecycle's "build" step will respect
symlinks in the base layer, but removals via overlay-scripts will
hide those symlinks.