### PR TITLE
requirements: update craft-providers to 1.7.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-cli==1.2.0
 craft-parts==1.18.1
-craft-providers==1.6.2
+craft-providers==1.7.2
 cryptography==38.0.4
 Deprecated==1.2.13
 dill==0.3.6

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
 craft-parts==1.18.1
-craft-providers==1.6.2
+craft-providers==1.7.2
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.12.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
 craft-parts==1.18.1
-craft-providers==1.6.2
+craft-providers==1.7.2
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.12.7


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Update to craft-providers v1.7.2, which includes performance improvements when launching LXD instances.

<details><summary>Changelog</summary>
<p>


1.7.2 (2023-02-06)
------------------
- Check LXD id map before starting an existing instance.
  If the id map does not match, the instance will be auto cleaned
  or an error will be raised.
- Add `lxc.config_get()` method to retrieve config values

1.7.1 (2023-01-23)
------------------
- Set LXD id maps after launching or copying an instance
- Raise BaseConfigurationError for snap refresh failures

1.7.0 (2023-01-11)
------------------
- LXD instances launch from a cached base instance rather than a base image.
  This reduces disk usage and launch time.
- For the LXD launch function `launched_environment`, the parameter `use_snapshots`
  has been replaced by `use_base_instance`. `use_snapshots` still works but logs
  a deprecation notice.
- Expire and recreate base instances older than 3 months (90 days)
- Add `lxc.copy()` method to copy instances
- Check for network connectivity after network-related commands fail
- Add documentation for network connectivity issues inside instances
- Enable testing for Ubuntu 22.04 images
- Update `MultipassInstance.push_file_io()` to work regardless of the
  host's working directory

</p>
</details>
