### PR TITLE
chore(deps): bump craft-providers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ craft-application==1.0.0
 craft-archives==1.1.3
 craft-cli==2.4.0
 craft-parts==1.25.2
-craft-providers==1.19.2
+craft-providers==1.19.2 # bump this
 Deprecated==1.2.14
 distro==1.8.0
 httplib2==0.22.0


### PR DESCRIPTION
This new version fixes the ack failure in 'account'

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
