### PR TITLE
tests: check before handling rockcraft instances

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -80,8 +80,11 @@ prepare: |
 restore-each: |
   # Cleanup after each task.
   docker system prune -a -f
-  lxc --project=rockcraft stop --all
-  lxc --project=rockcraft delete $(lxc --project=rockcraft list -c n --format csv)
+  if lxc project info rockcraft > /dev/null 2>&1 ; then
+    # only stop/cleanup instances if the test actually created them 
+    lxc --project=rockcraft stop --all
+    lxc --project=rockcraft delete $(lxc --project=rockcraft list -c n --format csv)
+  fi  
 
 debug-each: |
   # output latest rockcraft log file on test failure


### PR DESCRIPTION
The previous code always tried to stop/delete rockcraft-related lxc instances because all spread tests created them. Now we have spread tests that don't, so wrap the cleanup in an `if`.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
