### PR TITLE
cli, parts: support --debug

### DIFF
--- a/rockcraft/commands/lifecycle.py
+++ b/rockcraft/commands/lifecycle.py
@@ -41,6 +41,14 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
         emit.trace(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
         lifecycle.run(self.name, parsed_args)
 
+    def fill_parser(self, parser: "argparse.ArgumentParser") -> None:
+        super().fill_parser(parser)  # type: ignore
+        parser.add_argument(
+            "--debug",
+            action="store_true",
+            help="Shell into the environment if the build fails",
+        )
+
 
 class _LifecycleStepCommand(_LifecycleCommand):
     """Lifecycle step commands."""

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -119,6 +119,7 @@ def run(command_name: str, parsed_args: "argparse.Namespace") -> None:
             step_name,
             shell=getattr(parsed_args, "shell", False),
             shell_after=getattr(parsed_args, "shell_after", False),
+            debug=getattr(parsed_args, "debug", False),
         )
 
         if command_name == "pack":
@@ -216,6 +217,8 @@ def run_in_provider(
         cmd.append("--shell")
     if getattr(parsed_args, "shell_after", False):
         cmd.append("--shell-after")
+    if getattr(parsed_args, "debug", False):
+        cmd.append("--debug")
 
     host_project_path = Path().absolute()
     instance_project_path = utils.get_managed_environment_project_path()

--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -100,17 +100,24 @@ class PartsLifecycle:
         return self._lcm.project_info.prime_dir
 
     def run(
-        self, step_name: str, *, shell: bool = False, shell_after: bool = False
+        self,
+        step_name: str,
+        *,
+        shell: bool = False,
+        shell_after: bool = False,
+        debug: bool = False,
     ) -> None:
         """Run the parts lifecycle.
 
         :param step_name: The final step to execute.
         :param shell: Execute a shell instead of the target step.
         :param shell_after: Execute a shell after the target step.
+        :param debug: Execute a shell on failure.
 
         :raises PartsLifecycleError: On error during lifecycle.
         :raises RuntimeError: On unexpected error.
         """
+        # pylint: disable=too-many-branches,too-many-statements
         target_step = _LIFECYCLE_STEPS.get(step_name)
         if not target_step:
             raise RuntimeError(f"Invalid target step {step_name!r}")
@@ -146,15 +153,27 @@ class PartsLifecycle:
 
             emit.progress("Executed parts lifecycle", permanent=True)
         except craft_parts.PartsError as err:
+            if debug:
+                emit.progress(str(err), permanent=True)
+                launch_shell()
             raise PartsLifecycleError.from_parts_error(err) from err
         except RuntimeError as err:
+            if debug:
+                emit.progress(str(err), permanent=True)
+                launch_shell()
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:
             msg = err.strerror
             if err.filename:
                 msg = f"{err.filename}: {msg}"
+            if debug:
+                emit.progress(msg, permanent=True)
+                launch_shell()
             raise PartsLifecycleError(msg) from err
         except Exception as err:
+            if debug:
+                emit.progress(str(err), permanent=True)
+                launch_shell()
             raise PartsLifecycleError(str(err)) from err
 
     def _install_package_repositories(self) -> None:

--- a/spread.yaml
+++ b/spread.yaml
@@ -21,16 +21,16 @@ backends:
     halt-timeout: 2h
     systems:
       - ubuntu-18.04-64:
-          workers: 1
+          workers: 2
           storage: 40G
       - ubuntu-20.04-64:
-          workers: 1
+          workers: 2
           storage: 40G
       - ubuntu-22.04-64:
-          workers: 1
+          workers: 2
           storage: 40G
       - fedora-36-64:
-          workers: 1
+          workers: 2
           storage: 40G
 
 prepare: |

--- a/tests/spread/general/configure-hook/task.yaml
+++ b/tests/spread/general/configure-hook/task.yaml
@@ -1,5 +1,8 @@
 summary: snap configure hook test
 
+# Run this test last, as it removes the base instances that other tests can use
+priority: -100
+
 execute: |
   # `rockcraft pull` will create the rockcraft project, buildd remote, and an instance
   rockcraft init

--- a/tests/spread/general/remove-hook/task.yaml
+++ b/tests/spread/general/remove-hook/task.yaml
@@ -1,5 +1,8 @@
 summary: snap remove hook test
 
+# Run this test last, as it removes the base instances that other tests can use
+priority: -100
+
 execute: |
   rockcraft init
 

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -286,6 +286,36 @@ def test_lifecycle_run_in_provider(
     mock_capture_logs_from_instance.assert_called_once_with(mock_instance)
 
 
+def test_lifecycle_run_in_provider_debug(
+    mock_get_instance_name,
+    mock_instance,
+    mock_provider,
+    mock_project,
+    mocker,
+):
+    # mock provider calls
+    mock_base_configuration = Mock()
+    mocker.patch(
+        "rockcraft.lifecycle.providers.get_base_configuration",
+        return_value=mock_base_configuration,
+    )
+    mocker.patch("rockcraft.lifecycle.providers.capture_logs_from_instance")
+    mocker.patch("rockcraft.lifecycle.providers.ensure_provider_is_available")
+    mock_project.build_base = "ubuntu:22.04"
+
+    lifecycle.run_in_provider(
+        project=mock_project,
+        command_name="test",
+        parsed_args=argparse.Namespace(debug=True),
+    )
+    # Check that `rockcraft` was called with `--debug`.
+    mock_instance.execute_run.assert_called_once_with(
+        ["rockcraft", "test", "--verbosity=quiet", "--debug"],
+        check=True,
+        cwd=Path("/root/project"),
+    )
+
+
 def test_clean_provider(emitter, mock_get_instance_name, mock_provider, tmpdir):
     lifecycle.clean_provider(project_name="test-project", project_path=tmpdir)
 


### PR DESCRIPTION
The implementation mimics Snapcraft's: if a lifecycle step fails, run a shell before propagating the error out.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
