### PR TITLE
feat: build Rockcraft rock

### DIFF
--- a/.github/workflows/rockcraft-rock.yaml
+++ b/.github/workflows/rockcraft-rock.yaml
@@ -1,0 +1,81 @@
+name: Rockcraft rock
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+jobs:
+  snap-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: rockcraft
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: snap
+          path: ${{ steps.rockcraft.outputs.snap }}
+
+  rock-build:
+    runs-on: ubuntu-22.04
+    needs: [snap-build]
+    strategy:
+      matrix:
+        ubuntu-release: [22.04]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+      - name: Download snap artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: snap
+          path: tests
+      - name: Install Rockcraft
+        run: |
+          sudo snap install --classic --dangerous ./tests/*.snap
+      # This should change once this build matrix has more ubuntu-releases
+      - name: Build Rockcraft rock
+        id: rockcraft-rock
+        run: |
+          rockcraft pack --verbosity trace
+          echo "name=$(ls rockcraft*.rock)" >> $GITHUB_OUTPUT
+          echo "tag=$(rockcraft -V | cut -d' ' -f 2)-${{ matrix.ubuntu-release }}_edge" >> $GITHUB_OUTPUT
+      - name: Upload rock
+        uses: actions/upload-artifact@v3
+        with:
+          name: rock
+          path: ${{ steps.rockcraft-rock.outputs.name }}
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish rock to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          /snap/rockcraft/current/bin/skopeo copy \
+            oci-archive:${{ steps.rockcraft-rock.outputs.name }} \
+            docker://ghcr.io/${{ github.repository }}/rockcraft-rock:latest
+      - name: Published tagged rock to GHCR
+        if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' }}
+        run: |
+          # Only publish the versioned image when it
+          /snap/rockcraft/current/bin/skopeo copy \
+            oci-archive:${{ steps.rockcraft-rock.outputs.name }} \
+            docker://ghcr.io/${{ github.repository }}/rockcraft-rock:${{ steps.rockcraft-rock.outputs.tag }}

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,128 @@
+# Run the container:
+#   docker run --rm -v $PWD:/project \
+#     --device /dev/fuse \
+#     --cap-add SYS_ADMIN \
+#     --security-opt apparmor:unconfined \
+#     <rock>
+name: rockcraft
+
+# Other bases are automatically built by the CI
+base: ubuntu@22.04
+
+# Until adopt-info is supported, we'll just build dev images based on whatever
+# is committed to the main branch
+version: "dev"
+summary: A Rockcraft rock
+description: |
+  This is a rock that offers Rockcraft's capabilities from inside a container.
+  The default behavior is to pack a rock in destructive mode.
+license: GPL-3.0
+platforms:
+  amd64:
+
+services:
+  rockcraft:
+    override: replace
+    startup: enabled
+    command: /usr/libexec/rockcraft/rockcraft-entrypoint.sh [ -v ]
+    working-dir: /workdir
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  rockcraft:
+    plugin: python
+    source: .
+    python-packages:
+      - wheel
+      - pip
+      - setuptools
+    python-requirements:
+      - requirements-jammy.txt
+      - requirements.txt
+    build-environment:
+      - "CFLAGS": "$(pkg-config python-3.10 yaml-0.1 --cflags)"
+    build-attributes:
+      - enable-patchelf
+    build-packages:
+      - libapt-pkg-dev
+      - aspell
+      - aspell-en
+    stage-packages:
+      - binutils
+      - snapd
+      - python3-venv
+      - fuse-overlayfs
+      - rsync
+      - g++
+    organize:
+      bin/craftctl: usr/libexec/rockcraft/craftctl
+      bin/rockcraft: usr/libexec/rockcraft/rockcraft
+
+  # The custom script makes sure the build happens in a different path from
+  # the host's bind mount, to avoid polluting that space.
+  startup-script:
+    plugin: dump
+    source: tools
+    organize:
+      rock/rockcraft-entrypoint.sh: usr/libexec/rockcraft/rockcraft-entrypoint.sh
+    prime:
+      - usr/libexec/rockcraft/rockcraft-entrypoint.sh
+
+  workdirs:
+    plugin: nil
+    override-build: |
+      # This is where Rockcraft projects on the host should be mounted
+      mkdir -p ${CRAFT_PART_INSTALL}/project
+      # This is where Rockcraft actually builds the rocks, to avoid polluting
+      # the host
+      mkdir -p ${CRAFT_PART_INSTALL}/workdir
+
+  umoci:
+    plugin: make
+    source: https://github.com/opencontainers/umoci.git
+    source-tag: v0.4.7
+    make-parameters:
+      - umoci.static
+    override-build: |
+      make umoci.static
+      mkdir "$CRAFT_PART_INSTALL"/bin
+      install -m755 umoci.static "$CRAFT_PART_INSTALL"/bin/umoci
+    build-packages:
+      - golang-go
+      - make
+
+  skopeo:
+    plugin: nil
+    source: https://github.com/containers/skopeo.git
+    source-tag: v1.9.0
+    override-build: |
+      CGO=1 go build -ldflags -linkmode=external ./cmd/skopeo
+      mkdir -p "$CRAFT_PART_INSTALL"/bin
+      install -m755 skopeo "$CRAFT_PART_INSTALL"/bin/skopeo
+    stage-packages:
+      - libgpgme11
+      - libassuan0
+      - libbtrfs0
+      - libdevmapper1.02.1
+    build-attributes:
+      - enable-patchelf
+    build-snaps:
+      - go/1.17/stable
+    build-packages:
+      - libgpgme-dev
+      - libassuan-dev
+      - libbtrfs-dev
+      - libdevmapper-dev
+      - pkg-config
+    overlay-packages:
+      - ca-certificates
+
+  chisel:
+    plugin: nil
+    stage-snaps:
+      - chisel/latest/candidate
+    organize:
+      bin/chisel: usr/libexec/rockcraft/chisel
+    stage:
+      - usr/libexec/rockcraft/chisel

--- a/tools/rock/rockcraft-entrypoint.sh
+++ b/tools/rock/rockcraft-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+
+apt update &>/dev/null
+
+export PATH="$PATH:/usr/libexec/rockcraft"
+
+rsync -a --exclude="*.rock" /project/ /workdir
+
+/usr/libexec/rockcraft/rockcraft pack --destructive-mode "$@"
+
+(ls /workdir/*.rock &>/dev/null && cp /workdir/*.rock /project/) || \
+    echo "No rocks were built. Exiting..."


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This PR adds the `rockcraft.yaml` for building a Rockcraft rock.

The rock runs `pack` by default, in destructive mode. Other rockcraft commands can only be achieved via the pebble `exec` command or by overriding the entrypoint.

Because of fuse, the resulting rock needs to be executed with certain privileges.

Example:
```bash
rockcraft pack -v
skopeo copy oci-archive:rockcraft_dev_amd64.rock docker-daemon:rockcraft-rock:latest
docker run --rm -v $PWD:/project \
     --device /dev/fuse \
     --cap-add SYS_ADMIN \
     --security-opt apparmor:unconfined \
     rockcraft-rock
```

The resulting rock will be copied into the host's working directory

**Additionally:** this PR also includes the GH workflow for building and pushing this rock to GHCR
