### PR TITLE
oci: use alternative registry

### DIFF
--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -36,6 +36,12 @@ from rockcraft import errors
 
 logger = logging.getLogger(__name__)
 
+# Public Amazon Elastic Container Registry has images that are updated more frequently
+# and with less severe pull-rate limits than Docker Hub.
+ECR_URL = "public.ecr.aws/ubuntu"
+
+REGISTRY_URL = ECR_URL
+
 
 @dataclass(frozen=True)
 class Image:
@@ -59,6 +65,8 @@ class Image:
     ) -> Tuple["Image", str]:
         """Obtain an image from a docker registry.
 
+        The image is fetched from the registry at ``REGISTRY_URL``.
+
         :param image_name: The image to retrieve, in ``name:tag`` format.
         :param image_dir: The directory to store local OCI images.
         :param arch: The architecture of the Docker image to fetch.
@@ -70,7 +78,7 @@ class Image:
         image_dir.mkdir(parents=True, exist_ok=True)
         image_target = image_dir / image_name
 
-        source_image = f"docker://{image_name}"
+        source_image = f"docker://{REGISTRY_URL}/{image_name}"
         platform_params = ["--override-arch", arch]
         if variant:
             platform_params += ["--override-variant", variant]

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -106,7 +106,7 @@ class TestImage:
         )
         assert Path("images/dir").is_dir()
         assert image.image_name == "a:b"
-        assert source_image == "docker://a:b"
+        assert source_image == f"docker://{oci.REGISTRY_URL}/a:b"
         assert image.path == Path("images/dir")
         assert mock_run.mock_calls == [
             call(
@@ -116,7 +116,7 @@ class TestImage:
                     "--override-arch",
                     "amd64",
                     "copy",
-                    "docker://a:b",
+                    f"docker://{oci.REGISTRY_URL}/a:b",
                     "oci:images/dir/a:b",
                 ]
             )
@@ -135,7 +135,7 @@ class TestImage:
                     "--override-variant",
                     "v8",
                     "copy",
-                    "docker://a:b",
+                    f"docker://{oci.REGISTRY_URL}/a:b",
                     "oci:images/dir/a:b",
                 ]
             )


### PR DESCRIPTION
Docker Hub is fast but the Ubuntu images are updated infrequently and
the registry itself has pull limits for anonymous users. This limit is
annoying because currently rockcraft does not caching of base images.
    
The caching is coming, but in the meantime switch to Amazon ECR. The
registry has newer images and is only a little bit slower (from testing)
than Docker Hub).

