### PR TITLE
enable "streaming brief" CLI mode

### DIFF
--- a/docs/how-to/convert-to-pebble-layer.rst
+++ b/docs/how-to/convert-to-pebble-layer.rst
@@ -78,7 +78,7 @@ Now, build the final custom NGINX ROCK with:
 You should see something like this:
 
 ..  code-block:: text
-    :emphasize-lines: 5,29
+    :emphasize-lines: 5,26
     :class: log-snippets
 
     Launching instance...
@@ -106,9 +106,6 @@ You should see something like this:
     Executed: prime nginx
     Executed: prime pebble
     Executed parts lifecycle
-    Created new layer
-    Entrypoint set to ['/bin/pebble', 'enter']
-    Labels and annotations set to ['org.opencontainers.image.version=latest', 'org.opencontainers.image.title=custom-nginx-rock', 'org.opencontainers.image.ref.name=custom-nginx-rock', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2023-04-25T16:45:17.168734+00:00', 'org.opencontainers.image.base.digest=5f6d7e4dad348dbbae3c1e960dcaba98c2e262902c67c9bc41d5f2417cebaeb8']
     Exported to OCI archive 'custom-nginx-rock_latest_amd64.rock'
 
 Then copy the resulting ROCK (from the OCI archive format) to the Docker daemon

--- a/docs/how-to/install-slice.rst
+++ b/docs/how-to/install-slice.rst
@@ -90,7 +90,7 @@ Build your ROCK with:
 The output will be:
 
 ..  code-block:: text
-    :emphasize-lines: 4,6,8,10,12,17
+    :emphasize-lines: 4,6,8,10,12,15
     :class: log-snippets
 
     Launching instance...
@@ -107,8 +107,6 @@ The output will be:
     Executed: prime build-context
     Executed: prime pebble
     Executed parts lifecycle
-    Created new layer
-    Labels and annotations set to ['org.opencontainers.image.version=0.0.1', 'org.opencontainers.image.title=custom-openssl-rock', 'org.opencontainers.image.ref.name=custom-openssl-rock', 'org.opencontainers.image.licenses=GPL-3.0', 'org.opencontainers.image.created=2022-11-25T14:00:47.470814+00:00', 'org.opencontainers.image.base.digest=c4d1cae85485fb5bf8483a440f7e47b0fd2592ff114117cd4763604fbf6ae7a4']
     Exported to OCI archive 'custom-openssl-rock_0.0.1_amd64.rock'
 
 Test that the OpenSSL binaries have been correctly installed with the following:

--- a/docs/tutorials/chisel.rst
+++ b/docs/tutorials/chisel.rst
@@ -57,7 +57,7 @@ To build the ROCK, run:
 The output will look similar to:
 
 ..  code-block:: text
-    :emphasize-lines: 15
+    :emphasize-lines: 10
     :class: log-snippets
 
     Launching instance...
@@ -69,11 +69,6 @@ The output will look similar to:
     Executed: stage openssl
     Executed: prime openssl
     Executed parts lifecycle
-    Created new layer
-    Entrypoint set to ['/usr/bin/openssl']
-    Cmd set to []
-    Environment set to ['SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt']
-    Labels and annotations set to ['org.opencontainers.image.version=0.0.1', 'org.opencontainers.image.title=chisel-openssl', 'org.opencontainers.image.ref.name=chisel-openssl', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2022-09-30T17:57:57.070040+00:00', 'org.opencontainers.image.base.digest=719e29cbdf81d2c046598c274ae82bdcdfe7bf819058a0f304c57858b633d801']
     Exported to OCI archive 'chisel-openssl_0.0.1_amd64.rock'
 
 The process might take a little while, but at the end, a new file named

--- a/docs/tutorials/hello-world.rst
+++ b/docs/tutorials/hello-world.rst
@@ -68,9 +68,6 @@ The output should look as follows:
     Executed: prime hello
     Executed: prime pebble
     Executed parts lifecycle
-    Created new layer
-    Entrypoint set to ['/bin/pebble', 'enter', '--verbose']
-    Labels and annotations set to ['org.opencontainers.image.version=1.0', 'org.opencontainers.image.title=hello', 'org.opencontainers.image.ref.name=hello', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2023-07-13T14:55:46.049188+00:00', 'org.opencontainers.image.base.digest=93532f6b4812679c429e7415f60fc2260b070ffb744ec65298e65770e14bbe8d']
     Exported to OCI archive 'hello_1.0_amd64.rock'
 
 At the end of the process, a file named ``hello_1.0_amd64.rock`` should be

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,9 +17,9 @@ colorama==0.4.6
 commonmark==0.9.1
 coverage==6.5.0
 craft-archives==1.1.0
-craft-cli==2.0.1
-craft-parts==1.23.0
-craft-providers==1.8.0
+craft-cli==2.1.0
+craft-parts==1.24.1
+craft-providers==1.15.0
 cryptography==38.0.4
 Deprecated==1.2.14
 dill==0.3.7
@@ -63,8 +63,8 @@ polib==1.1.1
 psutil==5.9.5
 pycodestyle==2.8.0
 pycparser==2.21
-pydantic==1.9.0
-pydantic-yaml==0.8.1
+pydantic==1.10.0
+pydantic-yaml==0.11.2
 pydocstyle==6.1.1
 pyflakes==2.4.0
 Pygments==2.13.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -5,9 +5,9 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.0
-craft-cli==2.0.1
-craft-parts==1.23.0
-craft-providers==1.8.0
+craft-cli==2.1.0
+craft-parts==1.24.1
+craft-providers==1.15.0
 Deprecated==1.2.14
 distro==1.8.0
 docutils==0.17.1
@@ -29,8 +29,8 @@ packaging==22.0
 platformdirs==2.6.2
 polib==1.1.1
 psutil==5.9.5
-pydantic==1.9.0
-pydantic-yaml==0.8.1
+pydantic==1.10.0
+pydantic-yaml==0.11.2
 Pygments==2.13.0
 pyparsing==3.0.9
 pytz==2022.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ certifi==2022.12.7
 charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.0
-craft-cli==2.0.1
-craft-parts==1.23.0
-craft-providers==1.8.0
+craft-cli==2.1.0
+craft-parts==1.24.1
+craft-providers==1.15.0
 Deprecated==1.2.14
 distro==1.8.0
 docutils==0.17.1
@@ -27,8 +27,8 @@ overrides==7.3.1
 packaging==22.0
 platformdirs==2.6.2
 polib==1.1.1
-pydantic==1.9.0
-pydantic-yaml==0.8.1
+pydantic==1.10.0
+pydantic-yaml==0.11.2
 Pygments==2.13.0
 pytz==2022.6
 pyxdg==0.28

--- a/rockcraft/cli.py
+++ b/rockcraft/cli.py
@@ -99,6 +99,7 @@ def run() -> None:
         appname="rockcraft",
         greeting=f"Starting Rockcraft {__version__}",
         log_filepath=log_filepath,
+        streaming_brief=True,
     )
 
     dispatcher = craft_cli.Dispatcher(

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -181,7 +181,7 @@ def _pack(
         new_layer_dir=lifecycle.prime_dir,
         base_layer_dir=base_layer_dir,
     )
-    emit.progress("Created new layer", permanent=True)
+    emit.progress("Created new layer")
 
     if project.run_user:
         emit.progress(f"Creating new user {project.run_user}")

--- a/rockcraft/lifecycle.py
+++ b/rockcraft/lifecycle.py
@@ -278,7 +278,6 @@ def run_in_provider(
         project_name=project.name,
         project_path=host_project_path,
         base_configuration=base_configuration,
-        build_base=build_base.value,
         instance_name=instance_name,
     ) as instance:
         try:

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -334,7 +334,7 @@ class Image:
         image_path = self.path / self.image_name
         params = ["--clear=config.entrypoint", "--config.user", user]
         _config_image(image_path, params)
-        emit.progress(f"Default user set to {user}", permanent=True)
+        emit.progress(f"Default user set to {user}")
 
     def set_entrypoint(self) -> None:
         """Set the OCI image entrypoint. It is always Pebble and CMD is null."""
@@ -347,7 +347,7 @@ class Image:
         _config_image(image_path, params)
         # Clear the CMD
         _config_image(image_path, ["--clear=config.cmd"])
-        emit.progress(f"Entrypoint set to {entrypoint}", permanent=True)
+        emit.progress(f"Entrypoint set to {entrypoint}")
 
     def set_pebble_layer(
         self,
@@ -411,7 +411,7 @@ class Image:
             env_list.append(env_item)
             params.extend(["--config.env", env_item])
         _config_image(image_path, params)
-        emit.progress(f"Environment set to {env_list}", permanent=True)
+        emit.progress(f"Environment set to {env_list}")
 
     def set_control_data(self, metadata: Dict[str, Any]) -> None:
         """Create and populate the ROCK's control data folder.
@@ -462,7 +462,7 @@ class Image:
         _config_image(image_path, label_params)
         # Set the annotations as a copy of these labels (for OCI compliance only)
         _config_image(image_path, annotation_params)
-        emit.progress(f"Labels and annotations set to {labels_list}", permanent=True)
+        emit.progress(f"Labels and annotations set to {labels_list}")
 
 
 def _copy_image(

--- a/rockcraft/providers.py
+++ b/rockcraft/providers.py
@@ -24,6 +24,7 @@ from typing import Dict, Optional
 
 from craft_cli import emit
 from craft_providers import Provider, ProviderError, bases, executor
+from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
@@ -113,7 +114,7 @@ def get_base_configuration(
         environment=get_command_environment(),
         hostname=instance_name,
         snaps=[
-            bases.buildd.Snap(
+            Snap(
                 name="rockcraft",
                 channel=snap_channel,
                 classic=True,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,6 +16,7 @@
 
 import contextlib
 from pathlib import Path
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -48,6 +49,14 @@ def fake_provider(mock_instance):
     class FakeProvider(Provider):
         """Fake provider."""
 
+        @property
+        def name(self) -> str:
+            return "fake"
+
+        @property
+        def install_recommendation(self) -> str:
+            return "uninstallable"
+
         def clean_project_environments(self, *, instance_name: str):
             pass
 
@@ -69,8 +78,9 @@ def fake_provider(mock_instance):
             project_name: str,
             project_path: Path,
             base_configuration: base.Base,
-            build_base: str,
+            build_base: Optional[str] = None,
             instance_name: str,
+            allow_unstable: bool = False,
         ):
             yield mock_instance
 

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -20,7 +20,7 @@ from unittest.mock import Mock, call
 
 import pytest
 from craft_cli import EmitterMode, emit
-from craft_providers.bases.buildd import BuilddBaseAlias
+from craft_providers.bases import BuilddBaseAlias
 
 import tests
 from rockcraft import lifecycle
@@ -401,7 +401,6 @@ def test_lifecycle_run_in_provider(
         project_name="test-name",
         project_path=cwd,
         base_configuration=mock_base_configuration,
-        build_base=provider_base.value,
         instance_name="test-instance-name",
     )
     mock_instance.mount.assert_called_once_with(

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, Mock, call
 
 import pytest
 from craft_providers import ProviderError, bases
+from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
@@ -152,11 +153,7 @@ def test_get_base_configuration(
         compatibility_tag="rockcraft-buildd-base-v0.0",
         environment="test-env",
         hostname="test-instance-name",
-        snaps=[
-            bases.buildd.Snap(
-                name="rockcraft", channel=expected_snap_channel, classic=True
-            )
-        ],
+        snaps=[Snap(name="rockcraft", channel=expected_snap_channel, classic=True)],
         packages=["gpg", "dirmngr"],
     )
 


### PR DESCRIPTION
This PR does three things:

1) Bump versions of craft-parts, craft-providers and craft-cli;
2) Enables the "streaming brief" feature in craft-cli's Emitter, which makes it so that "info"-level messages get "streamed" inline with the current "progress" message when in Brief mode;
3) Cleans up some permanent progress messages related to packing the rock, so that the output in Brief mode is cleaner and more succint.

Here's a gif of the end result:

![streaming-brief-rockcraft](https://github.com/canonical/rockcraft/assets/1951299/8160dbc2-1e42-4e5f-be38-a6f07632e514)

Fixes #345 
