### PR TITLE
ci: remove test runs on macos-latest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019]
         python-version: [3.8, 3.9, "3.10"]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The macos-latest workers are frequently busy and the majority of the "interesting" tests are skipped on non-linux systems anyway. We can add the OS back in the future if we need to.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
