### PR TITLE
fix: use correct error message for invalid version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.3.2
-craft-application==1.1.0
+craft-application==1.2.0
 craft-archives==1.1.3
 craft-cli==2.5.0
 craft-parts==1.26.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -5,7 +5,7 @@ bracex==2.4
 certifi==2023.7.22
 charset-normalizer==3.3.1
 colorama==0.4.6
-craft-application==1.1.0
+craft-application==1.2.0
 craft-archives==1.1.3
 craft-cli==2.5.0
 craft-parts==1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2023.7.22
 charset-normalizer==3.3.1
-craft-application==1.1.0
+craft-application==1.2.0
 craft-archives==1.1.3
 craft-cli==2.5.0
 craft-parts==1.26.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,8 @@ warn_untyped_fields = True
 # D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
 # D215 Section underline is over-indented (reason: pep257 default)
 ignore = D105, D107, D203, D213, D215
+# Allow missing docstrings in methods that are overridden
+ignore_decorators = override
 
 [aliases]
 test = pytest

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -433,6 +433,23 @@ def test_project_name_invalid(yaml_loaded_data, invalid_name):
     assert expected_message in str(err.value)
 
 
+def test_project_version_invalid(yaml_loaded_data):
+    yaml_loaded_data["version"] = "invalid_version"
+
+    with pytest.raises(CraftValidationError) as err:
+        load_project_yaml(yaml_loaded_data)
+
+    # We don't want to be completely tied to the formatting of the message here,
+    # because it comes from craft-application and might change slightly. We just
+    # want to ensure that the message refers to the version.
+    expected_contents = "Invalid version: Valid versions consist of"
+    expected_suffix = "(in field 'version')"
+
+    message = str(err.value)
+    assert expected_contents in message
+    assert message.endswith(expected_suffix)
+
+
 @pytest.mark.parametrize(
     "field", ["name", "version", "base", "parts", "description", "summary", "license"]
 )

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -172,9 +172,9 @@ def test_unmarshal_invalid_repositories(yaml_loaded_data):
 
     assert error.value.args[0] == (
         "Bad rockcraft.yaml content:\n"
-        "- field type required in package-repositories[0] configuration\n"
-        "- field url required in package-repositories[0] configuration\n"
-        "- field key-id required in package-repositories[0] configuration"
+        "- field 'type' required in 'package-repositories[0]' configuration\n"
+        "- field 'url' required in 'package-repositories[0]' configuration\n"
+        "- field 'key-id' required in 'package-repositories[0]' configuration"
     )
 
 
@@ -443,7 +443,7 @@ def test_project_missing_field(yaml_loaded_data, field):
         load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        f"- field {field} required in top-level configuration"
+        f"- field '{field}' required in top-level configuration"
     )
 
 
@@ -454,7 +454,7 @@ def test_project_extra_field(yaml_loaded_data):
         load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        "- extra field extra not permitted in top-level configuration"
+        "- extra field 'extra' not permitted in top-level configuration"
     )
 
 
@@ -465,7 +465,7 @@ def test_project_parts_validation(yaml_loaded_data):
         load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
         "Bad rockcraft.yaml content:\n"
-        "- extra field invalid not permitted in parts.foo configuration"
+        "- extra field 'invalid' not permitted in 'parts.foo' configuration"
     )
 
 


### PR DESCRIPTION
**Note:** The first commit bumps craft-application 1.2.0 and fixes a couple of expected messages in tests. I couldn't split this into two PRs because two of the tests (related to name validation) can only pass with the second commit.

-------------

The code refers to the 'name' message, but the bug was due to the
"error_msg_templates" in the Config: it made *every* regex validation
failure use the INVALID_NAME_MESSAGE message, even for those fields that
*aren't* the 'name'.

Since the "error_msg_templates" option is deprecated and gone in
Pydantic 2 anyway, remove it altogether and use the new
transform_pydantic_errors() hook from craft-application to preserve the
customisation of the 'name' field's message. This is necessary because
our 'name' regex is different than the 'name' regex in
craft-application's model (ours is a bit stricter), so we can just use
craft-application's message as that would be misleading.

Fixes #429