### PR TITLE
build(deps): bump craft-providers to 1.23.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.22.0
+craft-providers==1.23.0
 cryptography==41.0.7
 Deprecated==1.2.14
 dill==0.3.7

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -9,7 +9,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.22.0
+craft-providers==1.23.0
 Deprecated==1.2.14
 distro==1.9.0
 docutils==0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.22.0
+craft-providers==1.23.0
 Deprecated==1.2.14
 distro==1.9.0
 httplib2==0.22.0


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

## Changelog

### 1.23.0 (2024-02-28)

- Update base compatibility tag to ``base-v7``
- Use ``buildd`` daily for Ubuntu 24.04 (Noble) and Ubuntu devel images
- Ensure apt installs non-interactively