### PR TITLE
chore: drop ubuntu 20.04 and python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
           sudo apt install -y libapt-pkg-dev aspell aspell-en
       - name: Install python packages and dependencies
         run: |
-          pip install -U -r requirements-focal.txt -r requirements.txt -r requirements-dev.txt
+          pip install -U -r requirements-jammy.txt -r requirements.txt -r requirements-dev.txt
       - name: Run black
         run: |
           make test-black
@@ -63,8 +63,8 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2019]
-        python-version: [3.8, 3.9, "3.10"]
+        os: [ubuntu-22.04, windows-2019]
+        python-version: ["3.10", "3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -84,15 +84,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-setuptools python3-wheel python3-venv libapt-pkg-dev
-      - name: Install Ubuntu 20.04-specific dependencies
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-        run: |
-          pip install -U -r requirements-focal.txt
       - name: Install Ubuntu 22.04-specific dependencies
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
-          # Same python-apt requirement as 20.04
-          pip install -U -r requirements-focal.txt
+          pip install -U -r requirements-jammy.txt
           # 22.04 is the only one that has an 'umoci' package
           sudo apt install -y umoci
       - name: Install dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
   jobs:
     post_checkout:
       - git submodule update --init -- docs/sphinx-starter-pack

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ help:
 install:
 	@echo "... setting up virtualenv"
 	python3 -m venv env
-	. $(VENV); pip install --upgrade -r ../requirements-doc.txt -r ../requirements-focal.txt
+	. $(VENV); pip install --upgrade -r ../requirements-doc.txt -r ../requirements-jammy.txt
 
 run:
 	. $(VENV); sphinx-autobuild --ignore ".git/*" --ignore "*.scss"  -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --host 0.0.0.0 --port $(PORT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ extend-exclude = "docs/sphinx-starter-pack"
 ignore = ["docs/sphinx-starter-pack"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 exclude = [
     "build",
     "results",

--- a/requirements-bionic.txt
+++ b/requirements-bionic.txt
@@ -1,1 +1,0 @@
-https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/1.6.6/python-apt_1.6.6.tar.xz; sys_platform == 'linux'

--- a/requirements-focal.txt
+++ b/requirements-focal.txt
@@ -1,1 +1,0 @@
-https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.0.1ubuntu0.20.04.1/python-apt_2.0.1ubuntu0.20.04.1.tar.xz; sys_platform == 'linux'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,10 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.10
 include_package_data = True
 packages = find:
 zip_safe = False

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,7 +11,7 @@ include:
     - tools/
     - docs/
     - requirements-doc.txt
-    - requirements-focal.txt
+    - requirements-jammy.txt
     - Makefile
     - rockcraft/
 


### PR DESCRIPTION
This commit bumps the minimum required Python version to 3.10. Note that the application can still build ubuntu:20.04 images, this is about the code of the application itself.

Also add 3.12 testing on CI since that'll be the new standard version in ubuntu 24.04.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
