### PR TITLE
refactor(project): drop ProjectValidationError

### DIFF
--- a/rockcraft/errors.py
+++ b/rockcraft/errors.py
@@ -43,10 +43,6 @@ class ProjectLoadError(RockcraftError):
     """Error loading rockcraft.yaml."""
 
 
-class ProjectValidationError(RockcraftError):
-    """Error validating rockcraft.yaml."""
-
-
 class LayerArchivingError(RockcraftError):
     """Error when creating the archive for the new layer."""
 

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -23,9 +23,8 @@ from typing import Any, Literal
 
 import pydantic
 import yaml
+from craft_application.errors import CraftValidationError
 from craft_cli import emit
-
-from rockcraft.errors import ProjectValidationError
 
 
 class HttpCheck(pydantic.BaseModel):
@@ -110,7 +109,7 @@ class Check(pydantic.BaseModel):
         else:
             return values
 
-        raise ProjectValidationError(err)
+        raise CraftValidationError(err)
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -20,9 +20,9 @@ from pathlib import Path
 import pydantic
 import pytest
 import yaml
+from craft_application.errors import CraftValidationError
 
 import tests
-from rockcraft.models.project import ProjectValidationError
 from rockcraft.pebble import Check, ExecCheck, HttpCheck, Pebble, Service, TcpCheck
 
 
@@ -368,7 +368,7 @@ class TestPebble:
             # Missing check type fields
             (
                 {},
-                ProjectValidationError,
+                CraftValidationError,
                 r"Must specify exactly one of http, tcp, exec for each check.",
             ),
             # Missing mandatory fields
@@ -380,7 +380,7 @@ class TestPebble:
             # Too many check types
             (
                 {"override": "merge", "exec": {"command": "foo"}, "tcp": {"port": 1}},
-                ProjectValidationError,
+                CraftValidationError,
                 r"Multiple check types specified ([\s\S]*). "
                 r"Each check must have exactly one type.",
             ),

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -24,13 +24,14 @@ from typing import Any
 import pydantic
 import pytest
 import yaml
+from craft_application.errors import CraftValidationError
 from craft_application.models import BuildInfo
 from craft_parts import Features
 from craft_providers.bases import BaseName
 
-from rockcraft.errors import ProjectLoadError, ProjectValidationError
-from rockcraft.models import Project, load_project
-from rockcraft.models.project import INVALID_NAME_MESSAGE, Platform
+from rockcraft.errors import ProjectLoadError
+from rockcraft.models import Project
+from rockcraft.models.project import INVALID_NAME_MESSAGE, Platform, load_project
 from rockcraft.pebble import Service
 
 _ARCH_MAPPING = {"x86": "amd64", "x64": "amd64"}
@@ -117,6 +118,10 @@ def pebble_part() -> dict[str, Any]:
     }
 
 
+def load_project_yaml(yaml_loaded_data) -> Project:
+    return Project.from_yaml_data(yaml_loaded_data, Path("rockcraft.yaml"))
+
+
 def test_project_unmarshal(check, yaml_loaded_data):
     project = Project.unmarshal(yaml_loaded_data)
 
@@ -148,7 +153,7 @@ def test_unmarshal_no_repositories(yaml_loaded_data):
 
     project = Project.unmarshal(yaml_loaded_data)
 
-    assert project.package_repositories == []
+    assert project.package_repositories is None
 
 
 def test_unmarshal_undefined_repositories(yaml_loaded_data):
@@ -162,14 +167,14 @@ def test_unmarshal_undefined_repositories(yaml_loaded_data):
 def test_unmarshal_invalid_repositories(yaml_loaded_data):
     yaml_loaded_data["package-repositories"] = [{}]
 
-    with pytest.raises(ProjectValidationError) as error:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as error:
+        load_project_yaml(yaml_loaded_data)
 
     assert error.value.args[0] == (
         "Bad rockcraft.yaml content:\n"
-        "- field 'type' required in 'package-repositories' configuration\n"
-        "- field 'url' required in 'package-repositories' configuration\n"
-        "- field 'key-id' required in 'package-repositories' configuration"
+        "- field type required in package-repositories[0] configuration\n"
+        "- field url required in package-repositories[0] configuration\n"
+        "- field key-id required in package-repositories[0] configuration"
     )
 
 
@@ -179,7 +184,7 @@ def test_unmarshal_invalid_repositories(yaml_loaded_data):
 )
 def test_project_unmarshal_with_unsupported_fields(unsupported_field, yaml_loaded_data):
     loaded_data_with_unsupported_fields = {**yaml_loaded_data, **unsupported_field}
-    with pytest.raises(ProjectValidationError) as err:
+    with pytest.raises(CraftValidationError) as err:
         _ = Project.unmarshal(loaded_data_with_unsupported_fields)
 
     assert (
@@ -198,7 +203,7 @@ def test_forbidden_env_var_interpolation(
     yaml_loaded_data["environment"]["foo"] = variable
 
     if is_forbidden:
-        with pytest.raises(ProjectValidationError) as err:
+        with pytest.raises(CraftValidationError) as err:
             Project.unmarshal(yaml_loaded_data)
             check.equal(
                 str(err.value), f"String interpolation not allowed for: {variable}"
@@ -220,19 +225,19 @@ def test_project_base(yaml_loaded_data, base):
 def test_project_base_invalid(yaml_loaded_data):
     yaml_loaded_data["base"] = "ubuntu@19.04"
 
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        "- unexpected value; permitted: 'bare', 'ubuntu@20.04', 'ubuntu@22.04' in field 'base'"
+        "- unexpected value; permitted: 'bare', 'ubuntu@20.04', 'ubuntu@22.04' (in field 'base')"
     )
 
 
 def test_project_license_invalid(yaml_loaded_data):
     yaml_loaded_data["license"] = "apache 0.x"
 
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         f"License {yaml_loaded_data['license']} not valid. It must be valid and in SPDX format."
     )
@@ -256,15 +261,15 @@ def test_project_title_empty_invalid_name(yaml_loaded_data):
     """Test that an invalid name doesn't break the validation of the title."""
     yaml_loaded_data.pop("title")
     yaml_loaded_data["name"] = "my@rock"
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
     assert "Invalid name for ROCK" in str(err.value)
 
 
 @pytest.mark.parametrize("entrypoint_service", [""])
 def test_project_entrypoint_service_empty(yaml_loaded_data, entrypoint_service):
     yaml_loaded_data["entrypoint-service"] = entrypoint_service
-    with pytest.raises(ProjectValidationError) as err:
+    with pytest.raises(CraftValidationError) as err:
         Project.unmarshal(yaml_loaded_data)
     assert "The provided entrypoint-service '' is not a valid Pebble service." in str(
         err.value
@@ -289,7 +294,7 @@ def test_project_entrypoint_service_valid(
 @pytest.mark.parametrize("entrypoint_service", ["baz"])
 def test_project_entrypoint_service_invalid(yaml_loaded_data, entrypoint_service):
     yaml_loaded_data["entrypoint-service"] = entrypoint_service
-    with pytest.raises(ProjectValidationError) as err:
+    with pytest.raises(CraftValidationError) as err:
         Project.unmarshal(yaml_loaded_data)
     assert (
         "The provided entrypoint-service 'baz' is not a valid Pebble service."
@@ -360,13 +365,13 @@ def test_project_platform_invalid():
     # build-for must be only 1 element (NOTE: this may change)
     mock_platform = {"build-on": ["amd64"], "build-for": ["amd64", "arm64"]}
     assert "multiple target architectures" in load_platform(
-        mock_platform, ProjectValidationError
+        mock_platform, CraftValidationError
     )
 
     # If build_for is provided, then build_on must also be
     mock_platform = {"build-for": ["arm64"]}
     assert "'build_for' expects 'build_on' to also be provided." in load_platform(
-        mock_platform, ProjectValidationError
+        mock_platform, CraftValidationError
     )
 
 
@@ -374,7 +379,7 @@ def test_project_all_platforms_invalid(yaml_loaded_data):
     def reload_project_platforms(new_platforms=None):
         if new_platforms:
             yaml_loaded_data["platforms"] = mock_platforms
-        with pytest.raises(ProjectValidationError) as err:
+        with pytest.raises(CraftValidationError) as err:
             Project.unmarshal(yaml_loaded_data)
 
         return str(err.value)
@@ -421,10 +426,10 @@ def test_project_name_valid(yaml_loaded_data, valid_name):
 def test_project_name_invalid(yaml_loaded_data, invalid_name):
     yaml_loaded_data["name"] = invalid_name
 
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
 
-    expected_message = f"{INVALID_NAME_MESSAGE} in field 'name'"
+    expected_message = f"{INVALID_NAME_MESSAGE} (in field 'name')"
     assert expected_message in str(err.value)
 
 
@@ -434,33 +439,33 @@ def test_project_name_invalid(yaml_loaded_data, invalid_name):
 def test_project_missing_field(yaml_loaded_data, field):
     del yaml_loaded_data[field]
 
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        f"- field '{field}' required in top-level configuration"
+        f"- field {field} required in top-level configuration"
     )
 
 
 def test_project_extra_field(yaml_loaded_data):
     yaml_loaded_data["extra"] = "invalid"
 
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        "- extra field 'extra' not permitted in top-level configuration"
+        "- extra field extra not permitted in top-level configuration"
     )
 
 
 def test_project_parts_validation(yaml_loaded_data):
     yaml_loaded_data["parts"]["foo"]["invalid"] = True
 
-    with pytest.raises(ProjectValidationError) as err:
-        Project.unmarshal(yaml_loaded_data)
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        "- extra field 'invalid' not permitted in 'parts.foo' configuration"
+        "- extra field invalid not permitted in parts.foo configuration"
     )
 
 
@@ -480,7 +485,7 @@ def test_project_bare_overlay(yaml_loaded_data, packages, script):
     foo_part["overlay-packages"] = packages
     foo_part["overlay-script"] = script
 
-    with pytest.raises(ProjectValidationError) as err:
+    with pytest.raises(CraftValidationError) as err:
         Project.unmarshal(yaml_loaded_data)
     assert str(err.value) == (
         'Overlays cannot be used with "bare" bases (there is no system to overlay).'
@@ -535,8 +540,8 @@ def test_project_unmarshal_existing_pebble(tmp_path):
         encoding="utf-8",
     )
 
-    with pytest.raises(ProjectValidationError):
-        Project.unmarshal(load_project(rockcraft_file))
+    with pytest.raises(CraftValidationError):
+        load_project(rockcraft_file)
 
 
 def test_project_load_error():

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -25,6 +25,7 @@ import pydantic
 import pytest
 import yaml
 from craft_application.models import BuildInfo
+from craft_parts import Features
 from craft_providers.bases import BaseName
 
 from rockcraft.errors import ProjectLoadError, ProjectValidationError
@@ -85,6 +86,13 @@ parts:
 
 entrypoint-service: test-service
 """
+
+
+@pytest.fixture(autouse=True)
+def enable_overlay_feature():
+    """Enable the overlay feature to make this test module standalone."""
+    Features.reset()
+    Features(enable_overlay=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Drop rockcraft's ProjectValidationError in favour of craft-application's
CraftValidationError. This lets us remove a bunch of duplicated code
related to formatting the errors and aligns us more closely with
upstream.
