### PR TITLE
errors: add rockcraft error base class

### DIFF
--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -24,7 +24,7 @@ from craft_cli import ArgumentParsingError, EmitterMode, ProvideHelpException, e
 from craft_parts import PartsError
 from craft_providers import ProviderError
 
-from rockcraft import __version__
+from rockcraft import __version__, errors
 
 from . import commands
 from .utils import get_managed_environment_log_path, is_managed_mode
@@ -98,7 +98,7 @@ def run() -> None:
         print(err, file=sys.stderr)  # to stderr, as argparse normally does
         emit.ended_ok()
         sys.exit(1)
-    except craft_cli.CraftError as err:  # TODO: define RockcraftError
+    except errors.RockcraftError as err:
         emit.error(err)
         sys.exit(1)
     except PartsError as err:

--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -19,17 +19,21 @@
 from craft_cli import CraftError
 
 
-class RockcraftInitError(CraftError):
+class RockcraftError(CraftError):
+    """Failire in a Rockcraft operation."""
+
+
+class RockcraftInitError(RockcraftError):
     """Error while initializing rockcraft project."""
 
 
-class PartsLifecycleError(CraftError):
+class PartsLifecycleError(RockcraftError):
     """Error during parts processing."""
 
 
-class ProjectLoadError(CraftError):
+class ProjectLoadError(RockcraftError):
     """Error loading rockcraft.yaml."""
 
 
-class ProjectValidationError(CraftError):
+class ProjectValidationError(RockcraftError):
     """Error validating rockcraft.yaml."""

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -29,8 +29,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
-from craft_cli import CraftError, emit
+from craft_cli import emit
 from craft_parts.overlays import overlays
+
+from rockcraft import errors
 
 logger = logging.getLogger(__name__)
 
@@ -484,4 +486,4 @@ def _process_run(command: List[str], **kwargs: Any) -> subprocess.CompletedProce
         msg = f"Failed to copy image: {err!s}"
         if err.stderr:
             msg += f" ({err.stderr.strip()!s})"
-        raise CraftError(msg) from err
+        raise errors.RockcraftError(msg) from err

--- a/spread.yaml
+++ b/spread.yaml
@@ -55,6 +55,7 @@ prepare: |
   # make sure docker is working
   retry -n 10 --wait 2 sh -c 'docker run --rm hello-world'
 
+  tests.pkgs remove lxd
   snap install lxd
 
   # Hold snap refreshes for 24h.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -24,6 +24,7 @@ from craft_cli import CraftError, ProvideHelpException, emit
 from craft_providers import ProviderError
 
 from rockcraft import cli, project
+from rockcraft.errors import RockcraftError
 
 
 @pytest.fixture
@@ -161,7 +162,7 @@ def test_run_arg_provider_help_exception(capsys, mocker):
 @pytest.mark.parametrize(
     "input_error, output_error",
     [
-        (CraftError("test error"), CraftError("test error")),
+        (RockcraftError("test error"), CraftError("test error")),
         (ProviderError("test error"), CraftError("craft-providers error: test error")),
         (
             Exception("test error"),


### PR DESCRIPTION
Implement a base class for Rockcraft errors for better organization, instead of using Craft-CLI's `CraftError` directly.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
