### PR TITLE
project: use pebble snap instead of building

### DIFF
--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -508,16 +508,8 @@ def _add_pebble_data(yaml_data: Dict[str, Any]) -> None:
 
     pebble_part_spec = {
         "plugin": "nil",
-        "source": "https://github.com/canonical/pebble.git",
-        "override-pull": (
-            "craftctl default\n"
-            "snap set system experimental.parallel-instances=true\n"
-            "snap install --unaliased go_pebble --channel 1.19/stable --classic\n"
-        ),
-        "override-build": (
-            "go_pebble mod download\n"
-            'CGO_ENABLED=0 go_pebble build -ldflags="-w -s" -o pebble ./cmd/pebble\n'
-            'install -D -m755 pebble "$CRAFT_PART_INSTALL"/usr/bin/pebble\n'
-        ),
+        "stage-snaps": ["pebble/latest/edge"],
+        "organize": {"bin/pebble": "usr/bin/pebble"},
+        "stage": ["usr/bin/pebble"],
     }
     parts["pebble"] = pebble_part_spec

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -509,7 +509,6 @@ def _add_pebble_data(yaml_data: Dict[str, Any]) -> None:
     pebble_part_spec = {
         "plugin": "nil",
         "stage-snaps": ["pebble/latest/edge"],
-        "organize": {"bin/pebble": "usr/bin/pebble"},
-        "stage": ["usr/bin/pebble"],
+        "stage": ["bin/pebble"],
     }
     parts["pebble"] = pebble_part_spec

--- a/spread.yaml
+++ b/spread.yaml
@@ -56,7 +56,7 @@ prepare: |
   retry -n 10 --wait 2 sh -c 'docker run --rm hello-world'
 
   tests.pkgs remove lxd
-  snap install lxd
+  snap install lxd --channel=5.9/stable
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -44,10 +44,10 @@ execute: |
   docker run --rm big bash -c 'stat -c "%a %U %G" /dir2/3.txt | grep -e "755 root root"'
 
   ############################################################################################
-  # check that /usr/bin/pebble is a static binary
+  # check that /bin/pebble is a static binary
   ############################################################################################
   docker run --name big-container big bash
-  docker cp big-container:/usr/bin/pebble - | tar xf -
+  docker cp big-container:/bin/pebble - | tar xf -
   file pebble | grep "statically linked"
   docker rm -f big-container
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -86,8 +86,7 @@ def pebble_part():
         "pebble": {
             "plugin": "nil",
             "stage-snaps": ["pebble/latest/edge"],
-            "organize": {"bin/pebble": "usr/bin/pebble"},
-            "stage": ["usr/bin/pebble"],
+            "stage": ["bin/pebble"],
         }
     }
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -85,17 +85,9 @@ def pebble_part():
     return {
         "pebble": {
             "plugin": "nil",
-            "source": "https://github.com/canonical/pebble.git",
-            "override-pull": (
-                "craftctl default\n"
-                "snap set system experimental.parallel-instances=true\n"
-                "snap install --unaliased go_pebble --channel 1.19/stable --classic\n"
-            ),
-            "override-build": (
-                "go_pebble mod download\n"
-                'CGO_ENABLED=0 go_pebble build -ldflags="-w -s" -o pebble ./cmd/pebble\n'
-                'install -D -m755 pebble "$CRAFT_PART_INSTALL"/usr/bin/pebble\n'
-            ),
+            "stage-snaps": ["pebble/latest/edge"],
+            "organize": {"bin/pebble": "usr/bin/pebble"},
+            "stage": ["usr/bin/pebble"],
         }
     }
 


### PR DESCRIPTION
Now that pebble has been published as a snap we can use it directly instead of building the binary each time. Prime only the binary and "organize" it as /usr/bin/pebble just like the previous part did.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

(CRAFT-1566)
