### PR TITLE
chore(deps): update craft-providers to 1.19.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ coverage==6.5.0
 craft-archives==1.1.3
 craft-cli==2.1.0
 craft-parts==1.24.1
-craft-providers==1.16.0
+craft-providers==1.19.2
 cryptography==38.0.4
 Deprecated==1.2.14
 dill==0.3.7

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,7 +7,7 @@ colorama==0.4.6
 craft-archives==1.1.3
 craft-cli==2.1.0
 craft-parts==1.24.1
-craft-providers==1.16.0
+craft-providers==1.19.2
 Deprecated==1.2.14
 distro==1.8.0
 docutils==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ colorama==0.4.6
 craft-archives==1.1.3
 craft-cli==2.1.0
 craft-parts==1.24.1
-craft-providers==1.16.0
+craft-providers==1.19.2
 Deprecated==1.2.14
 distro==1.8.0
 docutils==0.17.1


### PR DESCRIPTION
The current version has two bugs (the "looping timer" one and the "not collecting error logs" one) that are blocking for many users. Ideally we should merge main into this branch, this is a stopgap before we can allocate time for it.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
