### PR TITLE
style: change spelling for updated codespell

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -93,7 +93,7 @@ restore-each: |
   docker system prune -a -f
   if lxc project info rockcraft > /dev/null 2>&1 ; then
     for instance in $(lxc --project=rockcraft list -c n --format csv); do
-      # Don't remove the base instance, we want to re-use it between tests
+      # Don't remove the base instance, we want to reuse it between tests
       if ! [[ $instance =~ ^base-instance-rockcraft* ]]; then
         lxc --project=rockcraft delete --force "$instance"
       fi


### PR DESCRIPTION
"re-use" is a [perfectly valid spelling](https://en.wiktionary.org/wiki/re-use), but this is easier than changing codespell settings every time we disagree with it

Fixes the codespell issue in #388 


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
