### PR TITLE
snap: add remove hook to delete rockcraft data from lxd

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,0 +1,53 @@
+#! /usr/bin/env sh
+
+# Remove hook for rockcraft.
+# This shell script removes all LXD images, instances, and projects created by rockcraft.
+# Errors in the remove hook can be viewed with `snap tasks --last=remove`
+
+# separate lxc output by newlines
+# \n can not be last, or it will be stripped by $() - see shellcheck SC3003
+IFS=$(printf '\n\t')
+
+>&2 echo "removing lxd data for rockcraft"
+
+# check for lxc
+if ! command -v lxc > /dev/null 2>&1; then
+  >&2 echo "lxc not installed"
+  exit 0
+fi
+
+# check for rockcraft project
+if ! lxc project info rockcraft > /dev/null 2>&1; then
+  >&2 echo "project 'rockcraft' does not exist"
+  exit 0
+fi
+
+# get instances by name
+instances="$(lxc list --project=rockcraft --format=csv --columns="n")"
+
+# delete instances
+if [ -n "$instances" ]; then
+  for instance in $instances; do
+    >&2 echo "deleting instance $instance"
+    lxc delete --project=rockcraft --force "$instance"
+  done
+else
+  >&2 echo "no instances to remove"
+fi
+
+# get images by fingerprint
+images="$(lxc image list --project=rockcraft --format=csv --columns="f")"
+
+# delete images
+if [ -n "$images" ]; then
+  for image in $images; do
+    >&2 echo "deleting image $instance"
+    lxc image delete --project=rockcraft "$image"
+  done
+else
+  >&2 echo "no images to remove"
+fi
+
+# delete the project itself
+>&2 echo "deleting project 'rockcraft'"
+lxc project delete rockcraft

--- a/spread.yaml
+++ b/spread.yaml
@@ -55,7 +55,14 @@ prepare: |
   # make sure docker is working
   retry -n 10 --wait 2 sh -c 'docker run --rm hello-world'
 
-  tests.pkgs remove lxd
+  # older linux releases have separate packages for lxd and lxc (lxd-client)
+  if [ "$SPREAD_SYSTEM" = "ubuntu-18.04-64" ] || \
+     [ "$SPREAD_SYSTEM" = "ubuntu-20.04-64" ] || \
+     [ "$SPREAD_SYSTEM" = "fedora-36-64" ]; then
+    tests.pkgs remove lxd lxd-client
+  else
+    tests.pkgs remove lxd
+  fi
   snap install lxd --channel=5.9/stable
 
   # Hold snap refreshes for 24h.
@@ -70,12 +77,7 @@ prepare: |
   lxd waitready --timeout=30
   lxd init --auto
 
-  if stat /rockcraft/tests/*.snap 2>/dev/null; then
-    snap install --classic --dangerous /rockcraft/tests/*.snap
-  else
-    echo "Expected a snap to exist in /rockcraft/"
-    exit 1
-  fi
+  install_rockcraft
 
 restore-each: |
   # Cleanup after each task.

--- a/tests/spread/general/remove-hook/task.yaml
+++ b/tests/spread/general/remove-hook/task.yaml
@@ -1,0 +1,48 @@
+summary: snap remove hook test
+
+execute: |
+  rockcraft init
+
+  # `rockcraft pull` is enough to create an instance, no need to execute the
+  # entire lifecycle
+  run_rockcraft pull
+
+  # verify the lxd project and an instance were created
+  if [[ -z "$(lxc list --project rockcraft --format=csv --columns=n)" ]]; then
+    echo "could not find lxd project or instances"
+    exit 1
+  fi
+
+  # remove rockcraft
+  snap remove rockcraft
+
+  # verify instances were deleted
+  if [[ -n "$(lxc list --project rockcraft --format=csv --columns=n)" ]]; then
+    echo "instances were not removed"
+
+    # show snap log
+    snap tasks --last=remove
+    exit 1
+  fi
+
+  # verify images were deleted
+  if lxc image list --project rockcraft &> /dev/null; then
+    echo "images were not removed"
+
+    # show snap log
+    snap tasks --last=remove
+    exit 1
+  fi
+
+  # verify project was removed
+  if lxc project show rockcraft &> /dev/null; then
+    echo "project was not removed"
+
+    # show snap log
+    snap tasks --last=remove
+    exit 1
+  fi
+
+restore: |
+  # reinstall rockcraft so subsequent tests on the same runner are unaffected
+  install_rockcraft

--- a/tools/spread/install_rockcraft
+++ b/tools/spread/install_rockcraft
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# install_rockcraft: helper to install rockcraft from a local snap file.
+
+if stat /rockcraft/tests/*.snap 2>/dev/null; then
+  snap install --classic --dangerous /rockcraft/tests/*.snap
+else
+  echo "Expected a snap to exist in /rockcraft/"
+  exit 1
+fi


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

When removing rockcraft, the snap remove hook will delete rockcraft's images, instances, and project from LXD.

Similar to https://github.com/snapcore/snapcraft/pull/4014, except the snapcraft hook is currently very conservative and only deletes base instances and images.  The rockcraft remove hook is more useful and deletes all LXD data created by rockcraft.

:heavy_check_mark: the remove hook is tested by `shellcheck`

(CRAFT-1345)