### PR TITLE
ci, spread: add "large spreads" suite

### DIFF
--- a/.github/workflows/spread-large.yaml
+++ b/.github/workflows/spread-large.yaml
@@ -1,0 +1,47 @@
+name: Spread (large)
+on:
+  pull_request:
+    types: [ labeled ]
+  schedule:
+    - cron: "0 2 * * 0,3" # run at 2 AM on Sundays and Wednesdays
+
+jobs:
+  snap-build:
+    if: ${{ github.event.label.name == 'run-large-spread' || github.eventname == 'schedule' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: rockcraft
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: snap
+          path: ${{ steps.rockcraft.outputs.snap }}
+
+  snap-tests:
+    if: ${{ github.event.label.name == 'run-large-spread' || github.eventname == 'schedule' }}
+    runs-on: self-hosted
+    needs: [snap-build]
+
+    steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+      - name: Checkout rockcraft
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Download snap artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: snap
+          path: tests
+      - name: Run spread (large)
+        run: spread tests/spread/large/

--- a/spread.yaml
+++ b/spread.yaml
@@ -122,3 +122,8 @@ suites:
 
   tests/spread/general/:
     summary: tests for rockcraft core functionality
+
+  tests/spread/large/:
+    summary: bigger tests that take longer to run
+    manual: true
+

--- a/tests/spread/large/init/task.yaml
+++ b/tests/spread/large/init/task.yaml
@@ -1,0 +1,17 @@
+summary: rockcraft init test
+
+execute: |
+  run_rockcraft init
+  test -f rockcraft.yaml
+  run_rockcraft pack
+
+  test -f my-rock-name_0.1_amd64.rock
+  test ! -d work
+
+  # test container execution
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:my-rock-name_0.1_amd64.rock docker-daemon:my-rock-name:0.1
+  rm my-rock-name_0.1_amd64.rock
+  docker images my-rock-name:0.1
+  docker run --rm my-rock-name:0.1 exec bash -c 'echo Hello World'
+  docker system prune -a -f


### PR DESCRIPTION
Add a new spread suite, "tests/spread/large/", which runs on a cron of Sunday/Wednesday morning (2AM) *or* if a pull request gets the "run-large-spread" label.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
