### PR TITLE
project: constrain ROCK name to pebble's rules

### DIFF
--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -69,10 +69,7 @@ class Pebble:
         )
 
         new_layer_prefix = f"{(int(prefixes[-1]) + 1):03}" if prefixes else "001"
-        # TODO: we need proper name validation as Pebble is quite unforgiving
-        # about the layer's label. We also don't want to allow any character
-        # in the ROCK's name. For now, just replacing the common "_" with "-".
-        new_layer_name = f"{new_layer_prefix}-{rock_name.replace('_', '-')}.yaml"
+        new_layer_name = f"{new_layer_prefix}-{rock_name}.yaml"
 
         emit.progress(f"Preparing new Pebble layer file {new_layer_name}")
 

--- a/tests/spread/general/invalid-name/rockcraft.orig.yaml
+++ b/tests/spread/general/invalid-name/rockcraft.orig.yaml
@@ -1,0 +1,12 @@
+name: placeholder-name
+base: ubuntu:22.04
+version: '0.1'
+summary: A ROCK with an invalid name
+description: A ROCK with an invalid name
+license: GPL-3.0
+platforms:
+    amd64:
+
+parts:
+    my-part:
+        plugin: nil

--- a/tests/spread/general/invalid-name/task.yaml
+++ b/tests/spread/general/invalid-name/task.yaml
@@ -1,0 +1,8 @@
+summary: check that invalid ROCK names are blocked
+
+execute: |
+  for name in a_a a@a a--a aa-
+  do
+    sed "s/placeholder-name/$name/" rockcraft.orig.yaml  > rockcraft.yaml
+    rockcraft 2>&1 >/dev/null | MATCH "Invalid name for ROCK"
+  done


### PR DESCRIPTION
Pebble only accepts lowercase a-z letters, numbers and hyphens. Since we use the ROCK's name on the layer file, use the same regex.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
