### PR TITLE
make pebble write service logs to stdout by default

### DIFF
--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -233,8 +233,8 @@ class Image:
         """Set the OCI image entrypoint. It is always Pebble and CMD is null."""
         emit.progress("Configuring entrypoint...")
         image_path = self.path / self.image_name
-        entrypoint = [f"/{Pebble.PEBBLE_BINARY_PATH}", "enter"]
-        params = ["--clear=config.entrypoint", "--verbose"]
+        entrypoint = [f"/{Pebble.PEBBLE_BINARY_PATH}", "enter", "--verbose"]
+        params = ["--clear=config.entrypoint"]
         for entry in entrypoint:
             params.extend(["--config.entrypoint", entry])
         _config_image(image_path, params)

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -234,7 +234,7 @@ class Image:
         emit.progress("Configuring entrypoint...")
         image_path = self.path / self.image_name
         entrypoint = [f"/{Pebble.PEBBLE_BINARY_PATH}", "enter"]
-        params = ["--clear=config.entrypoint"]
+        params = ["--clear=config.entrypoint", "--verbose"]
         for entry in entrypoint:
             params.extend(["--config.entrypoint", entry])
         _config_image(image_path, params)

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -639,6 +639,8 @@ class TestImage:
                     "/bin/pebble",
                     "--config.entrypoint",
                     "enter",
+                    "--config.entrypoint",
+                    "--verbose",
                 ],
                 capture_output=True,
                 check=True,


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Pebble currently does not show any logs from the service, making it impossible to know whether the service really works or not without running `pebble logs`. True to convention, we should make services log to stdout by default. 

Closes https://github.com/canonical/cos-alerter/issues/37