### PR TITLE
chore(deps): bump craft-cli

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ colorama==0.4.6
 coverage==7.3.2
 craft-application==1.0.0
 craft-archives==1.1.3
-craft-cli==2.4.0
+craft-cli==2.5.0
 craft-parts==1.25.2
 craft-providers==1.19.2
 cryptography==41.0.5

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,7 +7,7 @@ charset-normalizer==3.3.1
 colorama==0.4.6
 craft-application==1.0.0
 craft-archives==1.1.3
-craft-cli==2.4.0
+craft-cli==2.5.0
 craft-parts==1.25.2
 craft-providers==1.19.2
 Deprecated==1.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2023.7.22
 charset-normalizer==3.3.1
 craft-application==1.0.0
 craft-archives==1.1.3
-craft-cli==2.4.0
+craft-cli==2.5.0
 craft-parts==1.25.2
 craft-providers==1.19.2
 Deprecated==1.2.14

--- a/rockcraft/services/lifecycle.py
+++ b/rockcraft/services/lifecycle.py
@@ -90,7 +90,7 @@ def _install_package_repositories(package_repositories, lifecycle_manager) -> No
         emit.progress("Refreshing repositories")
         lifecycle_manager.refresh_packages_list()
 
-    emit.progress("Package repositories installed", permanent=True)
+    emit.progress("Package repositories installed")
 
 
 def _install_overlay_repositories(overlay_dir, project_info):

--- a/rockcraft/services/package.py
+++ b/rockcraft/services/package.py
@@ -200,6 +200,6 @@ def _pack(
     emit.progress("Exporting to OCI archive")
     archive_name = f"{project.name}_{project.version}_{rock_suffix}.rock"
     new_image.to_oci_archive(tag=project.version, filename=archive_name)
-    emit.progress(f"Exported to OCI archive '{archive_name}'", permanent=True)
+    emit.progress(f"Exported to OCI archive '{archive_name}'")
 
     return archive_name


### PR DESCRIPTION
Version 2.5.0 clears the "streaming brief" progress when calling emit.message() and emit.error(). Also cleanup some wrongly-permanent progress messages, to keep brief verbosity clean.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
