### PR TITLE
build(deps): bump craft-providers to 1.23.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.23.0
+craft-providers==1.23.1
 cryptography==41.0.7
 Deprecated==1.2.14
 dill==0.3.7

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -9,7 +9,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.23.0
+craft-providers==1.23.1
 Deprecated==1.2.14
 distro==1.9.0
 docutils==0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ craft-application==1.2.1
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-parts==1.26.1
-craft-providers==1.23.0
+craft-providers==1.23.1
 Deprecated==1.2.14
 distro==1.9.0
 httplib2==0.22.0


### PR DESCRIPTION
Version 1.23.1 has a fix to parse LTS lxd versions correctly.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
