### PR TITLE
parts: add project-specific global variables

### DIFF
--- a/rockcraft/parts.py
+++ b/rockcraft/parts.py
@@ -58,12 +58,14 @@ class PartsLifecycle:
         self,
         all_parts: Dict[str, Any],
         *,
+        project_name: str,
         work_dir: pathlib.Path,
         part_names: Optional[List[str]],
         base_layer_dir: pathlib.Path,
         base_layer_hash: bytes,
         base: str,
         package_repositories: Optional[List[Dict[str, Any]]] = None,
+        project_vars: Optional[Dict[str, str]] = None,
     ):
         self._part_names = part_names
         self._package_repositories = package_repositories or []
@@ -87,6 +89,8 @@ class PartsLifecycle:
                 ignore_local_sources=["*.rock"],
                 base=base,
                 package_repositories=self._package_repositories,
+                project_name=project_name,
+                project_vars=project_vars,
             )
         except craft_parts.PartsError as err:
             raise PartsLifecycleError.from_parts_error(err) from err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,9 +53,9 @@ def temp_xdg(tmpdir, mocker):
 
 
 @pytest.fixture()
-def reset_overlay_callback():
-    """Fixture that resets the status of the configure-overlay callback, so that
-    tests can start with a clean slate.
+def reset_callbacks():
+    """Fixture that resets the status of craft-part's various lifecycle callbacks,
+    so that tests can start with a clean slate.
     """
     # pylint: disable=import-outside-toplevel
 

--- a/tests/integration/plugins/test_python_plugin.py
+++ b/tests/integration/plugins/test_python_plugin.py
@@ -63,6 +63,7 @@ def run_lifecycle(base: str, work_dir: Path) -> None:
         base_layer_dir=Path("unused"),
         base_layer_hash=b"deadbeef",
         base=base,
+        project_name="python-project",
     )
 
     lifecycle.run("stage")

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -1,0 +1,77 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rockcraft import lifecycle, oci
+from tests.util import jammy_only
+
+pytestmark = [jammy_only, pytest.mark.usefixtures("reset_callbacks")]
+
+
+# A Rockcraft project whose build step writes some global CRAFT_* variables to
+# a yaml file.
+ROCKCRAFT_YAML = """\
+name: my-project
+title: My Project
+version: 1.2.3
+base: bare
+build-base: "ubuntu:22.04"
+summary: "example of global variables"
+description: "example of global variables"
+license: Apache-2.0
+
+platforms:
+    amd64:
+
+parts:
+    foo:
+        plugin: nil
+        override-build: |
+            target_file=${CRAFT_PART_INSTALL}/variables.yaml
+            touch $target_file
+            echo "project_name:    \\"${CRAFT_PROJECT_NAME}\\""    >> $target_file
+            echo "project_dir:     \\"${CRAFT_PROJECT_DIR}\\""     >> $target_file
+            echo "project_version: \\"${CRAFT_PROJECT_VERSION}\\"" >> $target_file
+"""
+
+
+def test_global_environment(new_dir, monkeypatch, mocker, reset_callbacks):
+    """Test our additions to the global environment that is available to the
+    build process."""
+
+    # Mock some OCI operations that are not relevant to this test.
+    rootfs = Path(new_dir) / "rootfs"
+    rootfs.mkdir()
+    fake_digest = b"deadbeef"
+    mocker.patch.object(oci.Image, "extract_to", return_value=rootfs)
+    mocker.patch.object(oci.Image, "digest", return_value=fake_digest)
+
+    Path("rockcraft.yaml").write_text(ROCKCRAFT_YAML)
+
+    args = argparse.Namespace(destructive_mode=True)
+    lifecycle.run("stage", args)
+
+    variables_yaml = Path(new_dir) / "stage/variables.yaml"
+    assert variables_yaml.is_file()
+    variables = yaml.safe_load(variables_yaml.read_text())
+
+    assert variables["project_name"] == "my-project"
+    assert variables["project_dir"] == str(new_dir)
+    assert variables["project_version"] == "1.2.3"

--- a/tests/integration/test_oci.py
+++ b/tests/integration/test_oci.py
@@ -166,6 +166,7 @@ def test_add_layer_with_overlay(new_dir, mocker):
         base_layer_dir=base_layer_dir,
         base_layer_hash=b"deadbeef",
         base="unused",
+        project_name="overlay",
     )
 
     assert mock_geteuid.called

--- a/tests/integration/test_parts.py
+++ b/tests/integration/test_parts.py
@@ -17,24 +17,17 @@ import os
 from pathlib import Path
 
 import pytest
-from craft_parts import callbacks, overlays
+from craft_parts import overlays
 
 from rockcraft.parts import PartsLifecycle
 from tests.util import jammy_only
 
-pytestmark = jammy_only
+pytestmark = [jammy_only, pytest.mark.usefixtures("reset_callbacks")]
 
 # pyright: reportPrivateImportUsage=false
 
 
-@pytest.fixture(autouse=True)
-def _cleanup_callbacks():
-    callbacks.unregister_all()
-    yield
-    callbacks.unregister_all()
-
-
-def test_package_repositories_in_overlay(new_dir, mocker, reset_overlay_callback):
+def test_package_repositories_in_overlay(new_dir, mocker):
 
     # Mock overlay-related calls that need root; we won't be actually installing
     # any packages, just checking that the repositories are correctly installed
@@ -73,6 +66,7 @@ def test_package_repositories_in_overlay(new_dir, mocker, reset_overlay_callback
         base_layer_hash=b"deadbeef",
         base="fake-ubuntu",
         package_repositories=package_repositories,
+        project_name="package-repos",
     )
     # Mock the installation of package repositories in the base system, as that
     # is undesired and will fail without root.


### PR DESCRIPTION
The implementation follows Snapcraft's: a prologue callback is used to fill the project info with the project's name and version (the other 'useful' variables are already provided by craft_parts). This lets parts use those variables (for example during their builds).

A lot of the unit test changes come from a refactoring to make adding new parameters to parts.PartsLifecycle less painful in the future.

Closes #299

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
