### PR TITLE
build: set version from git

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,14 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libapt-pkg-dev aspell aspell-en
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install python packages and dependencies
         run: |
-          pip install -U -r requirements-jammy.txt -r requirements.txt -r requirements-dev.txt
+          pip install -U wheel -r requirements-jammy.txt -r requirements.txt -r requirements-dev.txt
+          pip install -e .
       - name: Run black
         run: |
           make test-black

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ docs/reference/commands
 .DS_Store
 __pycache__
 .idea/
+
+# build-generated version file
+rockcraft/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,27 @@
+[build-system]
+requires = [
+    "setuptools==67.7.2",
+    "setuptools_scm[toml]>=7.1"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "rockcraft/_version.py"
+# the version comes from the latest annotated git tag formatted as 'X.Y.Z'
+# version scheme:
+#   - X.Y.Z.post<commits since tag>+g<hash>.d<%Y%m%d>
+# parts of scheme:
+#   - X.Y.Z - most recent git tag
+#   - post<commits since tag>+g<hash> - present when current commit is not tagged
+#   - .d<%Y%m%d> - present when working dir is dirty
+# version scheme when no tags exist:
+#   - 0.0.post<total commits>+g<hash>
+version_scheme = "post-release"
+# deviations from the default 'git describe' command:
+# - only match annotated tags
+# - only match tags formatted as 'X.Y.Z'
+git_describe_command = "git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'"
+
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
@@ -58,6 +82,9 @@ extension-pkg-whitelist = [
     "pydantic"
 ]
 load-plugins = "pylint_pytest"
+ignore-paths = [
+  "rockcraft/_version.py"
+]
 
 [tool.ruff]
 line-length = 88
@@ -66,6 +93,7 @@ src = ["rockcraft", "tests"]
 extend-exclude = [
     "docs",
     "__pycache__",
+    "rockcraft/_version.py"
 ]
 # Follow ST063 - Maintaining and updating linting specifications for updating these.
 select = [  # Base linting rule selections.

--- a/rockcraft/__init__.py
+++ b/rockcraft/__init__.py
@@ -16,9 +16,12 @@
 
 """The craft tool to create ROCKs."""
 
-from craft_parts import Features
+try:
+    from ._version import __version__
+except ImportError:  # pragma: no cover
+    from importlib.metadata import PackageNotFoundError, version
 
-__version__ = "0.0.1.dev1"
-
-
-Features(enable_overlay=True)
+    try:
+        __version__ = version("rockcraft")
+    except PackageNotFoundError:
+        __version__ = "dev"

--- a/rockcraft/services/lifecycle.py
+++ b/rockcraft/services/lifecycle.py
@@ -25,11 +25,14 @@ from typing import cast
 from craft_application import LifecycleService
 from craft_archives import repo
 from craft_cli import emit
-from craft_parts import callbacks
+from craft_parts import Features, callbacks
 from craft_parts.errors import CallbackRegistrationError
 from overrides import override
 
 from rockcraft.models.project import Project
+
+# Enable the craft-parts features that we use
+Features(enable_overlay=True)
 
 
 class RockcraftLifecycleService(LifecycleService):

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = rockcraft
 version = attr: rockcraft.__version__
 description="Create ROCKS"
-long_description = file: README.md
+long_description = file: README.rst
 url = https://github.com/canonical/rockcraft
 project_urls =
     Documentation = https://rockcraft.readthedocs.io/en/latest/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,7 @@ summary: A craft like experience to create ROCKS
 description: |
     Rockcraft aims to take the same primitives used in Charmcraft and Snapcraft
     to create OCI images.
+adopt-info: rockcraft
 confinement: classic
 grade: devel
 license: GPL-3.0
@@ -69,6 +70,9 @@ parts:
         bin/craftctl: libexec/rockcraft/craftctl
     override-build: |
       ${SNAP}/libexec/snapcraft/craftctl default
+
+      version="$(python3 setup.py --version)"
+      ${SNAP}/libexec/snapcraft/craftctl set version="$version"
   
       sed -i -e '1 s|^#!/.*|#!/snap/rockcraft/current/bin/python -E|' $CRAFT_PART_INSTALL/bin/craftctl
     after:


### PR DESCRIPTION
This commit pulls in the "dynamic" version setting (from git) from Starbase, and updates snapcraft.yaml to use that version (via adopt-info).

A consequence of this is that, in order to be able to run "python3 setup.py --version" without the dependencies installed, the enabling of the overlay feature is moved from ``rockcraft/__init__.py`` to the lifecycle service, which makes more sense any way as it's a feature specific to that service.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
