### PR TITLE
fix(pebble): /var/lib/pebble/default has mode 0777

### DIFF
--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -172,7 +172,11 @@ class Pebble:
         "stage-snaps": ["pebble/latest/stable"],
         "stage": [PEBBLE_BINARY_PATH],
         # We need this because "services" is Optional, but the directory must exist
-        "override-prime": f"craftctl default\nmkdir -p {PEBBLE_LAYERS_PATH}",
+        "override-prime": str(
+            "craftctl default\n"
+            f"mkdir -p {PEBBLE_LAYERS_PATH}\n"
+            f"chmod 777 {PEBBLE_PATH}"
+        ),
     }
 
     def define_pebble_layer(

--- a/tests/spread/general/run-user-minimal/rockcraft.yaml
+++ b/tests/spread/general/run-user-minimal/rockcraft.yaml
@@ -1,0 +1,16 @@
+name: run-user-minimal-test
+version: latest
+summary: A minimal rock with a non-root user
+description: A minimal rock that has a non-root default user
+license: GPL-3.0
+
+base: ubuntu@22.04
+
+platforms:
+    amd64:
+
+run-user: _daemon_
+
+parts:
+    my-part:
+        plugin: nil

--- a/tests/spread/general/run-user-minimal/task.yaml
+++ b/tests/spread/general/run-user-minimal/task.yaml
@@ -1,0 +1,41 @@
+summary: non-root run-user minimal test
+
+execute: |
+  run_rockcraft pack
+
+  test -f run-user-minimal-test_latest_amd64.rock
+  test ! -d work
+
+  # Ensure docker does not have this container image
+  docker rmi --force run-user-minimal-test
+  # Install container
+  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy \
+    oci-archive:run-user-minimal-test_latest_amd64.rock \
+    docker-daemon:run-user-minimal-test:latest
+  # Ensure container exists
+  docker images run-user-minimal-test | MATCH "run-user-minimal-test"
+  docker inspect run-user-minimal-test --format '{{.Config.User}}' | \
+    MATCH "_daemon_"
+
+  # ensure username
+  docker run --rm --entrypoint /bin/sh run-user-minimal-test \
+    -c 'whoami' | MATCH "_daemon_"
+  docker run --rm run-user-minimal-test exec whoami | MATCH "_daemon_"
+
+  # check $HOME = /var/lib/pebble/default for non-root user
+  docker run --rm run-user-minimal-test exec \
+    env | MATCH "HOME=/var/lib/pebble/default"
+  docker run --rm run-user-minimal-test exec \
+    pwd | MATCH "/var/lib/pebble/default"
+
+  # check permission of /var/lib/pebble/default directory
+  docker run --rm run-user-minimal-test exec \
+    stat --format="%a" /var/lib/pebble/default | MATCH "777"
+
+  # check file creation capability of non-root user
+  docker run --rm run-user-minimal-test exec \
+    /bin/sh -c 'touch foo; ls' | MATCH foo
+
+restore: |
+  rm -f run-user-minimal-test_latest_amd64.rock
+  docker rmi -f run-user-minimal-test

--- a/tests/unit/commands/test_expand_extensions.py
+++ b/tests/unit/commands/test_expand_extensions.py
@@ -51,6 +51,7 @@ EXPECTED_EXPAND_EXTENSIONS = textwrap.dedent(
         override-prime: |-
           craftctl default
           mkdir -p var/lib/pebble/default/layers
+          chmod 777 var/lib/pebble/default
     platforms:
       amd64:
         build_on: null

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -113,7 +113,11 @@ def pebble_part() -> dict[str, Any]:
             "plugin": "nil",
             "stage-snaps": ["pebble/latest/stable"],
             "stage": ["bin/pebble"],
-            "override-prime": "craftctl default\nmkdir -p var/lib/pebble/default/layers",
+            "override-prime": str(
+                "craftctl default\n"
+                "mkdir -p var/lib/pebble/default/layers\n"
+                "chmod 777 var/lib/pebble/default"
+            ),
         }
     }
 


### PR DESCRIPTION
Fixes #461.

This PR ensures that the `PEBBLE` default directory `/var/lib/pebble/default` always has the mode 0777.

Previously, the mode of the `PEBBLE` dir was only set to 0777 if there were services or checks specified in the `rockcraft.yaml` file. Otherwise, it used to be 0755 with user=`root` group=`root`. This meant that if Pebble was being run as some user other than root, using the `run-user` directive or some other way, the Pebble run would fail. It would fail because Pebble could not create the necessary files (socket) inside that directory. This bug is reported in issue https://github.com/canonical/rockcraft/issues/461.


-----

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

