### PR TITLE
Spread updates

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -21,16 +21,13 @@ backends:
     location: snapd-spread/us-east1-b
     halt-timeout: 2h
     systems:
-      - ubuntu-18.04-64:
-          workers: 2
-          storage: 40G
       - ubuntu-20.04-64:
           workers: 2
           storage: 40G
       - ubuntu-22.04-64:
           workers: 2
           storage: 40G
-      - fedora-36-64:
+      - fedora-37-64:
           workers: 2
           storage: 40G
 

--- a/tests/spread/general/repo-bare-base/rockcraft.yaml
+++ b/tests/spread/general/repo-bare-base/rockcraft.yaml
@@ -5,11 +5,7 @@ description: A ROCK that pulls in a package from an external PPA
 license: Apache-2.0
 base: bare
 build-base: ubuntu:18.04
-services:
-  test:
-    override: replace
-    command: /bin/bash-static /usr/bin/test-ppa
-    startup: enabled
+
 platforms:
   amd64:
 

--- a/tests/spread/general/repo-bare-base/task.yaml
+++ b/tests/spread/general/repo-bare-base/task.yaml
@@ -13,12 +13,8 @@ execute: |
   # Ensure container exists
   docker images apt-repo-static-test | MATCH "apt-repo-static-test"
   
-  # ensure container doesn't exist
-  docker rm -f apt-repo-static-test-container
-  docker run -d --name apt-repo-static-test-container apt-repo-static-test -v
-  docker logs apt-repo-static-test-container | MATCH "hello!"
+  docker run --rm apt-repo-static-test exec /bin/bash-static /usr/bin/test-ppa | MATCH "hello!"
 
 restore: |
   rm -f apt-repo-static-test_latest_amd64.rock
-  docker rm -f apt-repo-static-test-container
   docker rmi -f apt-repo-static-test

--- a/tests/spread/general/repo-ubuntu-base/rockcraft.yaml
+++ b/tests/spread/general/repo-ubuntu-base/rockcraft.yaml
@@ -4,11 +4,7 @@ summary: A ROCK that pulls in a package from an external PPA
 description: A ROCK that pulls in a package from an external PPA
 license: Apache-2.0
 base: ubuntu:22.04
-services:
-  test:
-    override: replace
-    command: /usr/bin/python3.12 -c "import sys;print(sys.version)"
-    startup: enabled
+
 platforms:
   amd64:
 

--- a/tests/spread/general/repo-ubuntu-base/task.yaml
+++ b/tests/spread/general/repo-ubuntu-base/task.yaml
@@ -13,12 +13,8 @@ execute: |
   # Ensure container exists
   docker images apt-repo-test | MATCH "apt-repo-test"
   
-  # ensure container doesn't exist
-  docker rm -f apt-repo-test-container
-  docker run -d --name apt-repo-test-container apt-repo-test -v
-  docker logs apt-repo-test-container | MATCH "3.12"
+  docker run --rm apt-repo-test exec /usr/bin/python3.12 -c "import sys;print(sys.version)" | MATCH "3.12"
   
 restore: |
   rm -f apt-repo-test_latest_amd64.rock
-  docker rm -f apt-repo-test-container
   docker rmi -f apt-repo-test


### PR DESCRIPTION
Rework a spread test to be less flaky, and update the systems to remove 18.04 and bump Fedora to 37.