### PR TITLE
oci: handle duplicate directories because of usrmerge 

### DIFF
--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -45,3 +45,7 @@ class ProjectLoadError(RockcraftError):
 
 class ProjectValidationError(RockcraftError):
     """Error validating rockcraft.yaml."""
+
+
+class LayerArchivingError(RockcraftError):
+    """Error when creating the archive for the new layer."""

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -26,7 +26,7 @@ import tarfile
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 from craft_cli import emit
@@ -352,7 +352,6 @@ def _add_layer_into_image(
     _process_run(cmd + ["--history.created_by", " ".join(cmd)])
 
 
-# pylint: disable-next=too-many-locals
 def _archive_layer(
     new_layer_dir: Path, temp_tar_file: Path, base_layer_dir: Optional[Path] = None
 ) -> None:
@@ -363,6 +362,24 @@ def _archive_layer(
     :param base_layer_dir: optional path to the filesystem containing the extracted
         base below this new layer. Used to preserve lower-level directory symlinks,
         like the ones from Debian/Ubuntu's usrmerge.
+    """
+    layer_filenames = _get_layer_filenames(new_layer_dir, base_layer_dir)
+    with tarfile.open(temp_tar_file, mode="w") as tar_file:
+        for arcname, filepath in layer_filenames.items():
+            emit.debug(f"Adding to layer: {filepath} as '{arcname}'")
+            tar_file.add(filepath, arcname=arcname, recursive=False)
+
+
+def _get_layer_filenames(
+    new_layer_dir: Path, base_layer_dir: Optional[Path] = None
+) -> Dict[str, Path]:
+    """Map paths in ``new_layer_dir`` to names in a layer file.
+
+    See ``_archive_layer()`` for the parameters.
+
+    :return:
+      A dict where the value is a path (file or dir) in ``new_layer_dir`` and the
+      key is the name that this path should have in the tarball for the layer.
     """
 
     class LayerLinker:
@@ -397,61 +414,51 @@ def _archive_layer(
                 return Path(str_path.replace(self.upper_prefix, self.lower_prefix, 1))
             return path
 
-    with tarfile.open(temp_tar_file, mode="w") as tar_file:
-        layer_linker = LayerLinker()
-        for dirpath, subdirs, filenames in os.walk(new_layer_dir):
-            # Sort `subdirs` in-place, to ensure that `os.walk()` iterates on
-            # them in sorted order.
-            subdirs.sort()
+    layer_linker = LayerLinker()
+    result: Dict[str, Path] = {}
+    for dirpath, subdirs, filenames in os.walk(new_layer_dir):
+        # Sort `subdirs` in-place, to ensure that `os.walk()` iterates on
+        # them in sorted order.
+        subdirs.sort()
 
-            upper_subpath = Path(dirpath)
+        upper_subpath = Path(dirpath)
 
-            # The path with `new_layer_dir` as the "root"
-            relative_path = upper_subpath.relative_to(new_layer_dir)
+        # The path with `new_layer_dir` as the "root"
+        relative_path = upper_subpath.relative_to(new_layer_dir)
 
-            # The name of the subdir that will contain the files added in this
-            # iteration of the loop in the archive. Will be changed if
-            # `relative_path` corresponds to a symlink in the base layer.
-            archive_subdir = relative_path
+        # Handle adding an entry for the directory. We skip this IF:
+        # - The directory is the root (to skip a spurious "." entry), OR
+        # - The directory is NOT an opaque OCI entry AND
+        # - The directory's exists on ``base_layer_dir`` as a symlink to another
+        #   directory (like in usrmerge).
+        if upper_subpath != new_layer_dir:
+            upper_is_not_opaque_dir = not overlays.is_oci_opaque_dir(upper_subpath)
+            lower_symlink_target = _symlink_target_in_base_layer(
+                relative_path, base_layer_dir
+            )
+            lower_is_symlink = lower_symlink_target is not None
 
-            # Handle adding an entry for the directory. We skip this IF:
-            # - The directory is the root (to skip a spurious "." entry), OR
-            # - The directory is NOT an opaque OCI entry AND
-            # - The directory's exists on ``base_layer_dir`` as a symlink to another
-            #   directory (like in usrmerge).
-            if upper_subpath != new_layer_dir:
-                upper_is_not_opaque_dir = not overlays.is_oci_opaque_dir(upper_subpath)
-                lower_symlink_target = _symlink_target_in_base_layer(
-                    relative_path, base_layer_dir
+            if upper_is_not_opaque_dir and lower_is_symlink:
+                emit.debug(
+                    f"Skipping {upper_subpath} because it exists as a symlink on the lower layer"
                 )
-                lower_is_symlink = lower_symlink_target is not None
+                layer_linker.reset(str(relative_path), str(lower_symlink_target))
+            else:
+                lower_path = layer_linker.get_target_path(relative_path)
+                result[f"{lower_path}"] = upper_subpath
 
-                if upper_is_not_opaque_dir and lower_is_symlink:
-                    emit.debug(
-                        f"Skipping {upper_subpath} because it exists as a symlink on the lower layer"
-                    )
-                    archive_subdir = cast(Path, lower_symlink_target)
-                    layer_linker.reset(str(relative_path), str(archive_subdir))
+        # Add each file in the directory.
+        for name in filenames:
+            archive_path = layer_linker.get_target_path(relative_path / name)
+            result[f"{archive_path}"] = upper_subpath / name
 
-                else:
-                    lower_path = layer_linker.get_target_path(relative_path)
-                    emit.debug(f"Adding to layer: {upper_subpath} as '{lower_path}'")
-                    tar_file.add(
-                        upper_subpath, arcname=f"{lower_path}", recursive=False
-                    )
-
-            # Handle adding each file in the directory.
-            for name in filenames:
-                actual_path = upper_subpath / name
-                archive_path = layer_linker.get_target_path(archive_subdir / name)
-                emit.debug(f"Adding to layer: {actual_path} as '{archive_path}'")
-                tar_file.add(actual_path, arcname=f"{archive_path}")
+    return result
 
 
 def _symlink_target_in_base_layer(
     relative_path: Path, base_layer_dir: Optional[Path]
 ) -> Optional[Path]:
-    """If `relative_path` is a dir symlink in `base_layer_dir, return its 'target'.
+    """If `relative_path` is a dir symlink in `base_layer_dir`, return its 'target'.
 
     This function checks if `relative_path` exists in the base `base_layer_dir` as
     a symbolic link to another directory; if it does, the function will return the

--- a/tests/integration/test_oci.py
+++ b/tests/integration/test_oci.py
@@ -101,7 +101,7 @@ def test_add_layer_with_symlink_in_base(new_dir):
 
             (actual_dir / f"old_{target}_file").write_text(f"old {target} file")
 
-            os.symlink(f"usr/{target}", base_layer_dir / target)
+            (base_layer_dir / target).symlink_to(f"usr/{target}")
             assert os.listdir(base_layer_dir / target) == [f"old_{target}_file"]
 
     image, base_layer_dir = create_base_image(Path(new_dir), populate_base_layer)
@@ -135,7 +135,7 @@ def test_add_layer_with_overlay(new_dir, mocker):
 
     def populate_base_layer(base_layer_dir):
         (base_layer_dir / "usr/bin").mkdir(parents=True)
-        os.symlink("usr/bin", (base_layer_dir / "bin"))
+        (base_layer_dir / "bin").symlink_to("usr/bin")
 
     image, base_layer_dir = create_base_image(Path(new_dir), populate_base_layer)
 

--- a/tests/spread/general/usrmerge/rockcraft.yaml
+++ b/tests/spread/general/usrmerge/rockcraft.yaml
@@ -14,9 +14,15 @@ parts:
       # This build script adds a file in bin/ - the symlink in the base should be preserved.
       mkdir ${CRAFT_PART_INSTALL}/bin
       touch ${CRAFT_PART_INSTALL}/bin/new_bin_file
+      
       # Also add subdirectories in bin/ to make sure they are correctly handled.
       mkdir -p ${CRAFT_PART_INSTALL}/bin/subdir1/subdir2
       touch ${CRAFT_PART_INSTALL}/bin/subdir1/subdir2/subdir_bin_file
+      
+      # Also add the same subdirectory structure in usr/bin/ to make sure they are not
+      # duplicated in the layer file
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin/subdir1/subdir2
+      touch ${CRAFT_PART_INSTALL}/usr/bin/subdir1/subdir2/another_subdir_bin_file
 
     overlay-script: |
       # explicitly remove a base layer symlink and create a dir instead

--- a/tests/spread/general/usrmerge/task.yaml
+++ b/tests/spread/general/usrmerge/task.yaml
@@ -18,7 +18,12 @@ execute: |
   # check that the /bin symlink to /usr/bin *was not* broken by the /bin/new_bin_file addition
   ############################################################################################
   docker run --rm usrmerge readlink /bin | MATCH usr/bin
-  docker run  usrmerge:latest ls /bin/bash /bin/new_bin_file /bin/subdir1/subdir2/subdir_bin_file
+  docker run --rm usrmerge ls /bin/bash /bin/new_bin_file /bin/subdir1/subdir2/subdir_bin_file
+  
+  ############################################################################################
+  # check that the contents of bin/ and usr/bin *both* ended up in /usr/bin
+  ############################################################################################
+  docker run --rm usrmerge ls /usr/bin/subdir1/subdir2/{subdir_bin_file,another_subdir_bin_file}
 
   ############################################################################################
   # check that the /lib32 symlink to /usr/lib32 *was* broken by the overlay-script

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -231,7 +231,7 @@ class TestImage:
         # times (due to the recursion), but we're mainly interested that the first
         # call was to add `layer_dir`.
         assert spy_add.mock_calls[0] == call(
-            ANY, Path("layer_dir/foo.txt"), arcname="foo.txt"
+            ANY, Path("layer_dir/foo.txt"), arcname="foo.txt", recursive=False
         )
 
         expected_cmd = [


### PR DESCRIPTION
Reviewing note: the first commit restructures the code a bit without functional changes; the second commit has the actual bugfix.

=================
The situation is this: the primed payload has two distinct directories
(e.g. bin/dir1 and usr/bin/dir1) that, because of the usrmerge handling,
"point" to the same location (in this case, /usr/bin/dir1). We check
that the two directories have the same attributes (ownership and mode)
and then add a single entry to the layer (either one, they are all
equivalent).

All other cases (dirs with different attributes, conflicts between
files) raise errors. The reason for this is that we haven't seen this
come up "in the wild" yet, and it's hard to choose a behavior when we
don't know the circunstances.

(CRAFT-1634)
