### PR TITLE
parts: fix conversion of PartsError

### DIFF
--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -17,10 +17,11 @@
 """Rockcraft error definitions."""
 
 from craft_cli import CraftError
+from craft_parts import PartsError
 
 
 class RockcraftError(CraftError):
-    """Failire in a Rockcraft operation."""
+    """Failure in a Rockcraft operation."""
 
 
 class RockcraftInitError(RockcraftError):
@@ -29,6 +30,13 @@ class RockcraftInitError(RockcraftError):
 
 class PartsLifecycleError(RockcraftError):
     """Error during parts processing."""
+
+    @staticmethod
+    def from_parts_error(err: PartsError) -> "PartsLifecycleError":
+        """Shortcut to create a PartsLifecycleError from a PartsError."""
+        return PartsLifecycleError(
+            message=err.brief, details=err.details, resolution=err.resolution
+        )
 
 
 class ProjectLoadError(RockcraftError):

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -74,7 +74,7 @@ class PartsLifecycle:
                 ignore_local_sources=["*.rock"],
             )
         except craft_parts.PartsError as err:
-            raise PartsLifecycleError(str(err)) from err
+            raise PartsLifecycleError.from_parts_error(err) from err
 
     def clean(self) -> None:
         """Remove lifecycle artifacts."""
@@ -133,6 +133,8 @@ class PartsLifecycle:
                 launch_shell()
 
             emit.progress("Executed parts lifecycle", permanent=True)
+        except craft_parts.PartsError as err:
+            raise PartsLifecycleError.from_parts_error(err) from err
         except RuntimeError as err:
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:

--- a/spread.yaml
+++ b/spread.yaml
@@ -88,13 +88,13 @@ restore-each: |
 
 debug-each: |
   # output latest rockcraft log file on test failure
-  rockcraft_log_file=$(find /root/.cache/rockcraft/log/ -name 'rockcraft*.log' | sort -n | tail -n1)
+  rockcraft_log_file=$(find /root/.local/state/rockcraft/log/ -name 'rockcraft*.log' | sort -n | tail -n1)
   if [[ -f $rockcraft_log_file ]]; then
     echo -e "rockcraft log file contents:\n----------------------------"
     cat "$rockcraft_log_file"
     echo "----------------------------"
   else
-    echo "could not find rockcraft log file"
+    echo "could not find rockcraft log file (this is not necessarily an error)"
   fi
 
 suites:


### PR DESCRIPTION
The previous code was using the PartsError string representation (via str(err)) to populate a PartsLifecycleError's message. This has the effect of adding the original error's `details` into the message, which bypasses craft_cli's error reporting based on verbosity levels.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

(CRAFT-1538)
