### PR TITLE
chore(docs): match doc page titles with their respective titles in toc

### DIFF
--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -1,5 +1,5 @@
 ************************************************
-How to contribute to the Rockcraft documentation
+How to contribute to Rockcraft documentation
 ************************************************
 
 Tools and markup

--- a/docs/how-to/convert-to-pebble-layer.rst
+++ b/docs/how-to/convert-to-pebble-layer.rst
@@ -1,5 +1,5 @@
-How to convert a popular entrypoint to a Pebble layer
-*****************************************************
+How to convert an entrypoint to a Pebble layer
+***********************************************
 
 This guide will show you how to take an existing Docker image entrypoint
 and convert it into a Pebble layer, aka the list of one or more services

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,12 +14,12 @@ adapt the steps to fit your specific requirements.
    :maxdepth: 1
 
    Get started - quick guide <get-started>
-   Build a ROCK with GitHub Action <rockcraft-pack-action>
+   Use GitHub Action to ROCK <rockcraft-pack-action>
    Contribute to Rockcraft documentation <contribute-docs>
    Build the documentation <build-docs>
-   Use Chisel to cut existing slices <use-chisel>
+   Cut existing slices with Chisel <use-chisel>
    Create a package slice for Chisel <create-slice>
    Install a custom package slice <install-slice>
-   Publish a slice definitions <publish-slice>
+   Publish a slice definition <publish-slice>
    Convert an entrypoint to a Pebble layer <convert-to-pebble-layer>
    Publish a ROCK to a registry <publish-a-rock.rst>

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,12 +14,12 @@ adapt the steps to fit your specific requirements.
    :maxdepth: 1
 
    Get started - quick guide <get-started>
-   Use the GitHub Action <rockcraft-pack-action>
+   Build a ROCK with GitHub Action <rockcraft-pack-action>
+   Contribute to Rockcraft documentation <contribute-docs>
    Build the documentation <build-docs>
+   Use Chisel to cut existing slices <use-chisel>
    Create a package slice for Chisel <create-slice>
    Install a custom package slice <install-slice>
-   Release a slice definitions file <publish-slice>
-   Convert an entrypoint to a Pebble layer <convert-to-pebble-layer.rst>
-   contribute-docs
-   use-chisel
-   Publish a ROCK <publish-a-rock.rst>
+   Publish a slice definitions <publish-slice>
+   Convert an entrypoint to a Pebble layer <convert-to-pebble-layer>
+   Publish a ROCK to a registry <publish-a-rock.rst>

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,7 +14,7 @@ adapt the steps to fit your specific requirements.
    :maxdepth: 1
 
    Get started - quick guide <get-started>
-   Use GitHub Action to ROCK <rockcraft-pack-action>
+   Use Rockcraft's GitHub Action <rockcraft-pack-action>
    Contribute to Rockcraft documentation <contribute-docs>
    Build the documentation <build-docs>
    Cut existing slices with Chisel <use-chisel>

--- a/docs/how-to/install-slice.rst
+++ b/docs/how-to/install-slice.rst
@@ -1,4 +1,4 @@
-How to install your own package slice
+How to install a custom package slice
 *************************************
 
 When a specific package slice is not available on the `upstream Chisel

--- a/docs/how-to/publish-slice.rst
+++ b/docs/how-to/publish-slice.rst
@@ -1,7 +1,7 @@
 .. _publishslice:
 
 How to publish a slice definition
-**********************************
+*********************************
 
 At this stage, you have created some package slice definitions and you have a
 custom Chisel release in your local development environment. You have also

--- a/docs/how-to/publish-slice.rst
+++ b/docs/how-to/publish-slice.rst
@@ -1,7 +1,7 @@
 .. _publishslice:
 
-How to make custom slice definitions available for everyone
-***********************************************************
+How to publish a slice definition
+**********************************
 
 At this stage, you have created some package slice definitions and you have a
 custom Chisel release in your local development environment. You have also

--- a/docs/how-to/rockcraft-pack-action.rst
+++ b/docs/how-to/rockcraft-pack-action.rst
@@ -1,5 +1,5 @@
-How to build a ROCK with Rockcraft's GitHub Action
-**************************************************
+How to Use GitHub Action to ROCK
+********************************
 
 Within your GitHub repository, make sure you have
 `GitHub Actions enabled <https://docs.github.com/en/actions/quickstart>`_.

--- a/docs/how-to/rockcraft-pack-action.rst
+++ b/docs/how-to/rockcraft-pack-action.rst
@@ -1,5 +1,5 @@
-How to Use GitHub Action to ROCK
-********************************
+How to use Rockcraft's GitHub Action
+************************************
 
 Within your GitHub repository, make sure you have
 `GitHub Actions enabled <https://docs.github.com/en/actions/quickstart>`_.

--- a/docs/how-to/use-chisel.rst
+++ b/docs/how-to/use-chisel.rst
@@ -1,7 +1,7 @@
 .. _how_to_use_chisel:
 
-How to use Chisel
------------------
+How to use Chisel to cut existing slices
+-----------------------------------------
 
 Chisel has been integrated with Rockcraft in a way that it becomes seamless to
 users. Packages and slices can be both installed via the ``stage-packages``

--- a/docs/how-to/use-chisel.rst
+++ b/docs/how-to/use-chisel.rst
@@ -1,7 +1,7 @@
 .. _how_to_use_chisel:
 
-How to use Chisel to cut existing slices
------------------------------------------
+Cut existing slices with Chisel
+-------------------------------
 
 Chisel has been integrated with Rockcraft in a way that it becomes seamless to
 users. Packages and slices can be both installed via the ``stage-packages``

--- a/docs/tutorials/chisel.rst
+++ b/docs/tutorials/chisel.rst
@@ -1,5 +1,5 @@
-Install chiselled slices into a ROCK
-====================================
+Put Chisel slices in a ROCK
+===========================
 
 In this tutorial, you will create a lean ROCK that contains a fully functional
 OpenSSL installation, and you will verify that it is functional by loading the

--- a/docs/tutorials/chisel.rst
+++ b/docs/tutorials/chisel.rst
@@ -1,5 +1,5 @@
-Put Chisel slices in a ROCK
-===========================
+Install slices in a ROCK
+========================
 
 In this tutorial, you will create a lean ROCK that contains a fully functional
 OpenSSL installation, and you will verify that it is functional by loading the

--- a/docs/tutorials/chisel.rst
+++ b/docs/tutorials/chisel.rst
@@ -1,5 +1,5 @@
-Install packages slices into a ROCK
-===================================
+Install chiselled slices into a ROCK
+====================================
 
 In this tutorial, you will create a lean ROCK that contains a fully functional
 OpenSSL installation, and you will verify that it is functional by loading the

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -12,6 +12,6 @@ reproducible steps.
 
    1. Create a Hello World ROCK <hello-world>
    2. Containerise a PyPI package <pypi-package.rst>
-   3. Put Chisel slices in a ROCK <chisel.rst>
+   3. Install slices in a ROCK <chisel.rst>
    4. Bundle a Node.js app within a ROCK <node-app.rst>
    5. Migrate a Docker image to a chiselled ROCK <migrate-to-chiselled-rock.rst>

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -10,8 +10,8 @@ reproducible steps.
 .. toctree::
    :maxdepth: 1
 
-   1. Hello world <hello-world>
-   2. Containerise a PyPI package <pypi-package.rst>
-   3. Chisel packages into a ROCK <chisel.rst>
-   4. Bundle a Node.js app into a ROCK <node-app.rst>
+   1. Create a "Hello World" ROCK <hello-world>
+   2. Create a ROCK for a PyPI package <pypi-package.rst>
+   3. Install chiselled packages into a ROCK <chisel.rst>
+   4. Bundle a Node.js app within a ROCK <node-app.rst>
    5. Migrate a Docker image to a Chiselled ROCK <migrate-to-chiselled-rock.rst>

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -10,8 +10,8 @@ reproducible steps.
 .. toctree::
    :maxdepth: 1
 
-   1. Create a "Hello World" ROCK <hello-world>
-   2. Create a ROCK for a PyPI package <pypi-package.rst>
-   3. Install chiselled packages into a ROCK <chisel.rst>
+   1. Create a Hello World ROCK <hello-world>
+   2. Containerise a PyPI package <pypi-package.rst>
+   3. Put Chisel slices in a ROCK <chisel.rst>
    4. Bundle a Node.js app within a ROCK <node-app.rst>
-   5. Migrate a Docker image to a Chiselled ROCK <migrate-to-chiselled-rock.rst>
+   5. Migrate a Docker image to a chiselled ROCK <migrate-to-chiselled-rock.rst>

--- a/docs/tutorials/migrate-to-chiselled-rock.rst
+++ b/docs/tutorials/migrate-to-chiselled-rock.rst
@@ -1,4 +1,4 @@
-Migrate a popular Docker image to a Chiselled ROCK
+Migrate a popular Docker image to a chiselled ROCK
 **************************************************
 
 Prerequisites

--- a/docs/tutorials/node-app.rst
+++ b/docs/tutorials/node-app.rst
@@ -1,5 +1,5 @@
-Bundle a Node.js app into a ROCK
-********************************
+Bundle a Node.js app within a ROCK
+***********************************
 
 This tutorial describes the steps needed to bundle a typical Node.js application
 into a ROCK.

--- a/docs/tutorials/pypi-package.rst
+++ b/docs/tutorials/pypi-package.rst
@@ -1,4 +1,4 @@
-Create a ROCK from a PyPI package
+Create a ROCK for a PyPI package
 *********************************
 
 By the end of this tutorial you will be able to run pyfiglet via docker:

--- a/docs/tutorials/pypi-package.rst
+++ b/docs/tutorials/pypi-package.rst
@@ -1,5 +1,5 @@
-Create a ROCK for a PyPI package
-*********************************
+Containerise a PyPI package
+***************************
 
 By the end of this tutorial you will be able to run pyfiglet via docker:
 


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

I changed the doc page titles, in tutorials and how-to guides, in order to match them with their respective titles in table of contents.