### PR TITLE
test: add tox environments for snapping and running spread tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,3 +25,22 @@ commands = make test-units
 
 [pycodestyle]
 ignore = E501
+
+[testenv:build-snap]
+base =
+skip_install = true
+labels = test, test-spread
+allowlist_externals = snapcraft
+commands = snapcraft --use-lxd
+
+[testenv:test-spread]
+base =
+depends = build-snap
+skip_install = true
+labels = test, test-spread
+allowlist_externals = cp, git, spread
+commands_pre =
+    cp rockcraft_*.snap tests/rockcraft_spread.snap
+    git submodule init
+    git submodule update
+commands = spread {posargs:tests/spread/}

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,9 @@ base =
 depends = build-snap
 skip_install = true
 labels = test, test-spread
-allowlist_externals = cp, git, spread
+allowlist_externals = git, spread
 commands_pre =
-    cp rockcraft_*.snap tests/rockcraft_spread.snap
+    python -c "import os, pathlib, shutil;shutil.copy(sorted(pathlib.Path().glob('rockcraft_*.snap'), key=os.path.getmtime, reverse=True)[0], 'tests/rockcraft_spread.snap')"
     git submodule init
     git submodule update
 commands = spread {posargs:tests/spread/}


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This was convenience thing for me, as now I can run `tox run -m test-spread` to build the snap and run the spread tests. 

@tigarmo lmk what you think. If you like this I think I want to incorporate it into starbase too