### PR TITLE
tests: bump lxd to 5.11 in spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -63,7 +63,8 @@ prepare: |
   else
     tests.pkgs remove lxd
   fi
-  snap install lxd --channel=5.9/stable
+  snap install lxd --channel=latest/stable
+  snap refresh lxd --channel=5.9/stable
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The spread tests are failing to install lxd 5.9.

The snap channel for lxd 5.9 is now unlisted and can't be directly installed.  I filed a bug report https://bugs.launchpad.net/snapstore-server/+bug/2008114


#### Option 1
Follow latest.  
```bash
snap install lxd --channel=latest/stable
```
:x: fails

#### Option 2
Pin to another release.
```bash
snap install lxd --channel=5.10/stable  # or 5.11/candidate
```

:x: [Error from 5.10/stable](https://github.com/canonical/rockcraft/actions/runs/4245088818/jobs/7380328437).
:x: [Error from 5.11/candidate](https://github.com/canonical/rockcraft/actions/runs/4245574447/jobs/7381414281).


#### Option 3
Workaround to stay on 5.9
```bash
snap install lxd --channel=latest/stable
snap refresh lxd --channel=5.9/stable
```
:heavy_check_mark: succeeds
