### PR TITLE
add support for health checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,11 @@ release = rockcraft.__version__
 html_favicon = "_static/favicon.png"
 
 html_context = {
+    # Change to the link to your product website (without "https://")
+    "product_page": "github.com/canonical/rockcraft",
+    # Add your product tag to ".sphinx/_static" and change the path
+    # here (start with "_static"), default is the circle of friends
+    "product_tag": "_static/tag.png",
     # Change to the discourse instance you want to be able to link to
     # (use an empty value if you don't want to link)
     "discourse": "https://discourse.ubuntu.com/c/rocks/117",

--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -138,6 +138,18 @@ specification syntax exactly, with each entry defining a Pebble service. For
 each service, the ``override`` and ``command`` fields are mandatory, but all
 others are optional.
 
+``checks``
+------------
+
+**Type**: dict, following the `Pebble Layer Specification format`_
+
+**Required**: No
+
+A list of health checks that can be configured to restart Pebble services
+when they fail. It uses Pebble's layer specification syntax, with each
+entry corresponding to a check. Each check can be one of three types:
+``http``, ``tcp`` or ``exec``.
+
 ``platforms``
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ line_length = 88
 # are not overwritten.
 extend-exclude = "docs/sphinx-starter-pack"
 
+[tool.pyright]
+ignore = ["docs/sphinx-starter-pack"]
+
 [tool.mypy]
 python_version = "3.8"
 exclude = [

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -199,9 +199,23 @@ def _pack(
     emit.progress("Adding Pebble entrypoint")
 
     new_image.set_entrypoint()
-    if project.services:
-        new_image.set_pebble_services(
-            services=project.dict(exclude_none=True, by_alias=True)["services"],
+
+    services = (
+        project.dict(exclude_none=True, by_alias=True)["services"]
+        if project.services
+        else {}
+    )
+
+    checks = (
+        project.dict(exclude_none=True, by_alias=True)["checks"]
+        if project.checks
+        else {}
+    )
+
+    if services or checks:
+        new_image.set_pebble_layer(
+            services=services,
+            checks=checks,
             name=project.name,
             tag=project.version,
             summary=project.summary,

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -200,17 +200,9 @@ def _pack(
 
     new_image.set_entrypoint()
 
-    services = (
-        project.dict(exclude_none=True, by_alias=True)["services"]
-        if project.services
-        else {}
-    )
+    services = project.dict(exclude_none=True, by_alias=True).get("services", {})
 
-    checks = (
-        project.dict(exclude_none=True, by_alias=True)["checks"]
-        if project.checks
-        else {}
-    )
+    checks = project.dict(exclude_none=True, by_alias=True).get("checks", {})
 
     if services or checks:
         new_image.set_pebble_layer(

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -370,10 +370,10 @@ class Image:
         :param base_layer_dir: Path to the base layer's root filesystem
         """
         # pylint: disable=too-many-arguments
-        pebble_layer_content = {
+        pebble_layer_content: Dict[str, Any] = {
             "summary": summary,
             "description": description,
-        }  # type: Dict[str, Any]
+        }
 
         if services:
             emit.progress(

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -349,18 +349,20 @@ class Image:
         _config_image(image_path, ["--clear=config.cmd"])
         emit.progress(f"Entrypoint set to {entrypoint}", permanent=True)
 
-    def set_pebble_services(
+    def set_pebble_layer(
         self,
         services: Dict[str, Any],
+        checks: Dict[str, Any],
         name: str,
         tag: str,
         summary: str,
         description: str,
         base_layer_dir: Path,
     ) -> None:
-        """Write the provided services into a Pebble layer in the filesystem.
+        """Write the provided services and checks into a Pebble layer in the filesystem.
 
-        :param services: The Pebble services to be written into the Pebble
+        :param services: The Pebble services
+        :param checks: The Pebble checks
         :param name: The name of the ROCK
         :param tag: The ROCK's image tag
         :param summary: The summary for the Pebble layer
@@ -368,13 +370,20 @@ class Image:
         :param base_layer_dir: Path to the base layer's root filesystem
         """
         # pylint: disable=too-many-arguments
-        service_names = list(services.keys())
-        emit.progress(f"Configuring Pebble services {', '.join(service_names)}")
         pebble_layer_content = {
             "summary": summary,
             "description": description,
-            "services": services,
-        }
+        }  # type: Dict[str, Any]
+
+        if services:
+            emit.progress(
+                f"Configuring Pebble services {', '.join(list(services.keys()))}"
+            )
+            pebble_layer_content["services"] = services
+
+        if checks:
+            emit.progress(f"Configuring Pebble checks {', '.join(list(checks.keys()))}")
+            pebble_layer_content["checks"] = checks
 
         pebble = Pebble()
         with tempfile.TemporaryDirectory() as tmpfs:

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -44,7 +44,7 @@ class TcpCheck(pydantic.BaseModel):
     """Lightweight schema validation for a Pebble TCP check."""
 
     port: int
-    host: Optional[str] = "localhost"
+    host: Optional[str]
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""
@@ -57,7 +57,7 @@ class ExecCheck(pydantic.BaseModel):
     """Lightweight schema validation for a Pebble exec check."""
 
     command: str
-    service_context: Optional[str] = "localhost"
+    service_context: Optional[str]
     environment: Optional[Dict[str, str]]
     user: Optional[str]
     user_id: Optional[int]

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -18,7 +18,7 @@
 
 import glob
 from pathlib import Path
-from typing import Any, Dict, Literal, Mapping, Optional
+from typing import Any, Dict, List, Literal, Mapping, Optional
 import pydantic
 
 import yaml
@@ -109,6 +109,43 @@ class Check(pydantic.BaseModel):
             return values
 
         raise ProjectValidationError(err)
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        allow_population_by_field_name = True
+        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
+        extra = "forbid"
+
+
+class Service(pydantic.BaseModel):
+    """Lightweight schema validation for a Pebble service.
+
+    Based on
+    https://github.com/canonical/pebble#layer-specification
+    """
+
+    override: Literal["merge", "replace"]
+    command: str
+    summary: Optional[str]
+    description: Optional[str]
+    startup: Optional[Literal["enabled", "disabled"]]
+    after: Optional[List[str]]
+    before: Optional[List[str]]
+    requires: Optional[List[str]]
+    environment: Optional[Dict[str, str]]
+    user: Optional[str]
+    user_id: Optional[int]
+    group: Optional[str]
+    group_id: Optional[int]
+    working_dir: Optional[str]
+    on_success: Optional[Literal["restart", "shutdown", "ignore"]]
+    on_failure: Optional[Literal["restart", "shutdown", "ignore"]]
+    on_check_failure: Optional[Dict[str, Literal["restart", "shutdown", "ignore"]]]
+    backoff_delay: Optional[str]
+    backoff_factor: Optional[float]
+    backoff_limit: Optional[str]
+    kill_delay: Optional[str]
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -19,8 +19,8 @@
 import glob
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Mapping, Optional
-import pydantic
 
+import pydantic
 import yaml
 from craft_cli import emit
 

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -93,17 +93,17 @@ class Check(pydantic.BaseModel):
     @classmethod
     def _validates_check_type(cls, values: Mapping[str, Any]) -> Mapping[str, Any]:
         """Before validation, make sure only one of 'http', 'tcp' or 'exec' exist."""
-        mutually_exclusive = ["http", "tcp", "exec"]
-        count = sum(field in values for field in mutually_exclusive)
+        mutually_exclusive = {"http", "tcp", "exec"}
+        check_types = mutually_exclusive & values.keys()
 
-        if count > 1:
+        if len(check_types) > 1:
             err = str(
-                f"Only one of {', '.join(mutually_exclusive)} "
-                "may be specified for each check."
+                f"Multiple check types specified ({', '.join(check_types)}). "
+                "Each check must have exactly one type."
             )
-        elif count < 1:
+        elif len(check_types) < 1:
             err = str(
-                f"Must specify one of {', '.join(mutually_exclusive)} for each check."
+                f"Must specify exactly one of {', '.join(mutually_exclusive)} for each check."
             )
         else:
             return values

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -30,7 +30,7 @@ from rockcraft.errors import ProjectValidationError
 class HttpCheck(pydantic.BaseModel):
     """Lightweight schema validation for a Pebble HTTP check."""
 
-    url: str
+    url: pydantic.AnyHttpUrl
     headers: Optional[Dict[str, str]]
 
     class Config:  # pylint: disable=too-few-public-methods

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -93,8 +93,9 @@ class Check(pydantic.BaseModel):
     @classmethod
     def _validates_check_type(cls, values: Mapping[str, Any]) -> Mapping[str, Any]:
         """Before validation, make sure only one of 'http', 'tcp' or 'exec' exist."""
-        mutually_exclusive = {"http", "tcp", "exec"}
-        check_types = mutually_exclusive & values.keys()
+        mutually_exclusive = ["http", "tcp", "exec"]
+        check_types = list(set(mutually_exclusive) & values.keys())
+        check_types.sort()
 
         if len(check_types) > 1:
             err = str(
@@ -103,7 +104,7 @@ class Check(pydantic.BaseModel):
             )
         elif len(check_types) < 1:
             err = str(
-                f"Must specify exactly one of {', '.join(mutually_exclusive)} for each check."
+                f"Must specify exactly one of {', '.join(list(mutually_exclusive))} for each check."
             )
         else:
             return values

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -44,7 +44,7 @@ from pydantic_yaml import YamlModel
 from rockcraft.errors import ProjectLoadError, ProjectValidationError
 from rockcraft.extensions import apply_extensions
 from rockcraft.parts import part_has_overlay, validate_part
-from rockcraft.pebble import Pebble, Check, Service
+from rockcraft.pebble import Check, Pebble, Service
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 if TYPE_CHECKING:

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -44,7 +44,7 @@ from pydantic_yaml import YamlModel
 from rockcraft.errors import ProjectLoadError, ProjectValidationError
 from rockcraft.extensions import apply_extensions
 from rockcraft.parts import part_has_overlay, validate_part
-from rockcraft.pebble import Pebble, Check
+from rockcraft.pebble import Pebble, Check, Service
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 if TYPE_CHECKING:
@@ -154,43 +154,6 @@ class Platform(pydantic.BaseModel):
             )
 
         return values
-
-
-class Service(pydantic.BaseModel):
-    """Lightweight schema validation for a Pebble service.
-
-    Based on
-    https://github.com/canonical/pebble#layer-specification
-    """
-
-    override: Literal["merge", "replace"]
-    command: str
-    summary: Optional[str]
-    description: Optional[str]
-    startup: Optional[Literal["enabled", "disabled"]]
-    after: Optional[List[str]]
-    before: Optional[List[str]]
-    requires: Optional[List[str]]
-    environment: Optional[Dict[str, str]]
-    user: Optional[str]
-    user_id: Optional[int]
-    group: Optional[str]
-    group_id: Optional[int]
-    working_dir: Optional[str]
-    on_success: Optional[Literal["restart", "shutdown", "ignore"]]
-    on_failure: Optional[Literal["restart", "shutdown", "ignore"]]
-    on_check_failure: Optional[Dict[str, Literal["restart", "shutdown", "ignore"]]]
-    backoff_delay: Optional[str]
-    backoff_factor: Optional[float]
-    backoff_limit: Optional[str]
-    kill_delay: Optional[str]
-
-    class Config:  # pylint: disable=too-few-public-methods
-        """Pydantic model configuration."""
-
-        allow_population_by_field_name = True
-        alias_generator = lambda s: s.replace("_", "-")  # noqa: E731
-        extra = "forbid"
 
 
 NAME_REGEX = r"^([a-z](?:-?[a-z0-9]){2,})$"

--- a/rockcraft/project.py
+++ b/rockcraft/project.py
@@ -44,7 +44,7 @@ from pydantic_yaml import YamlModel
 from rockcraft.errors import ProjectLoadError, ProjectValidationError
 from rockcraft.extensions import apply_extensions
 from rockcraft.parts import part_has_overlay, validate_part
-from rockcraft.pebble import Pebble
+from rockcraft.pebble import Pebble, Check
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 if TYPE_CHECKING:
@@ -231,6 +231,7 @@ class Project(YamlModel):
     environment: Optional[Dict[str, str]]
     run_user: Optional[Literal[tuple(SUPPORTED_GLOBAL_USERNAMES)]]  # type: ignore
     services: Optional[Dict[str, Service]]
+    checks: Optional[Dict[str, Check]]
 
     package_repositories: Optional[List[Dict[str, Any]]]
 

--- a/tests/spread/general/health-checks/rockcraft.yaml
+++ b/tests/spread/general/health-checks/rockcraft.yaml
@@ -1,0 +1,61 @@
+name: healthy-rock
+summary: A ROCK with health checks
+description: A test ROCK with a bunch of different Pebble checks
+license: Apache-2.0
+
+version: latest
+base: "ubuntu:22.04"
+
+services: 
+  webserver:
+    override: replace
+    command: timeout 30 nginx -g 'daemon off;'
+    environment:
+      TZ: UTC
+    startup: enabled
+    on-failure: shutdown
+
+checks:
+  http-check:
+    override: replace
+    level: alive
+    period: 1s
+    http:
+      url: http://localhost/
+  tcp-check:
+    override: replace
+    level: ready
+    tcp:
+      port: 80
+  exec-check:
+    override: replace
+    exec:
+      command: pebble services
+
+platforms:
+  amd64:
+
+package-repositories:
+  - type: apt
+    url: https://nginx.org/packages/mainline/ubuntu
+    key-id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+    suites: 
+      - jammy
+    components:
+      - nginx
+    priority: always
+
+parts:
+  nginx-user:
+    plugin: nil
+    overlay-script: |
+      set -x
+      useradd -R $CRAFT_OVERLAY -M -U -r nginx
+
+  nginx:
+    plugin: nil
+    after:
+      - nginx-user
+    stage-packages:
+      - nginx
+      - tzdata

--- a/tests/spread/general/health-checks/task.yaml
+++ b/tests/spread/general/health-checks/task.yaml
@@ -1,0 +1,18 @@
+summary: health checks test
+
+execute: |
+  run_rockcraft pack
+
+  test -f healthy-rock_latest_amd64.rock
+  test ! -d parts -a ! -d stage -a ! -d prime
+
+  # test container execution
+  docker images
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:healthy-rock_latest_amd64.rock docker-daemon:healthy-rock:latest
+  rm healthy-rock_latest_amd64.rock
+  docker images healthy-rock:latest
+  id=$(docker run --rm -d healthy-rock)
+
+  [[ $(docker exec "$id" pebble checks | grep -c -E "http-check|tcp-check|exec-check") -eq 3 ]]
+
+  docker rm -f "$id"

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import re
 from pathlib import Path
 
 import pydantic
@@ -261,9 +260,8 @@ class TestPebble:
         ],
     )
     def test_bad_services(self, bad_service, error):
-        with pytest.raises(pydantic.ValidationError) as err:
+        with pytest.raises(pydantic.ValidationError, match=error):
             _ = Service(**bad_service)
-        assert re.match(error, str(err.value)), "Unexpected Service validation error"
 
     @pytest.mark.parametrize(
         "bad_http_check,error",
@@ -283,9 +281,8 @@ class TestPebble:
         ],
     )
     def test_bad_http_checks(self, bad_http_check, error):
-        with pytest.raises(pydantic.ValidationError) as err:
+        with pytest.raises(pydantic.ValidationError, match=error):
             _ = HttpCheck(**bad_http_check)
-        assert re.match(error, str(err.value)), "Unexpected HttpCheck validation error"
 
     @pytest.mark.parametrize(
         "bad_tcp_check,error",
@@ -305,9 +302,8 @@ class TestPebble:
         ],
     )
     def test_bad_tcp_checks(self, bad_tcp_check, error):
-        with pytest.raises(pydantic.ValidationError) as err:
+        with pytest.raises(pydantic.ValidationError, match=error):
             _ = TcpCheck(**bad_tcp_check)
-        assert re.match(error, str(err.value)), "Unexpected TcpCheck validation error"
 
     @pytest.mark.parametrize(
         "bad_exec_check,error",
@@ -339,9 +335,8 @@ class TestPebble:
         ],
     )
     def test_bad_exec_checks(self, bad_exec_check, error):
-        with pytest.raises(pydantic.ValidationError) as err:
+        with pytest.raises(pydantic.ValidationError, match=error):
             _ = ExecCheck(**bad_exec_check)
-        assert re.match(error, str(err.value)), "Unexpected ExecCheck validation error"
 
     def test_full_check(self):
         full_check = {
@@ -412,6 +407,5 @@ class TestPebble:
         ],
     )
     def test_bad_checks(self, bad_check, exception, error):
-        with pytest.raises(exception) as err:
+        with pytest.raises(exception, match=error):
             _ = Check(**bad_check)
-        assert re.match(error, str(err.value)), "Unexpected Check validation error"

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -17,12 +17,13 @@
 import os
 from pathlib import Path
 
+import pydantic
 import pytest
+import re
 import yaml
 
 import tests
-from rockcraft.pebble import Pebble
-from rockcraft.project import Service
+from rockcraft.pebble import Pebble, Service
 
 
 @tests.linux_only
@@ -180,3 +181,85 @@ class TestPebble:
             for service_fields in content["services"].values():
                 for field in service_fields:
                     check.is_not_in("_", field)
+
+    def test_full_service(self):
+        full_service = {
+            "override": "merge",
+            "command": "foo cmd",
+            "summary": "mock summary",
+            "description": "mock description",
+            "startup": "enabled",
+            "after": ["foo"],
+            "before": ["bar"],
+            "requires": ["some-other"],
+            "environment": {"envVar": "value"},
+            "user": "ubuntu",
+            "user-id": 1000,
+            "group": "ubuntu",
+            "group-id": 1000,
+            "working-dir": "/tmp",
+            "on-success": "ignore",
+            "on-failure": "restart",
+            "on-check-failure": {"check": "restart"},
+            "backoff-delay": "10ms",
+            "backoff-factor": 1.2,
+            "backoff-limit": "1m",
+            "kill-delay": "5s",
+        }
+        _ = Service(**full_service)
+
+    def test_minimal_service(self):
+        _ = Service(override="merge", command="foo cmd")  # pyright: ignore
+
+    @pytest.mark.parametrize(
+        "bad_service,error",
+        [
+            # Missing fields
+            ({}, r"^2 validation errors[\s\S]*override[\s\S]*command"),
+            # Bad attributes values
+            (
+                {
+                    "override": "bad value",
+                    "command": "free text allowed",
+                    "startup": "bad value",
+                    "on-success": "bad value",
+                    "on-failure": "bad value",
+                    "on-check-failure": {"check": "bad value"},
+                },
+                r"^5 validation errors[\s\S]*"
+                r"override[\s\S]*unexpected value[\s\S]*'merge', 'replace'[\s\S]*"
+                r"startup[\s\S]*unexpected value[\s\S]*'enabled', 'disabled'[\s\S]*"
+                r"on-success[\s\S]*unexpected value[\s\S]*"
+                r"'restart', 'shutdown', 'ignore'[\s\S]*"
+                r"on-failure[\s\S]*unexpected value[\s\S]*"
+                r"'restart', 'shutdown', 'ignore'[\s\S]*"
+                r"on-check-failure[\s\S]*unexpected value[\s\S]*"
+                r"'restart', 'shutdown', 'ignore'[\s\S]*",
+            ),
+            # Bad attribute types
+            (
+                {
+                    "override": ["merge"],
+                    "command": ["not a string"],
+                    "summary": {"foo": "bar"},
+                    "after": "not a List",
+                    "environment": "not a Dict",
+                    "user-id": "not an int",
+                    "on-check-failure": {"check": ["not a Literal"]},
+                    "backoff-factor": "not a float",
+                },
+                r"^8 validation errors[\s\S]*"
+                r"unhashable type[\s\S]*"
+                r"str type expected[\s\S]*"
+                r"value is not a valid list[\s\S]*"
+                r"value is not a valid dict[\s\S]*"
+                r"value is not a valid integer[\s\S]*"
+                r"unhashable type[\s\S]*"
+                r"value is not a valid float[\s\S]*",
+            ),
+        ],
+    )
+    def test_bad_services(self, bad_service, error):
+        with pytest.raises(pydantic.ValidationError) as err:
+            _ = Service(**bad_service)
+        assert re.match(error, str(err.value)), "Unexpected Service validation error"

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -15,11 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 from pathlib import Path
 
 import pydantic
 import pytest
-import re
 import yaml
 
 import tests


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

In this PR:
 - move all Pebble-related schemas into the Pebble module
 - add the schema for Pebble checks (based on https://github.com/canonical/pebble/#layer-specification)
 - change the lifecycle logic to encompass the new `checks` field alongside the `services` field, when creating the Pebble layer
 - add new field to reference documentation