### PR TITLE
Move Permissions definition in rockcraft schema to top scope

### DIFF
--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -617,31 +617,29 @@
           }
         }
       },
-      "additionalProperties": false,
-      "definitions": {
-        "Permissions": {
-          "title": "Permissions",
-          "description": "Description of the ownership and permission settings for a set of files.\n\nA ``Permissions`` object specifies that a given pattern-like ``path`` should\nbe owned by ``owner`` with a given ``group``, and have the read/write/execute\nbits defined by ``mode``.\n\nNotes\n-----\n- ``path`` is optional and defaults to \"everything\";\n- ``owner`` and ``group`` are optional if both are omitted - that is, if\n  one of the pair is specified then both must be;\n- ``mode`` is a string containing an integer in base 8. For example, \"755\",\n  \"0755\" and \"0o755\" are all accepted and are the equivalent of calling\n  ``chmod 755 ...``.",
-          "type": "object",
-          "properties": {
-            "path": {
-              "title": "Path",
-              "default": "*",
-              "type": "string"
-            },
-            "owner": {
-              "title": "Owner",
-              "type": "integer"
-            },
-            "group": {
-              "title": "Group",
-              "type": "integer"
-            },
-            "mode": {
-              "title": "Mode",
-              "type": "string"
-            }
-          }
+      "additionalProperties": false
+    },
+    "Permissions": {
+      "title": "Permissions",
+      "description": "Description of the ownership and permission settings for a set of files.\n\nA ``Permissions`` object specifies that a given pattern-like ``path`` should\nbe owned by ``owner`` with a given ``group``, and have the read/write/execute\nbits defined by ``mode``.\n\nNotes\n-----\n- ``path`` is optional and defaults to \"everything\";\n- ``owner`` and ``group`` are optional if both are omitted - that is, if\n  one of the pair is specified then both must be;\n- ``mode`` is a string containing an integer in base 8. For example, \"755\",\n  \"0755\" and \"0o755\" are all accepted and are the equivalent of calling\n  ``chmod 755 ...``.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "title": "Path",
+          "default": "*",
+          "type": "string"
+        },
+        "owner": {
+          "title": "Owner",
+          "type": "integer"
+        },
+        "group": {
+          "title": "Group",
+          "type": "integer"
+        },
+        "mode": {
+          "title": "Mode",
+          "type": "string"
         }
       }
     }

--- a/tools/schema/schema.py
+++ b/tools/schema/schema.py
@@ -62,6 +62,10 @@ def generate_project_schema() -> str:
         "$ref": "#/definitions/Part"
     }
     project_schema["definitions"]["Part"] = part_schema
+    project_schema["definitions"]["Permissions"] = project_schema["definitions"][
+        "Part"
+    ]["definitions"]["Permissions"]
+    del project_schema["definitions"]["Part"]["definitions"]
 
     return json.dumps(project_schema, indent=2)
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This is to fix an issue in Rockcraft's schema.json, because `Permissions` needs to moved to the top scope `definitions` instead of being located inside `Part`'s definitions.