### PR TITLE
ci: remove ubuntu-18.04 runner from github workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,11 +59,8 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-latest, ubuntu-20.04, ubuntu-22.04, windows-2019]
         python-version: [3.8, 3.9, "3.10"]
-        exclude:
-          - os: ubuntu-18.04
-            python-version: "3.10"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -83,12 +80,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
-      - name: Install Ubuntu 18.04-specific dependencies
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: |
-          # pip 20.2 breaks python3-apt, so pin the version before building
-          pip install -U pip==20.1
-          pip install -U -r requirements-bionic.txt
       - name: Install Ubuntu 20.04-specific dependencies
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

The ubuntu-18.04 runner will be [fully unsupported](https://github.com/actions/runner-images/issues/6002) on 2023-Apr-01.

Today it is offline and breaking the workflow.

Note that it will be unsupported, not unavailable.  It will still be available for about 3 more months (2023-Jul).