### PR TITLE
docs: add how-to guide for the rockcraft-pack GH action

### DIFF
--- a/docs/how-to/code/rockcraft-pack-action/rockcraft-pack.yaml
+++ b/docs/how-to/code/rockcraft-pack-action/rockcraft-pack.yaml
@@ -1,0 +1,3 @@
+steps:
+  - uses: actions/checkout@v3
+  - uses: canonical/craft-actions/rockcraft-pack@main

--- a/docs/how-to/code/rockcraft-pack-action/task.yaml
+++ b/docs/how-to/code/rockcraft-pack-action/task.yaml
@@ -12,4 +12,3 @@ prepare: |
 
 execute: |
   yamllint rockcraft-pack.yaml
-  

--- a/docs/how-to/code/rockcraft-pack-action/task.yaml
+++ b/docs/how-to/code/rockcraft-pack-action/task.yaml
@@ -1,0 +1,14 @@
+###########################################
+# IMPORTANT
+# Comments matter!
+# The docs use the wrapping comments as 
+# markers for including said instructions 
+# as snippets in the docs.
+###########################################
+summary: test the "Use the GitHub Action" guide
+
+prepare: |
+  tests.pkgs install yamllint
+
+execute: |
+  yamllint rockcraft-pack.yaml

--- a/docs/how-to/code/rockcraft-pack-action/task.yaml
+++ b/docs/how-to/code/rockcraft-pack-action/task.yaml
@@ -12,3 +12,4 @@ prepare: |
 
 execute: |
   yamllint rockcraft-pack.yaml
+  

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,6 +14,7 @@ adapt the steps to fit your specific requirements.
    :maxdepth: 1
 
    Get started - quick guide <get-started>
+   Use the GitHub Action <rockcraft-pack-action>
    Build the documentation <build-docs>
    Create a package slice for Chisel <create-slice>
    Install a custom package slice <install-slice>

--- a/docs/how-to/rockcraft-pack-action.rst
+++ b/docs/how-to/rockcraft-pack-action.rst
@@ -1,0 +1,23 @@
+How to build a ROCK with Rockcraft's GitHub Action
+**************************************************
+
+Within your GitHub repository, make sure you have
+`GitHub Actions enabled <https://docs.github.com/en/actions/quickstart>`_.
+
+Navigate to ``.github/workflows``, open the YAML file where you want the ROCK
+build to take place, and add the following steps:
+
+.. literalinclude:: code/rockcraft-pack-action/rockcraft-pack.yaml
+    :language: yaml
+
+Commit the changes and push. GitHub shall then trigger a new workflow
+execution and with it, Rockcraft will be set up and used to pack your ROCK,
+based on whatever ``rockcraft.yaml`` file there is at your project's root.
+
+To know how to publish this ROCK outside the GitHub build environment, and how
+to pass additional inputs parameters to this action, please refer to the
+`action's
+documentation <https://github.com/canonical/craft-actions#rockcraft-pack>`_.
+
+
+

--- a/docs/how-to/rockcraft-pack-action.rst
+++ b/docs/how-to/rockcraft-pack-action.rst
@@ -10,12 +10,12 @@ build to take place, and add the following steps:
 .. literalinclude:: code/rockcraft-pack-action/rockcraft-pack.yaml
     :language: yaml
 
-Commit and push the changes. This will trigger a new workflow run using 
-Rockcraft to pack your ROCK based on the ``rockcraft.yaml`` file at your 
+Commit and push the changes. This will trigger a new workflow run using
+Rockcraft to pack your ROCK based on the ``rockcraft.yaml`` file at your
 project's root.
 
-To know how to publish this ROCK outside the GitHub build environment, and how
-to pass additional inputs parameters to this action, please refer to the
+To learn how to publish this ROCK outside the GitHub build environment and how
+to pass additional input parameters to this action, please refer to the
 `action's
 documentation <https://github.com/canonical/craft-actions#rockcraft-pack>`_.
 

--- a/docs/how-to/rockcraft-pack-action.rst
+++ b/docs/how-to/rockcraft-pack-action.rst
@@ -10,9 +10,9 @@ build to take place, and add the following steps:
 .. literalinclude:: code/rockcraft-pack-action/rockcraft-pack.yaml
     :language: yaml
 
-Commit the changes and push. GitHub shall then trigger a new workflow
-execution and with it, Rockcraft will be set up and used to pack your ROCK,
-based on whatever ``rockcraft.yaml`` file there is at your project's root.
+Commit and push the changes. This will trigger a new workflow run using 
+Rockcraft to pack your ROCK based on the ``rockcraft.yaml`` file at your 
+project's root.
 
 To know how to publish this ROCK outside the GitHub build environment, and how
 to pass additional inputs parameters to this action, please refer to the


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

A new `rockcraft-pack`  GH action has been created at https://github.com/canonical/craft-actions#rockcraft-pack.

This PR adds a how-to guide to the Rockcraft docs, instructing how to add this action to a GitHub Actions workflow, and referring to the original action's docs for more info.