### PR TITLE
build(deps): bump craft-providers to 1.19.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ craft-application==1.0.0
 craft-archives==1.1.3
 craft-cli==2.4.0
 craft-parts==1.25.2
-craft-providers==1.19.0
+craft-providers==1.19.2
 cryptography==41.0.5
 Deprecated==1.2.14
 dill==0.3.7

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -9,7 +9,7 @@ craft-application==1.0.0
 craft-archives==1.1.3
 craft-cli==2.4.0
 craft-parts==1.25.2
-craft-providers==1.19.0
+craft-providers==1.19.2
 Deprecated==1.2.14
 distro==1.8.0
 docutils==0.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ craft-application==1.0.0
 craft-archives==1.1.3
 craft-cli==2.4.0
 craft-parts==1.25.2
-craft-providers==1.19.0
+craft-providers==1.19.2
 Deprecated==1.2.14
 distro==1.8.0
 httplib2==0.22.0


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

### Changelog

#### 1.19.2 (2023-11-02)
- Update base compatibility tag from ``base-v2`` to ``base-v3``
  This fixes an issue where LXD instances created with
  ``craft-providers==1.16.0`` may fail to start with
  ``craft-providers>=1.17.0``.

#### 1.19.1 (2023-10-26)
- Require a disk device in the default LXD profile