### PR TITLE
build(deps): bump craft-parts from 1.24.1 to 1.25.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ commonmark==0.9.1
 coverage==6.5.0
 craft-archives==1.1.3
 craft-cli==2.1.0
-craft-parts==1.24.1
+craft-parts==1.25.1
 craft-providers==1.16.0
 cryptography==38.0.4
 Deprecated==1.2.14

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.3
 craft-cli==2.1.0
-craft-parts==1.24.1
+craft-parts==1.25.1
 craft-providers==1.16.0
 Deprecated==1.2.14
 distro==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.1.1
 colorama==0.4.6
 craft-archives==1.1.3
 craft-cli==2.1.0
-craft-parts==1.24.1
+craft-parts==1.25.1
 craft-providers==1.16.0
 Deprecated==1.2.14
 distro==1.8.0


### PR DESCRIPTION
Craft Parts 1.25.1 adds numerous improvements to the Rust plugin.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
