### PR TITLE
feat: prune primed files if they exist on the base

### DIFF
--- a/tests/spread/general/prune/check_layers.py
+++ b/tests/spread/general/prune/check_layers.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+
+def _get_tar_contents(sha):
+    """Get a mapping (filename -> TarInfo) for the layer identified by ``sha``."""
+    if ":" in sha:
+        sha = sha[sha.find(":") + 1 :]
+
+    layers_dir = Path("blobs/sha256")
+    filename = layers_dir / sha
+
+    contents = {}
+    with tarfile.open(filename) as tar:
+        # Filter only the regular files, as that's all we prune.
+        members = tar.getmembers()
+        for member in members:
+            if member.isfile():
+                contents[member.name] = member
+
+    return contents
+
+
+def _get_stats(tarinfo):
+    """Get size, permission bits, owner and group from a TarInfo."""
+    return tarinfo.size, tarinfo.mode, tarinfo.uid, tarinfo.gid
+
+
+rock_name = sys.argv[1]
+
+inspect = subprocess.check_output(
+    ["/snap/rockcraft/current/bin/skopeo", "inspect", f"oci-archive:{rock_name}"]
+)
+as_json = json.loads(inspect)
+
+base_layer_sha = as_json["Layers"][0]
+base_layer_contents = _get_tar_contents(base_layer_sha)
+
+lifecycle_layer_sha = as_json["Layers"][1]
+lifecycle_contents = _get_tar_contents(lifecycle_layer_sha)
+
+duplicates = set(base_layer_contents).intersection(lifecycle_contents)
+
+for duplicate in duplicates:
+    base_tarinfo = base_layer_contents[duplicate]
+    base_stats = _get_stats(base_tarinfo)
+
+    lifecycle_tarinfo = lifecycle_contents[duplicate]
+    lifecycle_stats = _get_stats(lifecycle_tarinfo)
+
+    # If the filename is present in both layers then it's expected that the size,
+    # or ownership, or permissions, are different.
+    assert base_stats != lifecycle_stats, f"File {duplicate} is the same in both layers"

--- a/tests/spread/general/prune/rockcraft.yaml
+++ b/tests/spread/general/prune/rockcraft.yaml
@@ -1,0 +1,15 @@
+name: prune-prime
+version: latest
+summary: Check that the lifecycle layer has no duplicated files from the base
+description: Check that the lifecycle layer has no duplicated files from the base
+license: Apache-2.0
+base: ubuntu@20.04
+
+platforms:
+  amd64:
+
+parts:
+  pruned:
+    plugin: nil
+    stage-packages:
+      - python3-venv

--- a/tests/spread/general/prune/task.yaml
+++ b/tests/spread/general/prune/task.yaml
@@ -1,0 +1,15 @@
+summary: check that the lifecycle layer has no duplicated files from the base
+
+execute: |
+  run_rockcraft pack
+
+  test -f ./*.rock
+  
+  # Unpack the ROCK and verify that the lifecycle-based layer has no files in
+  # common with the base Ubuntu layer.
+  tar -xf ./*.rock
+  python3 check_layers.py ./*.rock
+
+restore: |
+  rm -f ./*.rock
+  rm -rf blobs/

--- a/tests/testing/lifecycle.py
+++ b/tests/testing/lifecycle.py
@@ -31,6 +31,7 @@ def run_mocked_lifecycle(
     work_dir: pathlib.Path,
     mocker,
     base_layer_dir: pathlib.Path | None = None,
+    step: str = "stage",
 ) -> RockcraftLifecycleService:
     """Run a project's lifecycle with a mocked base image."""
 
@@ -56,6 +57,6 @@ def run_mocked_lifecycle(
     mocker.patch.object(factory.image, "obtain_image", return_value=image_info)
 
     lifecycle_service = factory.lifecycle
-    lifecycle_service.run("stage")
+    lifecycle_service.run(step)
 
     return cast(RockcraftLifecycleService, lifecycle_service)

--- a/tests/testing/project.py
+++ b/tests/testing/project.py
@@ -19,11 +19,11 @@ from rockcraft.models import Project
 
 def create_project(**kwargs) -> Project:
     """Utility function to create test Projects with defaults."""
-    base = kwargs.get("base", "ubuntu:22.04")
+    base = kwargs.get("base", "ubuntu@22.04")
 
     build_base = kwargs.get("build_base")
     if not build_base:
-        build_base = base if base != "bare" else "ubuntu:22.04"
+        build_base = base if base != "bare" else "ubuntu@22.04"
 
     return Project.unmarshal(
         {

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -55,6 +55,7 @@ def test_lifecycle_args(lifecycle_service, default_factory, default_image_info, 
         project_name="default",
         project_vars={"version": "1.0"},
         work_dir=Path("work"),
+        rootfs_dir=Path("."),
     )
 
 


### PR DESCRIPTION
**Note** The first commit is from PR #416 and doesn't need to be reviewed here

------------

This commit adds a lifecycle callback that "prunes" (removes) those
primed files that already exist (with same contents and permissions) in
the base layer. This is necessary because the dependency resolver
doesn't look into the base layer when deciding dependency cutoffs (and
also to support chisel slices, which only look at the target install
dir). Some notes:

1) This first implementation only looks are regular files (no symlinks
and directories), as those are the simplest to handle and provide the
biggest size "wins". If necessary, we can address symlinks and/or
directories in follow-up work.
2) This could have been implemented during the archiving of the new
layer, where we already loop on the files and look at the base layer (to
handle things like the usrmerge). We decided to implement this as part
of the lifecycle to improve the "clarity" and "debuggability" of
Rockcraft runs: after running the lifecycle, the prime directory
contains exactly what's going to be packed in the new layer.

The resulting ROCK should be "semantically" equivalent, but smaller. For
instance, the Pyfiglet ROCK in docs/tutorials/code/pyfiglet goes from
69MB to 53MB, with no functional changes.

Fixes #363
