### PR TITLE
requirements: update craft-parts to 1.18.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ colorama==0.4.6
 commonmark==0.9.1
 coverage==6.5.0
 craft-cli==1.2.0
-craft-parts==1.18.1
+craft-parts==1.18.4
 craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
-craft-parts==1.18.1
+craft-parts==1.18.4
 craft-providers==1.8.0
 Deprecated==1.2.13
 docutils==0.17.1

--- a/spread.yaml
+++ b/spread.yaml
@@ -64,7 +64,6 @@ prepare: |
     tests.pkgs remove lxd
   fi
   snap install lxd --channel=latest/stable
-  snap refresh lxd --channel=5.9/stable
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"


### PR DESCRIPTION
Craft-parts 1.18.4 makes the /dev rbind mount private, fixing chroot and overlayfs mounts when using lxd 5.11.

Fixes #195.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
