### PR TITLE
oci: fix handling of subdirs in usrmerge

### DIFF
--- a/tests/spread/general/big/rockcraft.yaml
+++ b/tests/spread/general/big/rockcraft.yaml
@@ -35,19 +35,6 @@ parts:
       - path: dir2/3.txt
         mode: "755"
 
-  usrmerge-part:
-    plugin: nil
-    override-build: |
-      # This build script adds a file in bin/ - the symlink in the base should be preserved.
-      mkdir ${CRAFT_PART_INSTALL}/bin
-      touch ${CRAFT_PART_INSTALL}/bin/new_bin_file
-    overlay-script: |
-      # explicitly remove a base layer symlink and create a dir instead
-      cd ${CRAFT_OVERLAY}
-      rm lib32
-      mkdir lib32
-      touch lib32/new_lib32_file
-
   rock-symlink-part:
     plugin: nil
     override-build: |

--- a/tests/spread/general/big/task.yaml
+++ b/tests/spread/general/big/task.yaml
@@ -50,19 +50,7 @@ execute: |
   docker cp big-container:/bin/pebble - | tar xf -
   file pebble | grep "statically linked"
   docker rm -f big-container
-
-  ############################################################################################
-  # check that the /bin symlink to /usr/bin *was not* broken by the /bin/new_bin_file addition
-  ############################################################################################
-  docker run --rm big readlink /bin | MATCH usr/bin
-  docker run --rm big ls /bin/bash /bin/new_bin_file
-
-  ############################################################################################
-  # check that the /lib32 symlink to /usr/lib32 *was* broken by the overlay-script
-  ############################################################################################
-  docker run --rm big readlink /lib32 | NOMATCH usr/lib32
-  docker run --rm big ls /lib32/new_lib32_file
-
+  
   ############################################################################################
   # This check documents the fact that we currently don't preserve/observe symlinks between
   # layers - we only take the base on which the ROCK was built into account. If the behavior

--- a/tests/spread/general/usrmerge/rockcraft.yaml
+++ b/tests/spread/general/usrmerge/rockcraft.yaml
@@ -1,0 +1,26 @@
+name: usrmerge
+version: latest
+summary: A ROCK that tests usrmerge handling.
+description: A ROCK that tests usrmerge handling
+license: Apache-2.0
+base: ubuntu:22.04
+platforms:
+  amd64:
+
+parts:
+  usrmerge-part:
+    plugin: nil
+    override-build: |
+      # This build script adds a file in bin/ - the symlink in the base should be preserved.
+      mkdir ${CRAFT_PART_INSTALL}/bin
+      touch ${CRAFT_PART_INSTALL}/bin/new_bin_file
+      # Also add subdirectories in bin/ to make sure they are correctly handled.
+      mkdir -p ${CRAFT_PART_INSTALL}/bin/subdir1/subdir2
+      touch ${CRAFT_PART_INSTALL}/bin/subdir1/subdir2/subdir_bin_file
+
+    overlay-script: |
+      # explicitly remove a base layer symlink and create a dir instead
+      cd ${CRAFT_OVERLAY}
+      rm lib32
+      mkdir lib32
+      touch lib32/new_lib32_file

--- a/tests/spread/general/usrmerge/task.yaml
+++ b/tests/spread/general/usrmerge/task.yaml
@@ -1,0 +1,27 @@
+summary: test usrmerge handling
+
+execute: |
+  run_rockcraft pack
+
+  ROCK=$(ls usrmerge*.rock)
+
+  test -f "$ROCK"
+
+  # copy image to docker
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:"$ROCK" docker-daemon:usrmerge:latest
+  rm "$ROCK"
+
+  docker images
+  
+  ############################################################################################
+  # check that the /bin symlink to /usr/bin *was not* broken by the /bin/new_bin_file addition
+  ############################################################################################
+  docker run --rm usrmerge readlink /bin | MATCH usr/bin
+  docker run  usrmerge:latest ls /bin/bash /bin/new_bin_file /bin/subdir1/subdir2/subdir_bin_file
+
+  ############################################################################################
+  # check that the /lib32 symlink to /usr/lib32 *was* broken by the overlay-script
+  ############################################################################################
+  docker run --rm usrmerge readlink /lib32 | NOMATCH usr/lib32
+  docker run --rm usrmerge ls /lib32/new_lib32_file


### PR DESCRIPTION
The scenario that was broken was: a payload like "bin/dir1/dir2" where "bin" is a symlink to somewhere on the lower (base) layer. The subdirs "dir1" and "dir2" were being incorrectly placed in "bin" instead of in the symlink target.

This broke quite a few plugins that place file trees in places like "lib/".

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

CRAFT-1605
