### PR TITLE
build(deps): bump craft-parts from 1.25.1 to 1.25.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ colorama==0.4.6
 coverage==7.3.2
 craft-archives==1.1.3
 craft-cli==2.1.0
-craft-parts==1.25.1
+craft-parts==1.25.2
 craft-providers==1.18.0
 cryptography==41.0.4
 Deprecated==1.2.14

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,7 +7,7 @@ charset-normalizer==3.2.0
 colorama==0.4.6
 craft-archives==1.1.3
 craft-cli==2.1.0
-craft-parts==1.25.1
+craft-parts==1.25.2
 craft-providers==1.18.0
 Deprecated==1.2.14
 distro==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2023.7.22
 charset-normalizer==3.2.0
 craft-archives==1.1.3
 craft-cli==2.1.0
-craft-parts==1.25.1
+craft-parts==1.25.2
 craft-providers==1.18.0
 Deprecated==1.2.14
 distro==1.8.0


### PR DESCRIPTION
Craft Parts 1.25.2 fixes channel overrides in the Rust plugin,
validates part dependency names, and fixes environment variable
expansion.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
