### PR TITLE
Provide a default prime in the flask extension

### DIFF
--- a/docs/how-to/use-flask-extension.rst
+++ b/docs/how-to/use-flask-extension.rst
@@ -23,7 +23,7 @@ Managing project files with the flask extension
 -----------------------------------------------
 
 By default the flask extension only includes the ``app.py``, ``static``,
-and ``templates`` in the flask project. But you can overwrite this behavior
+and ``templates`` in the flask project. But you can overwrite this behaviour
 with a prime declaration in the specially-named ``flask/install-app``
 part to instruct the flask extension on which files to include or exclude
 from the project directory in the ROCK image.

--- a/docs/how-to/use-flask-extension.rst
+++ b/docs/how-to/use-flask-extension.rst
@@ -22,9 +22,9 @@ Example:
 Managing project files with the flask extension
 -----------------------------------------------
 
-By default the flask extension only includes the ``app.py``, ``static``,
-and ``templates`` in the flask project. But you can overwrite this behaviour
-with a prime declaration in the specially-named ``flask/install-app``
+By default the flask extension only includes the ``app.py``, ``static/``,
+``app/``, and ``templates/`` in the flask project. But you can overwrite this
+behaviour with a prime declaration in the specially-named ``flask/install-app``
 part to instruct the flask extension on which files to include or exclude
 from the project directory in the ROCK image.
 

--- a/docs/how-to/use-flask-extension.rst
+++ b/docs/how-to/use-flask-extension.rst
@@ -1,8 +1,8 @@
-Using the flask extension
--------------------------
+Using the flask-framework extension
+-----------------------------------
 
-The Flask extension is compatible with the ``bare``, ``ubuntu:20.04``, and
-``ubuntu:22.04`` bases. To employ it, include ``extensions: [flask]`` in your
+The Flask extension is compatible with the ``bare`` and ``ubuntu:22.04`` bases.
+To employ it, include ``extensions: [ flask-framework ]`` in your
 ``rockcraft.yaml`` file.
 
 Example:
@@ -17,21 +17,17 @@ Example:
     license: Apache-2.0
 
     extensions:
-      - flask
-
-    flask/install-app:
-      prime:
-        - -flask/app/.git
-        - -flask/app/.venv
-        - -flask/app/.yarn
-        - -flask/app/node_modules
+      - flask-framework
 
 Managing project files with the flask extension
 -----------------------------------------------
 
-The prime declaration must be included in the specially-named
-``flask/install-app`` section to instruct the flask extension on which files
-to include or exclude from the project directory in the ROCK image.
+By default the flask extension only includes the ``app.py``, ``static``,
+and ``templates`` in the flask project. But you can overwrite this behavior
+with a prime declaration in the specially-named ``flask/install-app``
+part to instruct the flask extension on which files to include or exclude
+from the project directory in the ROCK image.
+
 The extension places the files from the project folder in the ``/flask/app``
 directory in the final image - therefore, all inclusions and exclusions must
 be prefixed with ``flask/app``.
@@ -44,7 +40,7 @@ For example, to include only select files:
       prime:
         - flask/app/static
         - flask/app/.env
-        - flask/app/webapp
+        - flask/app/app.py
         - flask/app/templates
 
 To exclude certain files from the project directory in the rock image,

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -6,8 +6,8 @@ Rockcraft extensions are crafted to expand and modify the user-provided
 rockcraft project file, aiming to minimise the boilerplate code when
 initiating a new rock.
 
-The ``flask`` extension
------------------------
+The ``flask-framework`` extension
+---------------------------------
 
 The Flask extension streamlines the process of building Flask application rocks.
 

--- a/rockcraft/extensions/flask_framework.py
+++ b/rockcraft/extensions/flask_framework.py
@@ -193,9 +193,9 @@ class FlaskFramework(Extension):
             ),
             install_app_part_name: {
                 "prime": [
-                    "flask/app/app.py",
-                    "flask/app/static",
-                    "flask/app/templates",
+                    f"flask/app/{f}"
+                    for f in ("app", "app.py", "static", "templates")
+                    if (self.project_root / f).exists()
                 ],
                 **self._merge_existing_part(install_app_part_name, install_app_part),
             },

--- a/rockcraft/extensions/flask_framework.py
+++ b/rockcraft/extensions/flask_framework.py
@@ -161,19 +161,12 @@ class FlaskFramework(Extension):
         }
         install_app_part_name = "flask/install-app"
         dependencies_part_name = "flask/dependencies"
-
-        if install_app_part_name not in self.yaml_data.get("parts", {}):
-            raise ExtensionError(
-                "flask extension required flask/install-app not found "
-                "in parts of the rockcraft file"
-            )
-        install_prime = self.yaml_data["parts"][install_app_part_name].get("prime")
-        if not install_prime:
-            raise ExtensionError(
-                "flask extension required prime list not found or empty"
-                "in the flask/install-app part of the rockcraft file"
-            )
-        if not all(re.match("-? *flask/app", p) for p in install_prime):
+        user_prime = (
+            self.yaml_data.get("parts", {})
+            .get(install_app_part_name, {})
+            .get("prime", [])
+        )
+        if not all(re.match("-? *flask/app", p) for p in user_prime):
             raise ExtensionError(
                 "flask extension required prime entry in the flask/install-app part"
                 "to start with flask/app"
@@ -198,15 +191,21 @@ class FlaskFramework(Extension):
             dependencies_part_name: self._merge_existing_part(
                 dependencies_part_name, dependencies_part
             ),
-            install_app_part_name: self._merge_existing_part(
-                install_app_part_name, install_app_part
-            ),
+            install_app_part_name: {
+                "prime": [
+                    "flask/app/app.py",
+                    "flask/app/static",
+                    "flask/app/templates",
+                ],
+                **self._merge_existing_part(install_app_part_name, install_app_part),
+            },
         }
         if self.yaml_data["base"] == "bare":
             snippet["flask/container-processing"] = {
                 "plugin": "nil",
                 "source": ".",
                 "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp",
+                "stage-packages": ["bash_bins", "coreutils_bins"],
             }
         return snippet
 

--- a/tests/unit/extensions/test_flask_framework.py
+++ b/tests/unit/extensions/test_flask_framework.py
@@ -58,7 +58,6 @@ def test_flask_extension_default(tmp_path, input_yaml):
                 "prime": [
                     "flask/app/app.py",
                     "flask/app/static",
-                    "flask/app/templates",
                 ],
                 "source": ".",
                 "stage": [

--- a/tests/unit/extensions/test_flask_framework.py
+++ b/tests/unit/extensions/test_flask_framework.py
@@ -32,6 +32,57 @@ def input_yaml_fixture():
 
 
 @pytest.mark.usefixtures("flask_extension")
+def test_flask_extension_default(tmp_path, input_yaml):
+    (tmp_path / "requirements.txt").write_text("flask")
+    (tmp_path / "app.py").write_text("app = object()")
+    (tmp_path / "static").mkdir()
+    (tmp_path / "node_modules").mkdir()
+    applied = extensions.apply_extensions(tmp_path, input_yaml)
+    assert applied == {
+        "base": "ubuntu:22.04",
+        "parts": {
+            "flask/dependencies": {
+                "plugin": "python",
+                "python-packages": ["gunicorn"],
+                "python-requirements": ["requirements.txt"],
+                "source": ".",
+                "stage-packages": ["python3-venv"],
+            },
+            "flask/install-app": {
+                "organize": {
+                    "app.py": "flask/app/app.py",
+                    "requirements.txt": "flask/app/requirements.txt",
+                    "static": "flask/app/static",
+                },
+                "plugin": "dump",
+                "prime": [
+                    "flask/app/app.py",
+                    "flask/app/static",
+                    "flask/app/templates",
+                ],
+                "source": ".",
+                "stage": [
+                    "flask/app/app.py",
+                    "flask/app/requirements.txt",
+                    "flask/app/static",
+                ],
+            },
+        },
+        "platforms": {"amd64": {}},
+        "run_user": "_daemon_",
+        "services": {
+            "flask": {
+                "command": "/bin/python3 -m gunicorn --bind "
+                "0.0.0.0:8000 --chdir /flask/app app:app",
+                "override": "replace",
+                "startup": "enabled",
+                "user": "_daemon_",
+            }
+        },
+    }
+
+
+@pytest.mark.usefixtures("flask_extension")
 def test_flask_extension(tmp_path, input_yaml):
     (tmp_path / "requirements.txt").write_text("flask")
     (tmp_path / "app.py").write_text("app = object()")
@@ -149,6 +200,7 @@ def test_flask_extension_bare(tmp_path):
         "plugin": "nil",
         "source": ".",
         "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp",
+        "stage-packages": ["bash_bins", "coreutils_bins"],
     }
     assert applied["build-base"] == "ubuntu:22.04"
 
@@ -159,45 +211,6 @@ def test_flask_extension_no_requirements_txt_error(tmp_path):
     with pytest.raises(ExtensionError) as exc:
         extensions.apply_extensions(tmp_path, input_yaml)
     assert "requirements.txt" in str(exc)
-
-
-@pytest.mark.usefixtures("flask_extension")
-def test_flask_extension_no_install_app_part_error(tmp_path):
-    input_yaml = {"extensions": ["flask-framework"], "base": "bare"}
-
-    (tmp_path / "requirements.txt").write_text("flask")
-
-    with pytest.raises(ExtensionError) as exc:
-        extensions.apply_extensions(tmp_path, input_yaml)
-    assert "flask/install-app" in str(exc)
-
-
-@pytest.mark.usefixtures("flask_extension")
-def test_flask_extension_no_install_app_prime_error(tmp_path):
-    input_yaml = {
-        "extensions": ["flask-framework"],
-        "base": "bare",
-        "parts": {"flask/install-app": {}},
-    }
-    (tmp_path / "requirements.txt").write_text("flask")
-
-    with pytest.raises(ExtensionError) as exc:
-        extensions.apply_extensions(tmp_path, input_yaml)
-    assert "flask/install-app" in str(exc)
-
-
-@pytest.mark.usefixtures("flask_extension")
-def test_flask_extension_empty_install_app_prime_error(tmp_path):
-    input_yaml = {
-        "extensions": ["flask-framework"],
-        "base": "bare",
-        "parts": {"flask/install-app": {"prime": []}},
-    }
-    (tmp_path / "requirements.txt").write_text("flask")
-
-    with pytest.raises(ExtensionError) as exc:
-        extensions.apply_extensions(tmp_path, input_yaml)
-    assert "flask/install-app" in str(exc)
 
 
 @pytest.mark.usefixtures("flask_extension")


### PR DESCRIPTION
Provide a default prime list in the Flask extension for users' project files unless they supply their own.

If the user provides a prime list, it will replace the default one.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
