### PR TITLE
feat(docs): add definition for overlay_step in the docs

### DIFF
--- a/docs/explanation/overlay-step.rst
+++ b/docs/explanation/overlay-step.rst
@@ -8,6 +8,12 @@ The overlay step is specific to ROCKs and is configured with overlay parameters.
 To learn more about pull, build, stage and prime see
 :doc:`/reference/part_properties`
 
+The overlay step provides the means to modify the base filesystem before the
+build step is applied. If ``overlay-packages`` is used, those packages will be
+installed first. ``overlay-script`` will run the provided script in this step.
+The location of the overlay is made available in ${CRAFT_OVERLAY} environment
+variable. ``overlay-files`` can be used to specify which files will be migrated
+to the next steps, and when omitted its default value will be ``"*"``.
 
 .. Include a section about overlay parameters from the Craft Parts documentation.
 .. include:: /common/craft-parts/overlay_parameters.rst

--- a/docs/explanation/overlay-step.rst
+++ b/docs/explanation/overlay-step.rst
@@ -11,9 +11,9 @@ To learn more about pull, build, stage and prime see
 The overlay step provides the means to modify the base filesystem before the
 build step is applied. If ``overlay-packages`` is used, those packages will be
 installed first. ``overlay-script`` will run the provided script in this step.
-The location of the overlay is made available in ${CRAFT_OVERLAY} environment
-variable. ``overlay-files`` can be used to specify which files will be migrated
-to the next steps, and when omitted its default value will be ``"*"``.
+The location of the overlay is made available in the ${CRAFT_OVERLAY}
+environment variable. ``overlay`` can be used to specify which files will be
+migrated to the next steps, and when omitted its default value will be ``"*"``.
 
 .. Include a section about overlay parameters from the Craft Parts documentation.
 .. include:: /common/craft-parts/overlay_parameters.rst


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

I added the missing definition for the overlay-step in explanation docs.

Note that the overlay_parameters common doc mentions `overlay-filters` field, but apparently that's a typo and it should be `overlay-files`. I fixed that in rockcraft docs, but it needs to be fixed in craft-parts docs too.