### PR TITLE
spread: don't remove the base instance in cleanup

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -84,7 +84,10 @@ restore-each: |
   docker system prune -a -f
   if lxc project info rockcraft > /dev/null 2>&1 ; then
     for instance in $(lxc --project=rockcraft list -c n --format csv); do
-      lxc --project=rockcraft delete --force "$instance"
+      # Don't remove the base instance, we want to re-use it between tests
+      if ! [[ $instance =~ ^base-instance-rockcraft* ]]; then
+        lxc --project=rockcraft delete --force "$instance"
+      fi
     done
   fi  
 

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -116,6 +116,8 @@ class TestImage:
                     "--override-arch",
                     "amd64",
                     "copy",
+                    "--retry-times",
+                    str(oci.MAX_DOWNLOAD_RETRIES),
                     f"docker://{oci.REGISTRY_URL}/a:b",
                     "oci:images/dir/a:b",
                 ]
@@ -135,6 +137,8 @@ class TestImage:
                     "--override-variant",
                     "v8",
                     "copy",
+                    "--retry-times",
+                    str(oci.MAX_DOWNLOAD_RETRIES),
                     f"docker://{oci.REGISTRY_URL}/a:b",
                     "oci:images/dir/a:b",
                 ]


### PR DESCRIPTION
The original `restore-each` removes all instances, including the base one! With this fix we should be able to reuse the base instance between compatible tests. 