### PR TITLE
requirements: update craft-parts to 1.18.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ colorama==0.4.6
 commonmark==0.9.1
 coverage==6.5.0
 craft-cli==1.2.0
-craft-parts==1.17.1
+craft-parts==1.18.1
 craft-providers==1.6.2
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -5,7 +5,7 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
-craft-parts==1.17.1
+craft-parts==1.18.1
 craft-providers==1.6.2
 Deprecated==1.2.13
 docutils==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
-craft-parts==1.17.1
+craft-parts==1.18.1
 craft-providers==1.6.2
 Deprecated==1.2.13
 docutils==0.17.1


### PR DESCRIPTION
Craft-parts 1.18.1 fixes ignored file patterns when processing local sources.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
