### PR TITLE
docs: add warning for platforms field

### DIFF
--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -146,6 +146,11 @@ The set of architecture-specific ROCKs to be built. Supported architectures are:
 Entries in the ``platforms`` dict can be free-form strings, or the name of a
 supported architecture.
 
+.. warning::
+   **All** target architectures must be compatible with the architecture of
+   the host where Rockcraft is being executed (i.e. emulation is not supported
+   at the moment).
+
 ``platforms.<entry>.build-on``
 ------------------------------
 


### PR DESCRIPTION
This PR add a warning note, about that the host need to be compatible with the arch written on the rockcraft.yaml file.

Signed_Off_By: Samir Akarioh <samir.akarioh@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
