### PR TITLE
requirements: update craft-parts to 1.20.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-archives==0.0.3
 craft-cli==1.2.0
-craft-parts==1.19.3
+craft-parts==1.20.0
 craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==0.0.3
 craft-cli==1.2.0
-craft-parts==1.19.3
+craft-parts==1.20.0
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==0.0.3
 craft-cli==1.2.0
-craft-parts==1.19.3
+craft-parts==1.20.0
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/tests/spread/general/plugin-python-error/rockcraft.orig.yaml
+++ b/tests/spread/general/plugin-python-error/rockcraft.orig.yaml
@@ -1,0 +1,15 @@
+name: plugin-python-error
+base: placeholder-base
+build-base: ubuntu:22.04
+version: '0.1'
+summary: An invalid Python plugin project
+description: A project that uses the Python plugin but doesn't include Python
+license: GPL-3.0
+platforms:
+    amd64:
+
+parts:
+    my-part:
+        plugin: python
+        source: .
+        build-packages: [python3-pip]

--- a/tests/spread/general/plugin-python-error/task.yaml
+++ b/tests/spread/general/plugin-python-error/task.yaml
@@ -1,0 +1,7 @@
+summary: Check that invalid Python plugin cases fail the build
+environment:
+  BASE/base_2204: "ubuntu:22.04"
+  BASE/bare: "bare"
+execute: |
+  sed "s/placeholder-base/$BASE/" rockcraft.orig.yaml  > rockcraft.yaml
+  rockcraft -v 2>&1 >/dev/null | MATCH ":: No suitable Python interpreter found, giving up."


### PR DESCRIPTION
Also adds a test that checks that a project that uses the Python plugin but does _not_ bundle the interpreter in its payload fails to build. This is important because the generated ROCK is otherwise completely unusable.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
