### PR TITLE
oci: support file collisions if the files match

### DIFF
--- a/tests/spread/general/usrmerge-file-collision/rockcraft.yaml
+++ b/tests/spread/general/usrmerge-file-collision/rockcraft.yaml
@@ -1,0 +1,25 @@
+name: usrmerge
+version: latest
+summary: A ROCK that tests file conflicts in usrmerge handling.
+description: A ROCK that tests file conflicts in usrmerge handling
+license: Apache-2.0
+base: ubuntu:22.04
+platforms:
+  amd64:
+
+parts:
+  file-conflict-part:
+    plugin: nil
+    # Both overlay-packages and stage-packages include `libexpat1`, so because
+    # of the usrmerge in the ubuntu-based overlay we will have many file-based
+    # conflicts; for instance, both lib/x86_64-linux-gnu/libexpat.so.1 _and_
+    # usr/lib/x86_64-linux-gnu/libexpat.so.1 will be created, one coming from the
+    # overlay-package and one from the stage-package.
+    overlay-packages: [libexpat1]
+    stage-packages: [libexpat1]
+    organize:
+      # Give these files a prefix here to facilitate testing for their presence
+      # in the container later; this way there won't be a false-positive from the
+      # already-existing "libexpat.so.1" file from the ubuntu base.
+      usr/lib/x86_64-linux-gnu/libexpat.so.1: usr/lib/x86_64-linux-gnu/rock-libexpat.so.1
+      lib/x86_64-linux-gnu/libexpat.so.1: lib/x86_64-linux-gnu/rock-libexpat.so.1

--- a/tests/spread/general/usrmerge-file-collision/task.yaml
+++ b/tests/spread/general/usrmerge-file-collision/task.yaml
@@ -1,0 +1,20 @@
+summary: test file conflicts in usrmerge handling
+
+execute: |
+  run_rockcraft pack
+
+  ROCK=$(ls usrmerge*.rock)
+
+  test -f "$ROCK"
+
+  # copy image to docker
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:"$ROCK" docker-daemon:usrmerge:latest
+  rm "$ROCK"
+
+  docker images usrmerge:latest
+
+  ############################################################################################
+  # check that usr/lib/x86_64-linux-gnu/rock-libexpat.so.1 was successfully packed into the ROCK
+  ############################################################################################
+  docker run --rm usrmerge exec ls /usr/lib/x86_64-linux-gnu/rock-libexpat.so.1


### PR DESCRIPTION
In c3382fc2408 we added support for directory collisions caused by the usrmerge when creating the payload layer; now we add support for file collisions if the files match in attributes and contents. This scenario can happen if an Ubuntu package is used both as an overlay-package and as a stage-package.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
