### PR TITLE
requirements: update craft-providers to 1.8.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-cli==1.2.0
 craft-parts==1.18.1
-craft-providers==1.7.2
+craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13
 dill==0.3.6

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
 craft-parts==1.18.1
-craft-providers==1.7.2
+craft-providers==1.8.0
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.12.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
 craft-parts==1.18.1
-craft-providers==1.7.2
+craft-providers==1.8.0
 Deprecated==1.2.13
 docutils==0.17.1
 furo==2022.12.7


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Update craft-providers to 1.8.0. 

The main value-add for rockcraft users is the auto-cleaning of instances that are interrupted during setup.


### Changelog

#### 1.8.0 (2023-03-01)
------------------
- **Track if instances are properly setup when launching. If the instance did not fully
  complete setup and auto-clean is enabled, the instance will be cleaned and recreated.**
- Add new field `setup` to instance configuration to track set up status
- Update base compatibility tag from `base-v0` to `base-v1`
- Add new BuilddBaseAliases for Lunar and Kinetic
- Add support for interim Ubuntu releases for LXD
- Add support for custom LXD image remotes. LXD remotes can now add any
  remote server to retrieve images from using the `RemoteImage` class.
- Add deprecation warning for LXD function `configure_buildd_image_remote()`.
  Usage of this function should be replaced with RemoteImage's `add_remote()`.
- Rename BuilddBase function `setup_instance_config()` to `update_compatibility_tag()`
- Update brew for macos CI tests
- Update readthedocs link in readme
- **Capture subproccess error details when snap removal fails** (originally raised by @bencekov for rockcraft)
- Add default for `_run_lxc()` parameter `check=True`
- Refactor lxd unit and integration tests
- Enable more pylint checks
- Use new `use_base_instance` parameter when launching LXD instances from LXDProvider