### PR TITLE
fix(ci): correct conditional for snap publication

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -32,9 +32,9 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]
           then
-            echo "branch::pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"            
+            echo "branch=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"            
           else
-            echo "branch::${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
+            echo "branch=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish feature branch to edge/${{ steps.vars.outputs.branch }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Publish feature branch to edge/${{ steps.vars.outputs.branch }}
-        if: SNAPCRAFT_STORE_CREDENTIALS != ''
+        if: ${{ env.SNAPCRAFT_STORE_CREDENTIALS != '' }}
         uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -43,5 +43,5 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ steps.build-rockcraft.outputs.snap }}
           release: edge/${{ steps.vars.outputs.branch }}


### PR DESCRIPTION
The workflow is not valid. .github/workflows/snap.yaml (Line: 41, Col:
13): Unrecognized named-value: 'SNAPCRAFT_STORE_CREDENTIALS'. Located
at position 1 within expression: SNAPCRAFT_STORE_CREDENTIALS != ''

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
