### PR TITLE
requirements: update craft-parts to 1.19.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-archives==0.0.3
 craft-cli==1.2.0
-craft-parts==1.19.0
+craft-parts==1.19.3
 craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==0.0.3
 craft-cli==1.2.0
-craft-parts==1.19.0
+craft-parts==1.19.3
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==0.0.3
 craft-cli==1.2.0
-craft-parts==1.19.0
+craft-parts==1.19.3
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0


### PR DESCRIPTION
Craft Parts 1.19.3 fixes plugin properties state during the
planning phase.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
