### PR TITLE
Replace deprecated setuptools directive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ project_urls =
 author = Canonical Ltd.
 author_email = snapcraft@lists.snapcraft.io
 license = GNU Lesser General Public License v3 (LGPLv3)
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Developers


### PR DESCRIPTION
See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-license-file

Committed via https://github.com/asottile/all-repos