### PR TITLE
requirements: update craft-parts to 1.19.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ colorama==0.4.6
 commonmark==0.9.1
 coverage==6.5.0
 craft-cli==1.2.0
-craft-parts==1.18.4
+craft-parts==1.19.0
 craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -5,7 +5,7 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
-craft-parts==1.18.1
+craft-parts==1.19.0
 craft-providers==1.8.0
 Deprecated==1.2.13
 docutils==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-cli==1.2.0
-craft-parts==1.18.4
+craft-parts==1.19.0
 craft-providers==1.8.0
 Deprecated==1.2.13
 docutils==0.17.1

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -36,6 +36,9 @@ _LIFECYCLE_STEPS = {
 }
 
 
+craft_parts.Features(enable_overlay=True)
+
+
 class PartsLifecycle:
     """Create and manage the parts lifecycle.
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -21,8 +21,8 @@ from craft_parts.utils import os_utils
 def is_ubuntu_jammy() -> bool:
     release = os_utils.OsRelease()
     try:
-        return release.version_codename() == "jammy"
-    except errors.OsReleaseCodenameError:
+        return release.id() == "ubuntu" and release.version_id() == "22.04"
+    except errors.OsReleaseIdError:
         return False
 
 


### PR DESCRIPTION
Craft-parts 1.19.0 requires overlays to be enabled. Also update OS verifcation in tests now that Ubuntu-specific codenames were removed from Craft Parts' OSRelease.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
