### PR TITLE
fix(spread): tests must also use newer Chisel

### DIFF
--- a/docs/how-to/code/create-slice/task.yaml
+++ b/docs/how-to/code/create-slice/task.yaml
@@ -1,8 +1,8 @@
 ###########################################
 # IMPORTANT
 # Comments matter!
-# The docs use the wrapping comments as 
-# markers for including said instructions 
+# The docs use the wrapping comments as
+# markers for including said instructions
 # as snippets in the docs.
 ###########################################
 summary: test the "Create a package slice for Chisel" guide
@@ -12,6 +12,9 @@ execute: |
   apt show openssl
   # [docs:apt-show-openssl-end]
 
+  # Both the local chisel-releases and root path must be in $HOME for the 
+  # chisel snap to be able to access them.
+  pushd $HOME
   git clone -b ubuntu-22.04 https://github.com/canonical/chisel-releases
   cp openssl.yaml chisel-releases/slices
 
@@ -19,6 +22,6 @@ execute: |
 
   mkdir out
 
-  chisel cut --release ./chisel-releases --root ./out openssl_bins
+  chisel cut --release chisel-releases --root out openssl_bins
 
   rm -fr chisel-releases/ out/

--- a/docs/how-to/code/create-slice/task.yaml
+++ b/docs/how-to/code/create-slice/task.yaml
@@ -14,14 +14,19 @@ execute: |
 
   # Both the local chisel-releases and root path must be in $HOME for the 
   # chisel snap to be able to access them.
-  pushd $HOME
-  git clone -b ubuntu-22.04 https://github.com/canonical/chisel-releases
-  cp openssl.yaml chisel-releases/slices
+  local_release="${HOME}/chisel-releases_create-slice"
+  local_root="${HOME}/out_create-slice"
+  rm -fr "${local_release}" "${local_root}"
+
+  git clone -b ubuntu-22.04 https://github.com/canonical/chisel-releases \
+    "${local_release}"
+  mkdir "${local_root}"
+
+  cp openssl.yaml "${local_release}/slices"
 
   snap install chisel --channel=latest/candidate
 
-  mkdir out
+  chisel cut --release "${local_release}" --root "${local_root}" openssl_bins
 
-  chisel cut --release chisel-releases --root out openssl_bins
-
-  rm -fr chisel-releases/ out/
+restore: |
+  rm -fr "${HOME}/*_create-slice"

--- a/docs/how-to/code/create-slice/task.yaml
+++ b/docs/how-to/code/create-slice/task.yaml
@@ -12,17 +12,13 @@ execute: |
   apt show openssl
   # [docs:apt-show-openssl-end]
 
-  git clone https://github.com/canonical/chisel
   git clone -b ubuntu-22.04 https://github.com/canonical/chisel-releases
   cp openssl.yaml chisel-releases/slices
 
-  pushd chisel
-  git reset --hard f0bff5a30dfdcb400b3c4efe85962ad8ff3ca2ba
-  go build ./cmd/chisel
-  popd
+  snap install chisel --channel=latest/candidate
 
   mkdir out
 
-  ./chisel/chisel cut --release ./chisel-releases --root ./out openssl_bins
+  chisel cut --release ./chisel-releases --root ./out openssl_bins
 
-  rm -fr chisel-releases/ chisel/ out/
+  rm -fr chisel-releases/ out/

--- a/docs/how-to/code/install-slice/task.yaml
+++ b/docs/how-to/code/install-slice/task.yaml
@@ -17,12 +17,7 @@ execute: |
   grep -q "bins" chisel-releases/slices/openssl.yaml && echo "My slice exists"
   # [docs:slice-exists-end]
 
-  git clone https://github.com/canonical/chisel
-  pushd chisel
-  git reset --hard f0bff5a30dfdcb400b3c4efe85962ad8ff3ca2ba
-  go build ./cmd/chisel
-  mv chisel /bin/chisel
-  popd
+  sudo snap install chisel --channel=latest/candidate
 
   # [docs:cut]
   # Testing with Chisel directly:
@@ -46,7 +41,7 @@ execute: |
   sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:custom-openssl-rock_0.0.1_amd64.rock docker-daemon:chisel-openssl:latest
   # [docs:skopeo-copy-end]
 
-  rm -fr chisel/ chisel-releases/ my-custom-openssl-fs/ custom-openssl-rock_0.0.1_amd64.rock
+  rm -fr chisel-releases/ my-custom-openssl-fs/ custom-openssl-rock_0.0.1_amd64.rock
 
   # [docs:docker-run]
   docker run --rm chisel-openssl exec openssl

--- a/docs/how-to/code/install-slice/task.yaml
+++ b/docs/how-to/code/install-slice/task.yaml
@@ -1,13 +1,17 @@
 ###########################################
 # IMPORTANT
 # Comments matter!
-# The docs use the wrapping comments as 
-# markers for including said instructions 
+# The docs use the wrapping comments as
+# markers for including said instructions
 # as snippets in the docs.
 ###########################################
 summary: test the "Install a custom package slice" guide
 
 execute: |
+  # Both the local chisel-releases and root path must be in $HOME for the 
+  # chisel snap to be able to access them.
+  pushd $HOME
+
   # [docs:clone-chisel-releases]
   # Let's assume we are working with Ubuntu 22.04
   git clone -b ubuntu-22.04 https://github.com/canonical/chisel-releases/

--- a/docs/how-to/code/install-slice/task.yaml
+++ b/docs/how-to/code/install-slice/task.yaml
@@ -10,7 +10,9 @@ summary: test the "Install a custom package slice" guide
 execute: |
   # Both the local chisel-releases and root path must be in $HOME for the 
   # chisel snap to be able to access them.
+  mv rockcraft.yaml "${HOME}/rockcraft.yaml.backup"
   pushd $HOME
+  rm -fr chisel-releases/ my-custom-openssl-fs/
 
   # [docs:clone-chisel-releases]
   # Let's assume we are working with Ubuntu 22.04
@@ -29,8 +31,6 @@ execute: |
   chisel cut --release ./chisel-releases --root my-custom-openssl-fs openssl_bins
   # [docs:cut-end]
 
-  mv rockcraft.yaml rockcraft.yaml.backup
-
   # [docs:init]
   rockcraft init
   # [docs:init-end]
@@ -45,8 +45,11 @@ execute: |
   sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:custom-openssl-rock_0.0.1_amd64.rock docker-daemon:chisel-openssl:latest
   # [docs:skopeo-copy-end]
 
-  rm -fr chisel-releases/ my-custom-openssl-fs/ custom-openssl-rock_0.0.1_amd64.rock
-
   # [docs:docker-run]
   docker run --rm chisel-openssl exec openssl
   # [docs:docker-run-end]
+
+restore: |
+  pushd $HOME
+  rm -fr chisel-releases/ my-custom-openssl-fs/ custom-openssl-rock_0.0.1_amd64.rock
+


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

After https://github.com/canonical/chisel-releases/pull/78, the spread tests are now also failing because the building of the Chisel tool was still being done manually, from a hardcoded commit.

This PR changes the failing spread tasks such that Chisel is also installed from the snap store.

Fixes the tests for https://github.com/canonical/rockcraft/pull/455#issuecomment-1890672106.