### PR TITLE
feat: support ubuntu@24.04 devel rocks

### DIFF
--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -70,7 +70,7 @@ The rock version, used to tag the OCI image and name the rock file.
 ``base``
 --------
 
-**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | bare``
+**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | ubuntu@24.04 | bare``
 
 **Required**: Yes
 
@@ -84,10 +84,14 @@ which is typically used with static binaries or
    The notation "ubuntu:<channel>" is also supported for some channels, but this
    format is deprecated and should be avoided.
 
+.. note::
+   Base ``ubuntu@24.04`` is still unstable and under active development. To use
+   it, ``build-base`` *must* be ``devel``.
+
 ``build-base``
 --------------
 
-**Type**: One of ``ubuntu@20.04 | ubuntu@22.04``
+**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | devel``
 
 **Required**: Yes, if ``base`` is ``bare``
 
@@ -100,6 +104,11 @@ the value of ``base``.
 .. note::
    The notation "ubuntu:<channel>" is also supported for some channels, but this
    format is deprecated and should be avoided.
+
+.. note::
+   ``devel`` is a "special" value that means "the next Ubuntu version, currently
+   in development". This means that the contents of this system changes
+   frequently and should not be relied on for production rocks.
 
 ``license``
 -----------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.21.0
+craft-providers==1.22.0
 cryptography==41.0.7
 Deprecated==1.2.14
 dill==0.3.7

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -9,7 +9,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.21.0
+craft-providers==1.22.0
 Deprecated==1.2.14
 distro==1.9.0
 docutils==0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.21.0
+craft-providers==1.22.0
 Deprecated==1.2.14
 distro==1.9.0
 httplib2==0.22.0

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -117,6 +117,14 @@ INVALID_NAME_MESSAGE = (
 
 DEPRECATED_COLON_BASES = ["ubuntu:20.04", "ubuntu:22.04"]
 
+CURRENT_DEVEL_BASE = "ubuntu@24.04"
+
+DEVEL_BASE_WARNING = (
+    "The development build-base should only be used for testing purposes, "
+    "as its contents are bound to change with the opening of new Ubuntu releases, "
+    "suddenly and without warning."
+)
+
 
 class NameStr(pydantic.ConstrainedStr):
     """Constrained string type only accepting valid rock names."""
@@ -133,8 +141,8 @@ class Project(YamlModelMixin, BaseProject):
     description: str  # type: ignore[reportIncompatibleVariableOverride]
     rock_license: str = pydantic.Field(alias="license")
     platforms: dict[str, Any]
-    base: Literal["bare", "ubuntu@20.04", "ubuntu@22.04"]
-    build_base: Literal["ubuntu@20.04", "ubuntu@22.04"] | None
+    base: Literal["bare", "ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"]
+    build_base: Literal["ubuntu@20.04", "ubuntu@22.04", "devel"] | None
     environment: dict[str, str] | None
     run_user: _RunUser
     services: dict[str, Service] | None
@@ -154,7 +162,12 @@ class Project(YamlModelMixin, BaseProject):
     def effective_base(self) -> bases.BaseName:
         """Get the Base name for craft-providers."""
         base = super().effective_base
-        name, channel = base.split("@")
+
+        if base == "devel":
+            name, channel = "ubuntu", "devel"
+        else:
+            name, channel = base.split("@")
+
         return bases.BaseName(name, channel)
 
     @pydantic.root_validator(pre=True)
@@ -196,6 +209,24 @@ class Project(YamlModelMixin, BaseProject):
         if not title:
             title = values.get("name", "")
         return cast(str, title)
+
+    @pydantic.root_validator(skip_on_failure=True)
+    @classmethod
+    def _validate_devel_base(cls, values: Mapping[str, Any]) -> Mapping[str, Any]:
+        """If 'base' is currently unstable, 'build-base' must be 'devel'."""
+        base = values.get("base")
+        build_base = values.get("build_base")
+
+        if base == CURRENT_DEVEL_BASE and build_base != "devel":
+            raise CraftValidationError(
+                f'To use the unstable base "{CURRENT_DEVEL_BASE}", '
+                '"build-base" must be "devel".'
+            )
+
+        if base == CURRENT_DEVEL_BASE:
+            craft_cli.emit.message(DEVEL_BASE_WARNING)
+
+        return values
 
     @pydantic.validator("build_base", always=True)
     @classmethod

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -457,6 +457,10 @@ class Project(YamlModelMixin, BaseProject):
             "base-digest": base_digest.hex(),
         }
 
+        if self.build_base == "devel":
+            # Annotate that this project was built with a development base.
+            metadata["grade"] = "devel"
+
         annotations = {
             "org.opencontainers.image.version": self.version,
             "org.opencontainers.image.title": self.title,

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -35,7 +35,8 @@
       "enum": [
         "bare",
         "ubuntu@20.04",
-        "ubuntu@22.04"
+        "ubuntu@22.04",
+        "ubuntu@24.04"
       ],
       "type": "string"
     },
@@ -95,7 +96,8 @@
       "title": "Build-Base",
       "enum": [
         "ubuntu@20.04",
-        "ubuntu@22.04"
+        "ubuntu@22.04",
+        "devel"
       ],
       "type": "string"
     },

--- a/tests/integration/plugins/test_python_plugin.py
+++ b/tests/integration/plugins/test_python_plugin.py
@@ -25,7 +25,7 @@ from craft_parts.errors import OsReleaseVersionIdError
 from craft_parts.utils.os_utils import OsRelease
 
 from rockcraft import plugins
-from rockcraft.models.project import Project
+from rockcraft.models.project import CURRENT_DEVEL_BASE, Project
 from rockcraft.plugins.python_plugin import SITECUSTOMIZE_TEMPLATE
 from tests.testing.project import create_project
 from tests.util import ubuntu_only
@@ -60,10 +60,11 @@ def create_python_project(base, extra_part_props=None) -> Project:
         }
     }
 
-    return create_project(
-        base=base,
-        parts=parts,
-    )
+    build_base = None
+    if base == CURRENT_DEVEL_BASE:
+        build_base = "devel"
+
+    return create_project(base=base, parts=parts, build_base=build_base)
 
 
 @dataclass

--- a/tests/spread/general/base-devel/rockcraft.orig.yaml
+++ b/tests/spread/general/base-devel/rockcraft.orig.yaml
@@ -1,0 +1,18 @@
+name: base-devel
+base: placeholder-base
+build-base: devel
+version: '0.1'
+summary: A project using the "devel" build-base
+description: A project using the "devel" build-base
+license: GPL-3.0
+platforms:
+  amd64:
+
+parts:
+  from-chisel-slices:
+    plugin: nil
+    stage-packages: [dotnet-runtime-8.0_libs]
+
+  from-deb:
+    plugin: nil
+    stage-packages: [hello]

--- a/tests/spread/general/base-devel/task.yaml
+++ b/tests/spread/general/base-devel/task.yaml
@@ -1,0 +1,12 @@
+summary: Build rocks using the "devel" build-base
+environment:
+  BASE/base_2404: "ubuntu@24.04"
+  BASE/bare: "bare"
+execute: |
+  # Make sure the yaml file has the "placeholder-base" string, and replace
+  # it with the correct base.
+  grep placeholder-base rockcraft.orig.yaml
+  sed "s/placeholder-base/$BASE/" rockcraft.orig.yaml  > rockcraft.yaml
+
+  # Build the rock & load it into docker
+  run_rockcraft pack

--- a/tests/spread/general/base-devel/task.yaml
+++ b/tests/spread/general/base-devel/task.yaml
@@ -8,5 +8,22 @@ execute: |
   grep placeholder-base rockcraft.orig.yaml
   sed "s/placeholder-base/$BASE/" rockcraft.orig.yaml  > rockcraft.yaml
 
-  # Build the rock & load it into docker
+  # Build the rock
   run_rockcraft pack
+
+  # Extract the built rock and check that the "grade" is "devel" in the metadata
+
+  # Extract the rock into a dir called "devel"
+  mkdir devel
+  tar -xvf base-devel*.rock -C devel
+
+  # Unpack the rootfs into "rootfs"
+  /snap/rockcraft/current/bin/umoci unpack --rootless --image devel:0.1 rootfs
+
+  # Check the grade
+  MATCH "grade: devel" < rootfs/rootfs/.rock/metadata.yaml
+
+restore: |
+  rm -rf devel
+  rm -rf rootfs
+

--- a/tests/spread/general/plugin-python/base-2404/rockcraft.yaml
+++ b/tests/spread/general/plugin-python/base-2404/rockcraft.yaml
@@ -1,0 +1,5 @@
+name: base-2404
+base: ubuntu@24.04
+build-base: devel
+
+# Remaining contents will come from "parts.yaml"

--- a/tests/spread/general/plugin-python/task.yaml
+++ b/tests/spread/general/plugin-python/task.yaml
@@ -2,6 +2,7 @@ summary: Python plugin tests
 environment:
   SCENARIO/base_2004: base-2004
   SCENARIO/base_2204: base-2204
+  SCENARIO/base_2404: base-2404
   SCENARIO/bare_build_2004: bare-build-2004
   SCENARIO/bare_build_2204: bare-build-2204
 execute: |

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -605,6 +605,18 @@ def test_project_generate_metadata(yaml_loaded_data):
     }
 
 
+def test_metadata_base_devel(yaml_loaded_data):
+    yaml_loaded_data["base"] = CURRENT_DEVEL_BASE
+    yaml_loaded_data["build-base"] = "devel"
+    project = Project.unmarshal(yaml_loaded_data)
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    digest = "a1b2c3"  # mock digest
+
+    _, rock_metadata = project.generate_metadata(now, bytes.fromhex(digest))
+    assert rock_metadata["grade"] == "devel"
+
+
 EXPECTED_DUMPED_YAML = f"""\
 name: mytest
 title: My Test


### PR DESCRIPTION
This PR is a prototype/wip implementation of the same support for `devel` bases that Snapcraft has. The gist of it is: to build a noble-based rock, while noble is still in development, one can do:

```
base: ubuntu@24.04
build-base: devel
```

The PR is still in draft and has some failing integration tests but I'm putting it up for two reasons:

1) To add some spread tests to see whether we're able to build noble rocks at all (we are)
2) To have a place to discuss/argue so we can decide on the path forward and support 24.04 sooner rather than later.

So, have at it!