### PR TITLE
chore(chisel): update Chisel to v0.8.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -117,12 +117,6 @@ parts:
         - pkg-config
 
   chisel:
-    plugin: go
-    source: https://github.com/canonical/chisel.git
-    source-tag: v0.8.1
-    build-environment:
-      - CGO: "0"
-      - CGO_ENABLED: "0"
-      - GOBIN: "${CRAFT_PART_INSTALL}/libexec/rockcraft"
-    build-snaps:
-      - go/1.20/stable
+    plugin: nil
+    stage-snaps:
+      - chisel/latest/candidate

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,5 +120,7 @@ parts:
     plugin: nil
     stage-snaps:
       - chisel/latest/candidate
+    organize: 
+      bin/chisel: libexec/rockcraft/chisel
     stage:
-      - bin/chisel
+      - libexec/rockcraft/chisel

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,3 +120,5 @@ parts:
     plugin: nil
     stage-snaps:
       - chisel/latest/candidate
+    stage:
+      - bin/chisel

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -119,10 +119,10 @@ parts:
   chisel:
     plugin: go
     source: https://github.com/canonical/chisel.git
-    source-commit: bd27f8700cd7d2a6b4e0df6b10c3761c83a70485
+    source-tag: v0.8.1
     build-environment:
       - CGO: "0"
       - CGO_ENABLED: "0"
       - GOBIN: "${CRAFT_PART_INSTALL}/libexec/rockcraft"
     build-snaps:
-      - go/1.18/stable
+      - go/1.20/stable


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

In preparation for a coming backward incompatible Chisel release, this PR is updating the Chisel version to a patch release that will allow for a longer grace migration period.