### PR TITLE
docs: force max line length of 80 characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ test-pyright:
 
 .PHONY: test-sphinx-lint
 test-sphinx-lint:
-	sphinx-lint docs/*
+	sphinx-lint --ignore docs/_build --max-line-length 80 -e all docs/*
 
 .PHONY: test-units
 test-units: ## Run unit tests.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -3,28 +3,30 @@
 Rockcraft documentation guidelines
 **********************************
 
-The Rockcraft documentation pages adopt the `Diátaxis framework <https://diataxis.fr/>`_.
+The Rockcraft documentation pages adopt the
+`Diátaxis framework <https://diataxis.fr/>`_.
 
 Contributing to the docs
 ------------------------
 
-Rockcraft's documentation is generated with Sphinx, and we use reStructuredText as the
-markup language for the source files.
+Rockcraft's documentation is generated with Sphinx, and we use reStructuredText
+as the markup language for the source files.
 
 Code blocks
 ***********
 
-All code-like content going into the documentation must be tested, especially if said content
-is supposed to be reproducible.
+All code-like content going into the documentation must be tested, especially if
+said content is supposed to be reproducible.
 
-Whenever applicable, sections with code snippets will have their own directory, with a
-``code`` folder within (e.g. ``tutorials/code``).
+Whenever applicable, sections with code snippets will have their own directory,
+with a ``code`` folder within (e.g. ``tutorials/code``).
 
-Each technical page (i.e. a tutorial, a how-to guide, etc.) shall have its own folder within
-the ``code`` directory (e.g. ``tutorials/code/hello-world``).
+Each technical page (i.e. a tutorial, a how-to guide, etc.) shall have its own
+folder within the ``code`` directory (e.g. ``tutorials/code/hello-world``).
 
-Finally, each page shall have a corresponding ``task.yaml`` file for Spread tests, and use ``..  literalinclude::``
-to include code blocks from those YAML files.
+Finally, each page shall have a corresponding ``task.yaml`` file for Spread
+tests, and use ``..  literalinclude::`` to include code blocks from those YAML
+files.
 
 Build the docs
 --------------

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -4,10 +4,12 @@
 Explanation
 ***********
 
-Getting past the technical matters surrounding Rockcraft, from a higher perspective,
-you might be asking *"but what is this after all?"* and *"why do I need it?"*.
+Getting past the technical matters surrounding Rockcraft, from a higher
+perspective, you might be asking *"but what is this after all?"* and *"why do
+I need it?"*.
 
-Let's then use this page to go a bit deeper into the concepts and definitions behind Rockcraft.
+Let's then use this page to go a bit deeper into the concepts and definitions
+behind Rockcraft.
 
 
 
@@ -18,52 +20,61 @@ Rockcraft builds ROCKs, but **what is a ROCK**?
 
 In short, a ROCK is just an OCI-compliant container image! Period.
 
-A ROCK can live on any existing container registry, very much like any other Docker image out there.
-You can run a ROCK very much like any other container image...for example: ``docker run <rock> ...`` will work
-just fine.
+A ROCK can live on any existing container registry, very much like any other
+Docker image out there.
+You can run a ROCK very much like any other container image...for example:
+``docker run <rock> ...`` will work just fine.
 
-And the same applies to container image builds, in the sense that if you already have image build recipes (like Dockerfiles)
-and you want to start basing your own images on an existing ROCK, that will work just fine too!
+And the same applies to container image builds, in the sense that if you already
+have image build recipes (like Dockerfiles) and you want to start basing your
+own images on an existing ROCK, that will work just fine too!
 
 
 So why do I need ROCKs?
 .......................
 
-Now, this is where things get interesting. To answer this question, we first need to look at the current state of the art with respect to the existing container image offerings
-out there.
+Now, this is where things get interesting. To answer this question, we first
+need to look at the current state of the art with respect to the existing
+container image offerings out there.
 
-It is easy to find public studies (like `Unit 42 / Znet <https://www.zdnet.com/article/96-of-third-party-container-applications-deployed-in-cloud-infrastructure-contain-known-vulnerabilities-unit-42/>`_
-and `Snyk's state of open source security report 2020 <https://snyk.io/blog/10-docker-image-security-best-practices/>`_) where the findings
-state a concerning number of containers at risk deployed in cloud infrastructures.
+It is easy to find public studies (like `Unit 42 / Znet`_
+and `Snyk's state of open source security report 2020`_) where the findings
+state a concerning number of containers at risk deployed in cloud
+infrastructures.
 
-In fact, both these studies and our own assessments (dated from December 2021) show that the most popular images in Docker Hub
-contain known vulnerabilities, with Ubuntu being the only one without any critical or high ones.
+In fact, both these studies and our own assessments (dated from December 2021)
+show that the most popular images in Docker Hub contain known vulnerabilities,
+with Ubuntu being the only one without any critical or high ones.
 
 .. image:: _static/container-image-vulnerabilities.png
   :align: center
   :width: 95%
   :alt: Most popular container images contain known vulnerabilities
 
-Sure, consumers could venture to fix these vulnerabilities themselves, but not only would this increase the cost and proliferation of images, but it wouldn't be
-easy to accomplish due to the lack of expertise in the subject matter. The right approach is to actually fix the
-vulnerabilities at their source! And Canonical has already started doing this. If we compare some of the Docker Official
-container images vs some of the ones maintained by Canonical, we can verify that the latter have no high/critical vulnerabilities in them!
+Sure, consumers could venture to fix these vulnerabilities themselves, but not
+only would this increase the cost and proliferation of images, but it wouldn't
+be easy to accomplish due to the lack of expertise in the subject matter. The
+right approach is to actually fix the vulnerabilities at their source! And
+Canonical has already started doing this. If we compare some of the Docker
+Official container images vs some of the ones maintained by Canonical, we can
+verify that the latter have no high/critical vulnerabilities in them!
 
 .. image:: _static/canonical-images-vulnerabilities.png
   :align: center
   :width: 95%
   :alt: vulnerabilities in Official vs Canonical-maintained OCI images
 
-So this is where the motivation for a new generation of OCI images (aka ROCKs) starts - the need for more secure container images!
-And while this need might carry the biggest weight in the container users' demands, other values come into play when
-selecting the best container image, such as:
+So this is where the motivation for a new generation of OCI images (aka ROCKs)
+starts - the need for more secure container images! And while this need might
+carry the biggest weight in the container users' demands, other values come into
+play when selecting the best container image, such as:
 
 * stability
 * size
 * compliance
 * provenance
 
-You can find these values and their relevance in this report: https://juju.is/cloud-native-kubernetes-usage-report-2021#selection-criteria-for-container-images.
+You can find these values and their relevance in `this report`_.
 
 This brings us to the problem statement behind ROCKs:
 
@@ -75,19 +86,25 @@ This brings us to the problem statement behind ROCKs:
 A ROCK is:
 
 * **secure** and **stable**: based on the latest and greatest Ubuntu releases;
-* **OCI-compliant**: compatible with all the popular container management tools (Docker, Kubernetes, etc.);
-* **dependable**: built on top of Ubuntu, with a predictable release cadence and timely security updates;
+* **OCI-compliant**: compatible with all the popular container management tools
+  (Docker, Kubernetes, etc.);
+* **dependable**: built on top of Ubuntu, with a predictable release cadence and
+  timely security updates;
 * **production-grade**: tested and secured by default.
 
 
 Do I need to use Rockcraft?
 ===========================
 
-If you want to build a proper ROCK, yes, we'd recommend you do. This is not to say you wouldn't be able to build ROCK-like container images
-with your own tools, but Rockcraft has been developed precisely to offer an easy way to build production-grade container images.
+If you want to build a proper ROCK, yes, we'd recommend you do. This is not to
+say you wouldn't be able to build ROCK-like container images with your own
+tools, but Rockcraft has been developed precisely to offer an easy way to build
+production-grade container images.
 
-Furthermore, Rockcraft is built on top of existing concepts and within the same family as `Snapcraft <https://snapcraft.io/docs/snapcraft-overview>`_
-and `Charmcraft <https://juju.is/docs/sdk/charmcraft-cli-commands>`_, such that its adoption becomes seamless for those already used to building Snaps and Charms.
+Furthermore, Rockcraft is built on top of existing concepts and within the same
+family as `Snapcraft <https://snapcraft.io/docs/snapcraft-overview>`_ and
+`Charmcraft <https://juju.is/docs/sdk/charmcraft-cli-commands>`_, such that its
+adoption becomes seamless for those already used to building Snaps and Charms.
 
 
 .. _what-is-chisel:
@@ -95,16 +112,21 @@ and `Charmcraft <https://juju.is/docs/sdk/charmcraft-cli-commands>`_, such that 
 What is Chisel?
 ===============
 
-As the name says, Chisel is a tool for carving and cutting. But carving and cutting what? Even though we are talking about ROCKs, it's not
-like these are actual solid masses one can physically interact with...
+As the name says, Chisel is a tool for carving and cutting. But carving and
+cutting what? Even though we are talking about ROCKs, it's not like these are
+actual solid masses one can physically interact with...
 
-`Chisel <https://github.com/canonical/chisel>`_ is a software tool for carving and cutting **Debian packages**!
+`Chisel <https://github.com/canonical/chisel>`_ is a software tool for carving
+and cutting **Debian packages**!
 
-One of the key value propositions of Rockcraft is the ability to build truly minimal container images while honoring the Ubuntu experience.
-Well, when having a closer look at a Debian package, it is easy to understand that this artifact is purely an archive that can be inspected,
-navigated and deconstructed. Having noted this, we've come up with the idea of **Package Slices** - minimal, complimentary and loosely coupled
-sets of files, based on the package's metadata and content. Slices are basically subsets of the Debian packages, with their own content
-and set of dependencies to other internal and external slices.
+One of the key value propositions of Rockcraft is the ability to build truly
+minimal container images while honoring the Ubuntu experience. Well, when having
+a closer look at a Debian package, it is easy to understand that this artifact
+is purely an archive that can be inspected, navigated and deconstructed. Having
+noted this, we've come up with the idea of **Package Slices** - minimal,
+complimentary and loosely coupled sets of files, based on the package's metadata
+and content. Slices are basically subsets of the Debian packages, with their own
+content and set of dependencies to other internal and external slices.
 
 .. image:: _static/package-slices.png
   :width: 95%
@@ -118,36 +140,53 @@ and set of dependencies to other internal and external slices.
   :align: center
   :alt: A slice of Ubuntu
 
-This image depicts a simple case, where both packages *A* and *B* are deconstructed into multiple slices. At a package level, *B* depends on *A*,
-but in reality, there might be files in *A* that *B* doesn't actually need (eg. *A_slice3* isn't needed for *B* to function properly). With this
-slice definition in place, Chisel is able to extract a highly-customized and specialized Slice of the Ubuntu distribution, which one could see
-as a block of stone from which we can carve and extract small and relevant parts we need to run our applications.
-It is ideal to support the creation of smaller but equally functional container images.
+This image depicts a simple case, where both packages *A* and *B* are
+deconstructed into multiple slices. At a package level, *B* depends on *A*,
+but in reality, there might be files in *A* that *B* doesn't actually need (eg.
+*A_slice3* isn't needed for *B* to function properly). With this slice
+definition in place, Chisel is able to extract a highly-customized and
+specialized Slice of the Ubuntu distribution, which one could see as a block of
+stone from which we can carve and extract small and relevant parts we need to
+run our applications. It is ideal to support the creation of smaller but equally
+functional container images.
 
-    *“The sculpture is already complete within the marble block, before I start my work. It is already there, I just have to chisel away the superfluous material.”*
+    *“The sculpture is already complete within the marble block, before I start
+    my work. It is already there, I just have to chisel away the superfluous
+    material.”*
       \- Michelangelo
 
-In the end, it's like having a slice of Ubuntu - get *just what you need*. You can *have your cake and eat it too*!
+In the end, it's like having a slice of Ubuntu - get *just what you need*. You
+can *have your cake and eat it too*!
 
 
 How to use Chisel?
 ..................
 
-Chisel has been integrated with Rockcraft in a way that it becomes seamless to users. Packages and slices can be both installed via the
-`stage-packages` field without any ambiguities because slices follow an underscore-driven naming convention.
-For instance, `openssl` means the whole OpenSSL package, while
-`openssl_bins` means just the binaries slice of the OpenSSL package. And that's it. Rockcraft will then take care of the installation and
-priming of your content into the ROCK. There's an example :ref:`here <chisel-example>`.
+Chisel has been integrated with Rockcraft in a way that it becomes seamless to
+users. Packages and slices can be both installed via the ``stage-packages``
+field without any ambiguities because slices follow an underscore-driven naming
+convention. For instance, ``openssl`` means the whole OpenSSL package, while
+``openssl_bins`` means just the binaries slice of the OpenSSL package. And
+that's it. Rockcraft will then take care of the installation and priming of your
+content into the ROCK. There's an example :ref:`here <chisel-example>`.
 
-Chisel isn't, however, specific to Rockcraft. It can be used on its own! It relies on a `database of slices <https://github.com/canonical/chisel-releases>`_
+Chisel isn't, however, specific to Rockcraft. It can be used on its own! It
+relies on a `database of slices <https://github.com/canonical/chisel-releases>`_
 that are indexed per Ubuntu release. So for example, the following command:
 
 .. code-block:: bash
 
   chisel cut --release ubuntu-22.04 --root myrootfs libgcc-s1_libs libssl3_libs
 
-would look into the Ubuntu Jammy archives, fetch the provided packages and install only the desired slices into the `myrootfs` folder.
+would look into the Ubuntu Jammy archives, fetch the provided packages and
+install only the desired slices into the ``myrootfs`` folder.
 
-To learn more about Chisel and how it works, have a look at `<https://github.com/canonical/chisel>`_.
+To learn more about Chisel and how it works, have a look at
+`<https://github.com/canonical/chisel>`_.
 
-Do you need a package slice that doesn't exist yet? Please feel free to propose your slice definition in `<https://github.com/canonical/chisel-releases>`_.
+Do you need a package slice that doesn't exist yet? Please feel free to propose
+your slice definition in `<https://github.com/canonical/chisel-releases>`_.
+
+.. _Unit 42 / Znet: https://www.zdnet.com/article/96-of-third-party-container-applications-deployed-in-cloud-infrastructure-contain-known-vulnerabilities-unit-42/
+.. _Snyk's state of open source security report 2020: https://snyk.io/blog/10-docker-image-security-best-practices/
+.. _this report: https://juju.is/cloud-native-kubernetes-usage-report-2021#selection-criteria-for-container-images

--- a/docs/how-to/build-docs.rst
+++ b/docs/how-to/build-docs.rst
@@ -17,7 +17,8 @@ Install the documentation requirements:
     :end-before: [docs:install-deps-end]
     :dedent: 2
 
-Once the requirements are installed, you can use the provided ``Makefile`` to build the documentation:
+Once the requirements are installed, you can use the provided ``Makefile`` to
+build the documentation:
 
 .. literalinclude:: code/build-docs/task.yaml
     :language: bash
@@ -25,7 +26,8 @@ Once the requirements are installed, you can use the provided ``Makefile`` to bu
     :end-before: [docs:make-docs-end]
     :dedent: 2
 
-Even better, serve it locally on port 8080. The documentation will be rebuilt on each file change, and will reload the browser view.
+Even better, serve it locally on port 8080. The documentation will be rebuilt
+on each file change, and will reload the browser view.
 
 .. literalinclude:: code/build-docs/task.yaml
     :language: bash
@@ -33,4 +35,5 @@ Even better, serve it locally on port 8080. The documentation will be rebuilt on
     :end-before: [docs:make-rundocs-end]
     :dedent: 2
 
-Note that ``make rundocs`` automatically activates the virtual environment, as long as it already exists.
+Note that ``make rundocs`` automatically activates the virtual environment,
+as long as it already exists.

--- a/docs/how-to/create-slice.rst
+++ b/docs/how-to/create-slice.rst
@@ -1,26 +1,33 @@
 How to create a package slice for Chisel
 ****************************************
 
-If your package doesn't yet have the slice definitions you actually need to **create your own slice definition** (which you can, later on, propose to be merged upstream for everyone else to use :ref:`publishslice` ).
+If your package doesn't yet have the slice definitions you actually need to
+**create your own slice definition** (which you can, later on, propose to be
+merged upstream for everyone else to use :ref:`publishslice` ).
 
-**Let's assume you are trying to create a slice definition for installing the OpenSSL binary into your ROCK!**
+**Let's assume you are trying to create a slice definition for installing the
+OpenSSL binary into your ROCK!**
 
 Make sure the slice definition doesn't exist yet
 ------------------------------------------------
 
-To avoid re-creating a slice, check the following to see if something that fits your needs already exists:
+To avoid re-creating a slice, check the following to see if something that fits
+your needs already exists:
 
-#. Look into the upstream `chisel-releases <https://github.com/canonical/chisel-releases/tree/ubuntu-22.04/slices>`_ repository
-#. Switch to the branch corresponding to the desired Ubuntu release for your ROCK
+#. Look into the upstream `chisel-releases`_ repository
+#. Switch to the branch corresponding to the desired Ubuntu release for your
+   ROCK
 #. Search your package name within the list of slice definitions files
 
-   * if you find it, open it and try to find a slice name containing the bits and pieces you need from that package
+   * if you find it, open it and try to find a slice name containing the bits
+     and pieces you need from that package
 
 
 Structure of a slice definitions file
 ------------------------------------
 
-There can be only **one slice definitions file** for each Ubuntu package. All of the slice definitions files follow the same structure:
+There can be only **one slice definitions file** for each Ubuntu package. All of
+the slice definitions files follow the same structure:
 
 .. code-block:: yaml
 
@@ -59,7 +66,8 @@ There can be only **one slice definitions file** for each Ubuntu package. All of
 Find the dependencies of your package
 -------------------------------------
 
-Find the dependencies of the package for which you want to create a new slice definition (``openssl`` in this guide) with this command:
+Find the dependencies of the package for which you want to create a new slice
+definition (``openssl`` in this guide) with this command:
 
 .. literalinclude:: code/create-slice/task.yaml
     :language: bash
@@ -81,21 +89,39 @@ The output will be similar to:
     Bugs: https://bugs.launchpad.net/ubuntu/+filebug
     Depends: libc6 (>= 2.34), libssl3 (>= 3.0.2-0ubuntu1.2)
 
-From the above output, you can confirm that ``openssl`` **depends on** ``libc6`` and ``libssl3``. So when creating your slice definitions file for OpenSSL, you will need to remember to include those packages' slices as a dependency as well, whenever needed. Let's do that in the following section.
+From the above output, you can confirm that ``openssl`` **depends on** ``libc6``
+and ``libssl3``. So when creating your slice definitions file for OpenSSL, you
+will need to remember to include those packages' slices as a dependency as well,
+whenever needed. Let's do that in the following section.
 
 Create your slice definition
 ----------------------------
 
-You now have everything needed to actually define the OpenSSL slice that will install the content you are looking to have in the final ROCK. Since you are looking to install just the OpenSSL binaries from the ``openssl`` package, what about naming this new slice **bins**? Let's go for it:
+You now have everything needed to actually define the OpenSSL slice that will
+install the content you are looking to have in the final ROCK. Since you are
+looking to install just the OpenSSL binaries from the ``openssl`` package, what
+about naming this new slice **bins**? Let's go for it:
 
-#. **What is the name of your slice definitions file?** It is a YAML file called ``openssl.yaml``
-#. **What package name should be defined inside this file?** The package name is ``openssl``
-#. **What is your slice name?** It should be called ``bins``
-#. **What contents do you need from the OpenSSL package?** Just the binaries - ``/usr/bin/c_rehash`` and ``/usr/bin/openssl``
-#. **Does your slice depend on any other package slice?** Yes, OpenSSL depends on ``libc6`` and ``libssl3``
+#. **What is the name of your slice definitions file?**
+   It is a YAML file called ``openssl.yaml``
+#. **What package name should be defined inside this file?**
+   The package name is ``openssl``
+#. **What is your slice name?**
+   It should be called ``bins``
+#. **What contents do you need from the OpenSSL package?**
+   Just the binaries - ``/usr/bin/c_rehash`` and ``/usr/bin/openssl``
+#. **Does your slice depend on any other package slice?** Yes, OpenSSL depends
+   on ``libc6`` and ``libssl3``
 
-   * **Do these two packages have slice definitions files upstream?** Yes, there is already a slice definitions file for `libc6 <https://github.com/canonical/chisel-releases/blob/ubuntu-22.04/slices/libc6.yaml>`_ and another one for `libssl3 <https://github.com/canonical/chisel-releases/blob/ubuntu-22.04/slices/libssl3.yaml>`_ . If these dependencies were not present in the upstream Chisel release, you would also need to create their corresponding slice definitions
-   * **Which slices do you depend on then?** Since you only want the OpenSSL binaries, you might only need the libraries from ``libc6`` and ``libssl3``, as well as the configuration files from ``libc6`` and ``openssl`` themselves.
+   * **Do these two packages have slice definitions files upstream?** Yes, there
+     is already a slice definitions file for `libc6`_ and another one for
+     `libssl3`_. If these dependencies were not present in the upstream Chisel
+     release, you would also need to create their corresponding slice
+     definitions
+   * **Which slices do you depend on then?** Since you only want the OpenSSL
+     binaries, you might only need the libraries from ``libc6`` and ``libssl3``,
+     as well as the configuration files from ``libc6`` and ``openssl``
+     themselves.
 
 
 Create a new YAML file named ``openssl.yaml``, with the following content:
@@ -103,6 +129,22 @@ Create a new YAML file named ``openssl.yaml``, with the following content:
 .. literalinclude:: code/create-slice/openssl.yaml
     :language: yaml
 
-Notice the unforeseen new slice ``config``. Because your OpenSSL binaries depend on the OpenSSL configuration files, and those were not yet present anywhere in the Chisel releases upstream, you also need to create that slice! You may also ask **"why not put those configuration files inside the ``bins`` slice"**? You could! But we recommend, as a best practice, to separate and group contents according to their nature, as you may tomorrow need to create a new slice definition that only needs the OpenSSL configurations and not the binaries.
+Notice the unforeseen new slice ``config``. Because your OpenSSL binaries depend
+on the OpenSSL configuration files, and those were not yet present anywhere in
+the Chisel releases upstream, you also need to create that slice! You may also
+ask **"why not put those configuration files inside the "bins" slice"**? You
+could! But we recommend, as a best practice, to separate and group contents
+according to their nature, as you may tomorrow need to create a new slice
+definition that only needs the OpenSSL configurations and not the binaries.
 
-And that's it. This is your brand new slice definitions file, which will allow Chisel to install **just** the OpenSSL binaries (and their dependencies) into your ROCK! To learn about how to actually use this new slice definition file and publish it upstream for others to use, please check the following guides.
+And that's it. This is your brand new slice definitions file, which will allow
+Chisel to install **just** the OpenSSL binaries (and their dependencies) into
+your ROCK! To learn about how to actually use this new slice definition file and
+publish it upstream for others to use, please check the following guides.
+
+.. _chisel-releases:
+  https://github.com/canonical/chisel-releases/tree/ubuntu-22.04/slices
+.. _libc6:
+  https://github.com/canonical/chisel-releases/blob/ubuntu-22.04/slices/libc6.yaml
+.. _libssl3:
+  https://github.com/canonical/chisel-releases/blob/ubuntu-22.04/slices/libssl3.yaml

--- a/docs/how-to/get-started.rst
+++ b/docs/how-to/get-started.rst
@@ -6,18 +6,21 @@ See the :ref:`tutorial` for a full getting started guide.
 Getting started
 ---------------
 
-Rockcraft is **the tool** for building Ubuntu-based and production-grade OCI images, aka ROCKs!
+Rockcraft is **the tool** for building Ubuntu-based and production-grade OCI
+images, aka ROCKs!
 
-Rockcraft is distributed as a snap. For packing new ROCKs, it makes use of "providers" to execute
-all the steps involved in the ROCK's build process. At the moment, the supported providers are LXD and Multipass.
+Rockcraft is distributed as a snap. For packing new ROCKs, it makes use of
+"providers" to execute all the steps involved in the ROCK's build process. At
+the moment, the supported providers are LXD and Multipass.
 
 Requirements
 ............
 
-Before installing the Rockcraft snap, make sure you have the necessary tools and environment to
-install and run Rockcraft.
+Before installing the Rockcraft snap, make sure you have the necessary tools and
+environment to install and run Rockcraft.
 
-First things first, if you are running Ubuntu, Snap is already installed and ready to go:
+First things first, if you are running Ubuntu, Snap is already installed and
+ready to go:
 
 .. literalinclude:: code/get-started/task.yaml
     :language: bash
@@ -37,9 +40,11 @@ You'll get something like:
     ubuntu  22.04
     kernel  5.17.0-1016-oem
 
-If this is not the case, then please check https://snapcraft.io/docs/installing-snap-on-ubuntu.
+If this is not the case, then please check
+https://snapcraft.io/docs/installing-snap-on-ubuntu.
 
-For what concerns providers, LXD is the default one for Rockcraft, so start by checking if it is available:
+For what concerns providers, LXD is the default one for Rockcraft, so start by
+checking if it is available:
 
 .. literalinclude:: code/get-started/task.yaml
     :language: bash
@@ -97,18 +102,21 @@ May you find any problems with LXD, please check https://ubuntu.com/lxd.
 Choose a Rockcraft release
 ..........................
 
-Pick a Rockcraft release, either from the `snap store <https://snapcraft.io/rockcraft>`_ or via
+Pick a Rockcraft release, either from the `snap store`_ or via
 ``snap search rockcraft``.
 
-Keep in mind the chosen channel, as riskier releases are more prone to breaking changes.
+Keep in mind the chosen channel, as riskier releases are more prone to breaking
+changes.
 
-Also, note that the Rockcraft's snap confinement is set to "classic" (this is important for the installation step).
+Also, note that the Rockcraft's snap confinement is set to "classic" (this is
+important for the installation step).
 
 
 Installation steps
 ..................
 
-Having chosen a Rockcraft release, you must now install it via the snap CLI (or directly via the Ubuntu Desktop store):
+Having chosen a Rockcraft release, you must now install it via the snap CLI (or
+directly via the Ubuntu Desktop store):
 
 .. code-block:: text
 
@@ -126,7 +134,8 @@ For example:
 Testing Rockcraft
 .................
 
-Once installed, you can make sure that Rockcraft is actually present in the system and ready to be used:
+Once installed, you can make sure that Rockcraft is actually present in the
+system and ready to be used:
 
 .. literalinclude:: code/get-started/task.yaml
     :language: bash
@@ -141,3 +150,4 @@ The output will be similar to:
 
     rockcraft 0.0.1.dev1
 
+.. _snap store: https://snapcraft.io/rockcraft

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -3,10 +3,12 @@
 How-to guides
 *************
 
-If you have a specific goal but are already familiar with Rockcraft, our How-to guides have more in-depth detail than our tutorials
-and can be applied to a broader set of applications.
+If you have a specific goal but are already familiar with Rockcraft, our How-to
+guides have more in-depth detail than our tutorials and can be applied to a
+broader set of applications.
 
-They'll help you achieve an end result but may require you to understand and adapt the steps to fit your specific requirements.
+They'll help you achieve an end result but may require you to understand and
+adapt the steps to fit your specific requirements.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/how-to/install-slice.rst
+++ b/docs/how-to/install-slice.rst
@@ -1,11 +1,15 @@
 How to install your own package slice
 *************************************
 
-When a specific package slice is not available on the `upstream Chisel releases <https://github.com/canonical/chisel-releases>`_, you will more likely end up creating your own slice definition.
+When a specific package slice is not available on the `upstream Chisel
+releases <https://github.com/canonical/chisel-releases>`_, you will more
+likely end up creating your own slice definition.
 
-Once you have it though, the most obvious question is: **how can I install this custom slice with Chisel?**
+Once you have it though, the most obvious question is: **how can I install
+this custom slice with Chisel?**
 
-Let's assume you want to install the OpenSSL binaries slice created in :ref:`here <create-slice>`...
+Let's assume you want to install the OpenSSL binaries slice created in
+:ref:`here <create-slice>`...
 
 **First**, clone the Chisel releases repository:
 
@@ -15,11 +19,19 @@ Let's assume you want to install the OpenSSL binaries slice created in :ref:`her
     :end-before: [docs:clone-chisel-releases-end]
     :dedent: 2
 
-This repository acts as the database of slice definitions files for each Chisel release (Chisel releases are named analogously to Ubuntu releases, and mapped into Git branches within the repository).
+This repository acts as the database of slice definitions files for each
+Chisel release (Chisel releases are named analogously to Ubuntu releases, and
+mapped into Git branches within the repository).
 
-Chisel will only recognize slices belonging to a Chisel release, so you need to copy your slice definitions file - ``openssl.yaml`` in this example - into the ``chisel-releases/slices`` folder. Note that if a slice definitions file with the same name already exists, it most likely means that the package you're slicing has already been sliced before, and in this case, you only need to merge your changes into that existing file.
+Chisel will only recognize slices belonging to a Chisel release, so you need
+to copy your slice definitions file - ``openssl.yaml`` in this example - into
+the ``chisel-releases/slices`` folder. Note that if a slice definitions file
+with the same name already exists, it most likely means that the package
+you're slicing has already been sliced before, and in this case, you only
+need to merge your changes into that existing file.
 
-At this point, you should be able to find your custom OpenSSL slice ``bins`` in the local Chisel release:
+At this point, you should be able to find your custom OpenSSL slice ``bins``
+in the local Chisel release:
 
 .. literalinclude:: code/install-slice/task.yaml
     :language: bash
@@ -35,9 +47,11 @@ If you wanted to test it with Chisel alone, you could now simply run
     :end-before: [docs:cut-end]
     :dedent: 2
 
-You should end up with a folder named "my-custom-openssl-fs" containing a few folders, amongst which there would be ``./usr/bin/openssl``.
+You should end up with a folder named "my-custom-openssl-fs" containing a few
+folders, amongst which there would be ``./usr/bin/openssl``.
 
-**To install the custom package slice into a ROCK though**, you need to use Rockcraft!
+**To install the custom package slice into a ROCK though**, you need to use
+Rockcraft!
 
 Start by initializing a new Rockcraft project:
 
@@ -47,15 +61,23 @@ Start by initializing a new Rockcraft project:
     :end-before: [docs:init-end]
     :dedent: 2
 
-After this command, you should find a new ``rockcraft.yaml`` file in your current path.
+After this command, you should find a new ``rockcraft.yaml`` file in your
+current path.
 
-Adjust the ``rockcraft.yaml`` file according to the following content (feel free to adjust the metadata, but pay special attention to the ``parts`` section):
+Adjust the ``rockcraft.yaml`` file according to the following content (feel
+free to adjust the metadata, but pay special attention to the ``parts``
+section):
 
 .. literalinclude:: code/install-slice/rockcraft.yaml
     :language: yaml
 
-The "build-context" part allows you to send the local ``chisel-releases`` folder into the builder. The "override-build" enables you to install your custom slice.
-Please not that this level of customization is only needed when you want to install from a custom Chisel release. If the desired slice definitions are already upstream, then you can simply use ``stage-packages``, as demonstrated in :ref:`here <chisel-example>`.
+The "build-context" part allows you to send the local ``chisel-releases``
+folder into the builder. The "override-build" enables you to install your
+custom slice.
+Please not that this level of customization is only needed when you want to
+install from a custom Chisel release. If the desired slice definitions are
+already upstream, then you can simply use ``stage-packages``, as demonstrated
+in :ref:`here <chisel-example>`.
 
 Build your ROCK with:
 
@@ -139,4 +161,5 @@ The output of the Docker command will be OpenSSL's default help message:
     <... many more lines of output>
 
 
-And that's it! You've now built your own ROCK from a custom Chisel release. Next step: share your slice definitions file with others!
+And that's it! You've now built your own ROCK from a custom Chisel release.
+Next step: share your slice definitions file with others!

--- a/docs/how-to/publish-slice.rst
+++ b/docs/how-to/publish-slice.rst
@@ -3,12 +3,17 @@
 How to make custom slice definitions available for everyone
 ***********************************************************
 
-At this stage, you have created some package slice definitions and you have a custom Chisel release in your local development environment.
-You have also tested this custom Chisel release, and it works! You believe there are others who could really use it as well, so **how can you make it accessible to everyone**?
+At this stage, you have created some package slice definitions and you have a
+custom Chisel release in your local development environment. You have also
+tested this custom Chisel release, and it works! You believe there are others
+who could really use it as well, so **how can you make it accessible to
+everyone**?
 
-It is as simple as proposing your changes into the upstream `Chisel releases repository <https://github.com/canonical/chisel-releases>`_:
+It is as simple as proposing your changes into the upstream
+`Chisel releases repository <https://github.com/canonical/chisel-releases>`_:
 
-1. Fork this repository https://github.com/canonical/chisel-releases and clone your fork:
+1. Fork this repository https://github.com/canonical/chisel-releases and clone
+   your fork:
 
 .. code-block:: bash
 
@@ -34,4 +39,6 @@ It is as simple as proposing your changes into the upstream `Chisel releases rep
 
 Create a pull request and wait for it to be merged.
 
-And that's it! Your custom Chisel release and new slice definitions are now available in Chisel, and anyone can use them. **Congrats**! And thank you for your contribution.
+And that's it! Your custom Chisel release and new slice definitions are now
+available in Chisel, and anyone can use them. **Congrats**! And thank you for
+your contribution.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,17 +14,31 @@ Welcome to Rockcraft's documentation!
 ===========================================
 
 
-**Rockcraft is a tool to create ROCKs** - a new generation of secure, stable and OCI-compliant container images, powered by Ubuntu.
+**Rockcraft is a tool to create ROCKs** - a new generation of secure, stable
+and OCI-compliant container images, powered by Ubuntu.
 
-**Using the same language as Snapcraft and Charmcraft,** Rockcraft (currently under heavy development) offers a true declarative way for building efficient container images. By making use of existing Ubuntu tools like LXD and Multipass,
-Rockcraft is able to compartmentalize your typical container image build into multiple parts, each one being comprised of several independent lifecycle steps (pull, build, stage and prime), allowing you to declaratively perform
-complex operations, at build time, without the need for massaging or stripping down the build environment from where your final container image originates.
+**Using the same language as Snapcraft and Charmcraft,** Rockcraft (currently
+under heavy development) offers a true declarative way for building efficient
+container images. By making use of existing Ubuntu tools like LXD and Multipass,
+Rockcraft is able to compartmentalize your typical container image build into
+multiple parts, each one being comprised of several independent lifecycle
+steps (pull, build, stage and prime), allowing you to declaratively perform
+complex operations, at build time, without the need for massaging or
+stripping down the build environment from where your final container image
+originates.
 
-**Off with the cumbersome and explicit scripting, on with the new declarative builds.** While preserving the familiar Ubuntu experience, Rockcraft eliminates the need for imperative builds, allowing everyone to declaratively define
-a container image that is built from Ubuntu, for Ubuntu users. Rockcraft implements source-to-image best-practice designs, handling all the repetitive and boilerplate steps of a build and directing your focus to what really
-matters - the image's content.
+**Off with the cumbersome and explicit scripting, on with the new declarative
+builds.** While preserving the familiar Ubuntu experience, Rockcraft
+eliminates the need for imperative builds, allowing everyone to declaratively
+define a container image that is built from Ubuntu, for Ubuntu users.
+Rockcraft implements source-to-image best-practice designs, handling all the
+repetitive and boilerplate steps of a build and directing your focus to what
+really matters - the image's content.
 
-**Rockcraft is for everyone wanting to build production-grade container images,** regardless of their experience as a software developer. From independent software vendors to cloud-native developers and occasional container users.
+**Rockcraft is for everyone wanting to build production-grade container
+images,** regardless of their experience as a software developer. From
+independent software vendors to cloud-native developers and occasional
+container users.
 
 
 .. toctree::
@@ -62,8 +76,11 @@ matters - the image's content.
 Project and community
 =====================
 
-Rockcraft is a member of the Canonical family. It's an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
+Rockcraft is a member of the Canonical family. It's an open source project
+that warmly welcomes community projects, contributions, suggestions, fixes
+and constructive feedback.
 
 * `Ubuntu Code of Conduct <https://ubuntu.com/community/code-of-conduct>`_.
-* `Canonical contributor license agreement <https://ubuntu.com/legal/contributors>`_.
+* `Canonical contributor licenses agreement
+  <https://ubuntu.com/legal/contributors>`_.
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -8,7 +8,8 @@ Reference
 A Rockcraft project is defined in a YAML file named ``rockcraft.yaml``
 at the root of the project tree in the filesystem.
 
-This `Reference`_ section is for when you need to know which options can be used, and how, in this ``rockcraft.yaml`` file.
+This `Reference`_ section is for when you need to know which options can be
+used, and how, in this ``rockcraft.yaml`` file.
 
 
 Format specification
@@ -113,18 +114,25 @@ Rockcraft parts
 .. rubric:: The main building blocks of a ROCK are *parts*.
 
 If this sentence sounds familiar, it's because **it is familiar**!
-Rockcraft parts are inherited from other existing Craft tools like `Snapcraft <https://github.com/snapcore/snapcraft>`_ and
+Rockcraft parts are inherited from other existing Craft tools like
+`Snapcraft <https://github.com/snapcore/snapcraft>`_ and
 `Charmcraft <https://github.com/canonical/charmcraft>`_.
 
-Rockcraft *parts* go through the same lifecycle steps as Charmcraft and `Snapcraft parts <https://snapcraft.io/docs/parts-lifecycle>`_.
+Rockcraft *parts* go through the same lifecycle steps as Charmcraft and
+`Snapcraft parts <https://snapcraft.io/docs/parts-lifecycle>`_.
 
-The way the *parts*' keys and values are used in the *rockcraft.yaml* is exactly the same
-as in `*snapcraft.yaml* <https://snapcraft.io/docs/snapcraft-parts-metadata>`_ (`here <https://snapcraft.io/docs/adding-parts>`_ is
-how you define a *part*).
+The way the *parts*' keys and values are used in the *rockcraft.yaml* is exactly
+the same as in *`snapcraft.yaml`_*
+(`here <https://snapcraft.io/docs/adding-parts>`_ is how you define a *part*).
 
-Albeit being fundamentally identical to Snapcraft parts, Rockcraft parts actually offer some extended functionality and keywords:
+Albeit being fundamentally identical to Snapcraft parts, Rockcraft parts
+actually offer some extended functionality and keywords:
 
-* **stage-packages**: apart from offering the well-known package installation behavior, in Rockcraft the `stage-packages` keyword actually supports chiseled packages as well (:ref:`learn more about Chisel <what-is-chisel>`). To install a package slice instead of the whole package, simply follow the Chisel convention *<packageName>_<sliceName>*.
+* **stage-packages**: apart from offering the well-known package installation
+  behavior, in Rockcraft the ``stage-packages`` keyword actually supports
+  chiseled packages as well (:ref:`learn more about Chisel <what-is-chisel>`).
+  To install a package slice instead of the whole package, simply follow the
+  Chisel convention *<packageName>_<sliceName>*.
 
 
 Example
@@ -147,18 +155,22 @@ Example
         - hello
 
 
-NOTE: at the moment, it is not possible to mix packages and slices in the same stage-packages field.
+NOTE: at the moment, it is not possible to mix packages and slices in the same
+stage-packages field.
 
 
 Rockcraft commands
 ------------------
 Lifecycle commands
 ..................
-Lifecycle commands can take an optional parameter ``<part-name>``. When a part name is provided, the command applies to the specific part. When no part name is provided, the command applies to all parts.
+Lifecycle commands can take an optional parameter ``<part-name>``. When a part
+name is provided, the command applies to the specific part. When no part name is
+provided, the command applies to all parts.
 
 clean
 ^^^^^
-Removes a part's assets. When no part is provided, the entire build environment (e.g. the LXD instance) is removed
+Removes a part's assets. When no part is provided, the entire build environment
+(e.g. the LXD instance) is removed.
 
 pull
 ^^^^
@@ -166,7 +178,8 @@ Downloads or retrieves artifacts defined for each part.
 
 overlay
 ^^^^^^^
-Execute operations defined for each part on a layer over the base filesystem, potentially modifying its contents.
+Execute operations defined for each part on a layer over the base filesystem,
+potentially modifying its contents.
 
 build
 ^^^^^
@@ -178,13 +191,15 @@ Stages built artifacts into a common staging area, for each part.
 
 prime
 ^^^^^
-Prepare, for each part, the final payload to be packed as a ROCK, performing additional processing and adding metadata files.
+Prepare, for each part, the final payload to be packed as a ROCK, performing
+additional processing and adding metadata files.
 
 pack
 ^^^^
 *This is the default lifecycle command for* ``rockcraft``.
 
-Process parts and create the ROCK as an OCI archive file containing the project payload with the provided metadata.
+Process parts and create the ROCK as an OCI archive file containing the project
+payload with the provided metadata.
 
 Other commands
 ..............
@@ -195,3 +210,5 @@ Initializes a rockcraft project with a boilerplate ``rockcraft.yaml`` file.
 help
 ^^^^
 Shows information about a command.
+
+.. _snapcraft.yaml: https://snapcraft.io/docs/snapcraft-parts-metadata

--- a/docs/tutorials/chisel.rst
+++ b/docs/tutorials/chisel.rst
@@ -1,8 +1,10 @@
 Install packages slices into a ROCK
 ===================================
 
-In this tutorial, you will create a lean ROCK that contains a fully functional OpenSSL installation, and you will verify
-that it is functional by loading the ROCK into Docker and using it to validate the certificates of the Ubuntu website.
+In this tutorial, you will create a lean ROCK that contains a fully functional
+OpenSSL installation, and you will verify that it is functional by loading the
+ROCK into Docker and using it to validate the certificates of the Ubuntu
+website.
 
 Prerequisites
 -------------
@@ -29,14 +31,16 @@ Install Rockcraft on your host:
 Project Setup
 -------------
 
-Create a new directory, write the following into a text editor and save it as ``rockcraft.yaml``:
+Create a new directory, write the following into a text editor and save it as
+``rockcraft.yaml``:
 
 .. literalinclude:: code/chisel/rockcraft.yaml
     :language: yaml
 
-Note that this Rockcraft file uses the ``openssl_bins`` and ``ca-certificates_data`` Chisel slices to generate an image
-containing only files that are strictly necessary for a functional OpenSSL installation. See :ref:`what-is-chisel` for
-details on the Chisel tool.
+Note that this Rockcraft file uses the ``openssl_bins`` and
+``ca-certificates_data`` Chisel slices to generate an image containing only
+files that are strictly necessary for a functional OpenSSL installation. See
+:ref:`what-is-chisel` for details on the Chisel tool.
 
 
 Pack the ROCK with Rockcraft
@@ -72,8 +76,9 @@ The output will look similar to:
     Labels and annotations set to ['org.opencontainers.image.version=0.0.1', 'org.opencontainers.image.title=chisel-openssl', 'org.opencontainers.image.ref.name=chisel-openssl', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2022-09-30T17:57:57.070040+00:00', 'org.opencontainers.image.base.digest=719e29cbdf81d2c046598c274ae82bdcdfe7bf819058a0f304c57858b633d801']
     Exported to OCI archive 'chisel-openssl_0.0.1_amd64.rock'
 
-The process might take a little while, but at the end, a new file named ``chisel-openssl_0.0.1_amd64.rock`` will be
-present in the current directory. That's your OpenSSL ROCK, in oci-archive format.
+The process might take a little while, but at the end, a new file named
+``chisel-openssl_0.0.1_amd64.rock`` will be present in the current directory.
+That's your OpenSSL ROCK, in oci-archive format.
 
 Run the ROCK in Docker
 ----------------------
@@ -115,7 +120,8 @@ The output will be OpenSSL's default help message, which starts like this:
     s_client          s_server          s_time            sess_id
     <... many more lines of output>
 
-As you can see, OpenSSL has many features. Use one of them to check that Ubuntu's website has valid SSL certificates:
+As you can see, OpenSSL has many features. Use one of them to check that
+Ubuntu's website has valid SSL certificates:
 
 .. literalinclude:: code/chisel/task.yaml
     :language: bash
@@ -137,5 +143,5 @@ The output will look similar to the following:
     Verification: OK
     Server Temp Key: X25519, 253 bits
 
-The ``Verification: OK`` line indicates that the OpenSSL installation inside your ROCK was able to validate Ubuntu
-Website's certificates successfully.
+The ``Verification: OK`` line indicates that the OpenSSL installation inside
+your ROCK was able to validate Ubuntu Website's certificates successfully.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -3,8 +3,9 @@
 Tutorials
 *********
 
-If you want to learn the basics from experience, then our tutorials will help you acquire
-the necessary competencies from real-life examples with fully reproducible steps.
+If you want to learn the basics from experience, then our tutorials will help
+you acquire the necessary competencies from real-life examples with fully
+reproducible steps.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Use the already-enabled sphinx-lint tool to enforce 80 characters max per line, to facilitate review. Also enable *all* sphinx-lint linters, which in this case just mean some minor fixes.

Unfortunately we can't use tools like rstfmt because our docs have deviated enough from "standard" rst (using sphinx-only directives) that the tools fail to parse the source. This is a "next best thing" in that sphinx-lint doesn't format the docs, but can at least check it.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

(CRAFT-1503)
