### PR TITLE
dependencies: update craft-providers to 1.6.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-cli==1.2.0
 craft-parts==1.17.1
-craft-providers==1.6.1
+craft-providers==1.6.2
 cryptography==38.0.4
 Deprecated==1.2.13
 dill==0.3.6

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
 craft-parts==1.17.1
-craft-providers==1.6.1
+craft-providers==1.6.2
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.9.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
 craft-parts==1.17.1
-craft-providers==1.6.1
+craft-providers==1.6.2
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.9.29


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
This disables [automatic snap refreshes](https://github.com/canonical/craft-providers/pull/182) inside of instances.

Source: https://bugs.launchpad.net/snapcraft/+bug/1998100

(CRAFT-1520)