### PR TITLE
plugins: fix python shebang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ ensure_newline_before_comments = true
 line_length = 88
 
 [tool.black]
-exclude = "docs/sphinx-starter-pack"
+# Use extra-excludes so that the default excludes (including those from .gitignore)
+# are not overwritten.
+extra-excludes = "docs/sphinx-starter-pack"
 
 [tool.mypy]
 python_version = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ ensure_newline_before_comments = true
 line_length = 88
 
 [tool.black]
-# Use extra-excludes so that the default excludes (including those from .gitignore)
+# Use extend-exclude so that the default excludes (including those from .gitignore)
 # are not overwritten.
-extra-excludes = "docs/sphinx-starter-pack"
+extend-exclude = "docs/sphinx-starter-pack"
 
 [tool.mypy]
 python_version = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ python_version = "3.8"
 exclude = [
     "build",
     "results",
+    "tests/spread"
 ]
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,8 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-archives==1.1.0
 craft-cli==2.0.0
-craft-parts==1.22.0
+#craft-parts==1.22.0
+git+https://github.com/tigarmo/craft-parts.git@fix-python-3.6#egg=craft_parts
 craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,8 +18,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-archives==1.1.0
 craft-cli==2.0.0
-#craft-parts==1.22.0
-git+https://github.com/tigarmo/craft-parts.git@fix-python-3.6#egg=craft_parts
+craft-parts==1.23.0
 craft-providers==1.8.0
 cryptography==38.0.4
 Deprecated==1.2.13

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,8 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.0
 craft-cli==2.0.0
-#craft-parts==1.22.0
-git+https://github.com/tigarmo/craft-parts.git@fix-python-3.6#egg=craft_parts
+craft-parts==1.23.0
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,8 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.0
 craft-cli==2.0.0
-craft-parts==1.22.0
+#craft-parts==1.22.0
+git+https://github.com/tigarmo/craft-parts.git@fix-python-3.6#egg=craft_parts
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.0
 craft-cli==2.0.0
-#craft-parts==1.22.0
-git+https://github.com/tigarmo/craft-parts.git@fix-python-3.6#egg=craft_parts
+craft-parts==1.23.0
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.0
 craft-cli==2.0.0
-craft-parts==1.22.0
+#craft-parts==1.22.0
+git+https://github.com/tigarmo/craft-parts.git@fix-python-3.6#egg=craft_parts
 craft-providers==1.8.0
 Deprecated==1.2.13
 distro==1.8.0

--- a/rockcraft/plugins/python_plugin.py
+++ b/rockcraft/plugins/python_plugin.py
@@ -86,7 +86,7 @@ class PythonPlugin(python_plugin.PythonPlugin):
     @override
     def _get_script_interpreter(self) -> str:
         """Overridden because Python is always available in /bin/python3."""
-        return "#!/bin/python3"
+        return "#!/bin/${PARTS_PYTHON_INTERPRETER}"
 
     @override
     def get_build_commands(self) -> List[str]:

--- a/rockcraft/plugins/python_plugin.py
+++ b/rockcraft/plugins/python_plugin.py
@@ -97,9 +97,9 @@ class PythonPlugin(python_plugin.PythonPlugin):
         commands.append(
             dedent(
                 """
-                # Detect whether PARTS_PYTHON_INTERPRETER is a full path
+                # Detect whether PARTS_PYTHON_INTERPRETER is an absolute path
                 if [[ "${PARTS_PYTHON_INTERPRETER}" = /* ]]; then
-                    echo "Full paths in \"PARTS_PYTHON_INTERPRETER\" are not allowed: ${PARTS_PYTHON_INTERPRETER}"
+                    echo "Absolute paths in \"PARTS_PYTHON_INTERPRETER\" are not allowed: ${PARTS_PYTHON_INTERPRETER}"
                     exit 1
                 fi
                 """

--- a/tests/integration/plugins/test_python_plugin.py
+++ b/tests/integration/plugins/test_python_plugin.py
@@ -178,7 +178,5 @@ def test_python_plugin_invalid_interpreter(tmp_path):
 
     emit.ended_ok()
 
-    expected_text = (
-        ":: Full paths in PARTS_PYTHON_INTERPRETER are not allowed: /full/path/python3"
-    )
+    expected_text = ":: Absolute paths in PARTS_PYTHON_INTERPRETER are not allowed: /full/path/python3"
     assert expected_text in log_filepath.read_text()

--- a/tests/integration/plugins/test_python_plugin.py
+++ b/tests/integration/plugins/test_python_plugin.py
@@ -13,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
-import logging
 import os
 import typing
 from dataclasses import dataclass
@@ -174,7 +173,7 @@ def test_python_plugin_invalid_interpreter(tmp_path):
         "build-environment": [{"PARTS_PYTHON_INTERPRETER": "/full/path/python3"}]
     }
 
-    with pytest.raises(errors.PartsLifecycleError) as exc:
+    with pytest.raises(errors.PartsLifecycleError):
         run_lifecycle("bare", tmp_path, extra_part_props=extra_part)
 
     emit.ended_ok()

--- a/tests/integration/plugins/test_python_plugin.py
+++ b/tests/integration/plugins/test_python_plugin.py
@@ -13,16 +13,18 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
+import logging
 import os
 import typing
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+from craft_cli import EmitterMode, emit
 from craft_parts.errors import OsReleaseVersionIdError
 from craft_parts.utils.os_utils import OsRelease
 
-from rockcraft import plugins
+from rockcraft import errors, plugins
 from rockcraft.parts import PartsLifecycle
 from rockcraft.plugins.python_plugin import SITECUSTOMIZE_TEMPLATE
 from rockcraft.project import Project
@@ -45,14 +47,17 @@ def setup_python_test(monkeypatch):
     plugins.register()
 
 
-def run_lifecycle(base: str, work_dir: Path) -> None:
+def run_lifecycle(base: str, work_dir: Path, extra_part_props=None) -> None:
     source = Path(__file__).parent / "python_source"
+
+    extra = extra_part_props or {}
 
     parts = {
         "my-part": {
             "plugin": "python",
             "source": str(source),
             "stage-packages": ["python3-venv"],
+            **extra,
         }
     }
 
@@ -158,3 +163,23 @@ def test_python_plugin_bare(tmp_path):
     # sitecustomize.py module.
     pyvenv_cfg = tmp_path / "stage/pyvenv.cfg"
     assert not pyvenv_cfg.is_file()
+
+
+def test_python_plugin_invalid_interpreter(tmp_path):
+    """Check that an invalid value for PARTS_PYTHON_INTERPRETER fails the build"""
+    log_filepath = tmp_path / "log.txt"
+    emit.init(EmitterMode.VERBOSE, "rockcraft", "rockcraft", log_filepath=log_filepath)
+
+    extra_part = {
+        "build-environment": [{"PARTS_PYTHON_INTERPRETER": "/full/path/python3"}]
+    }
+
+    with pytest.raises(errors.PartsLifecycleError) as exc:
+        run_lifecycle("bare", tmp_path, extra_part_props=extra_part)
+
+    emit.ended_ok()
+
+    expected_text = (
+        ":: Full paths in PARTS_PYTHON_INTERPRETER are not allowed: /full/path/python3"
+    )
+    assert expected_text in log_filepath.read_text()

--- a/tests/spread/general/plugin-python-3.6/rockcraft.orig.yaml
+++ b/tests/spread/general/plugin-python-3.6/rockcraft.orig.yaml
@@ -1,0 +1,23 @@
+name: plugin-python-36
+base: placeholder-base
+build-base: ubuntu:20.04
+version: '0.1'
+summary: A project using Python 3.6
+description: A project using Python 3.6
+license: GPL-3.0
+platforms:
+    amd64:
+
+package-repositories:
+  - type: apt
+    ppa: deadsnakes/ppa
+    priority: always
+
+parts:
+    my-part:
+        plugin: python
+        source: .
+        stage-packages: [python3.6-venv]
+        python-packages: [black]
+        build-environment:
+            - PARTS_PYTHON_INTERPRETER: python3.6

--- a/tests/spread/general/plugin-python-3.6/rockcraft.orig.yaml
+++ b/tests/spread/general/plugin-python-3.6/rockcraft.orig.yaml
@@ -16,8 +16,7 @@ package-repositories:
 parts:
     my-part:
         plugin: python
-        source: .
+        source: src
         stage-packages: [python3.6-venv]
-        python-packages: [black]
         build-environment:
             - PARTS_PYTHON_INTERPRETER: python3.6

--- a/tests/spread/general/plugin-python-3.6/src/hello/__main__.py
+++ b/tests/spread/general/plugin-python-3.6/src/hello/__main__.py
@@ -1,0 +1,6 @@
+def main():
+    print("hello world")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/spread/general/plugin-python-3.6/src/setup.py
+++ b/tests/spread/general/plugin-python-3.6/src/setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup
+
+setup(
+    name="hello",
+    version="0.1",
+    entry_points={"console_scripts": ["hello=hello.__main__:main"]},
+    packages=["hello"],
+)

--- a/tests/spread/general/plugin-python-3.6/task.yaml
+++ b/tests/spread/general/plugin-python-3.6/task.yaml
@@ -1,0 +1,20 @@
+summary: Build ROCKs with Python 3.6 with bases bare and ubuntu:20.04
+environment:
+  BASE/base_2004: "ubuntu:20.04"
+  BASE/bare: "bare"
+execute: |
+  IMAGE="plugin-python-36:latest"
+
+  # Make sure the yaml file has the "placeholder-base" string, and replace
+  # it with the correct base.
+  grep placeholder-base rockcraft.orig.yaml
+  sed "s/placeholder-base/$BASE/" rockcraft.orig.yaml  > rockcraft.yaml
+
+  # Build the ROCK & load it into docker
+  run_rockcraft
+  ROCK=$(ls ./*.rock)
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:${IMAGE}
+  rm "${ROCK}"
+
+  docker run --rm $IMAGE exec python3.6 --version | MATCH "Python 3.6"
+  docker run --rm $IMAGE exec black --help

--- a/tests/spread/general/plugin-python-3.6/task.yaml
+++ b/tests/spread/general/plugin-python-3.6/task.yaml
@@ -17,4 +17,4 @@ execute: |
   rm "${ROCK}"
 
   docker run --rm $IMAGE exec python3.6 --version | MATCH "Python 3.6"
-  docker run --rm $IMAGE exec black --help
+  docker run --rm $IMAGE exec hello | MATCH "hello world"

--- a/tests/unit/plugins/test_python_plugin.py
+++ b/tests/unit/plugins/test_python_plugin.py
@@ -50,7 +50,7 @@ def test_invariants(base, tmp_path):
     plugin = create_plugin(base, tmp_path)
 
     assert plugin._get_system_python_interpreter() is None
-    assert plugin._get_script_interpreter() == "#!/bin/python3"
+    assert plugin._get_script_interpreter() == "#!/bin/${PARTS_PYTHON_INTERPRETER}"
 
 
 @pytest.mark.parametrize("base", ALL_BASES)


### PR DESCRIPTION
Use ${PARTS_PYTHON_INTERPRETER} to play nice with the upstream plugin;
If the user overrides this, there's probably a good reason (like using
Python 3.6).