### PR TITLE
mock out call to `shutil.which` 

### DIFF
--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -520,8 +520,13 @@ class TestImage:
             "subprocess.check_output",
             return_value="000102030405060708090a0b0c0d0e0f",
         )
+        mock_skopeo = mocker.patch(
+            "shutil.which",
+            return_value="/usr/bin/skopeo",
+        )
 
         digest = image.digest(source_image)
+        assert mock_skopeo.mock_calls == [call("skopeo")]
         assert mock_output.mock_calls == [
             call(
                 [


### PR DESCRIPTION

rather than expecting scopeo to be locally installed, mock out the call in unit tests

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

