### PR TITLE
build(deps): update skopeo to 1.14.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,8 +89,9 @@ parts:
         mkdir "$CRAFT_PART_INSTALL"/bin
         install -m755 umoci.static "$CRAFT_PART_INSTALL"/bin/umoci
     build-packages:
-        - golang-go
         - make
+    build-snaps:
+        - go/1.21/stable
 
   skopeo:
     plugin: nil
@@ -108,7 +109,7 @@ parts:
     build-attributes:
         - enable-patchelf
     build-snaps:
-        - go/1.17/stable
+        - go/1.21/stable
     build-packages:
         - libgpgme-dev
         - libassuan-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,7 +95,7 @@ parts:
   skopeo:
     plugin: nil
     source: https://github.com/containers/skopeo.git
-    source-tag: v1.9.0
+    source-tag: v1.14.2
     override-build: |
         CGO=1 go build -ldflags -linkmode=external ./cmd/skopeo
         mkdir "$CRAFT_PART_INSTALL"/bin


### PR DESCRIPTION
Version 1.14.2 fixes the issue with Docker Daemon API mismatch when converting the rock to a Docker image. The previous version (1.9.0) is also over a year and a half old so it's a good idea to update anyway.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
