### PR TITLE
fix(spread): more robust check of non-pruned files

### DIFF
--- a/tests/spread/general/prune/check_layers.py
+++ b/tests/spread/general/prune/check_layers.py
@@ -1,17 +1,24 @@
+import filecmp
 import json
+import shutil
 import subprocess
 import sys
 import tarfile
 from pathlib import Path
 
 
-def _get_tar_contents(sha):
-    """Get a mapping (filename -> TarInfo) for the layer identified by ``sha``."""
+def _get_tarfile_path(sha: str) -> Path:
+    """Get the path to the layer file identified by ``sha``."""
     if ":" in sha:
         sha = sha[sha.find(":") + 1 :]
 
     layers_dir = Path("blobs/sha256")
-    filename = layers_dir / sha
+    return layers_dir / sha
+
+
+def _get_tar_contents(sha: str):
+    """Get a mapping (filename -> TarInfo) for the layer identified by ``sha``."""
+    filename = _get_tarfile_path(sha)
 
     contents = {}
     with tarfile.open(filename) as tar:
@@ -27,6 +34,19 @@ def _get_tar_contents(sha):
 def _get_stats(tarinfo):
     """Get size, permission bits, owner and group from a TarInfo."""
     return tarinfo.size, tarinfo.mode, tarinfo.uid, tarinfo.gid
+
+
+def _get_tar_file(tarinfo: tarfile.TarInfo, sha: str, dest_dir: Path) -> Path:
+    """Extract file indicated by ``tarinfo`` from the layer identified by ``sha``.
+
+    Returns the path to the extracted file.
+    """
+    filename = _get_tarfile_path(sha)
+
+    with tarfile.open(filename) as tar:
+        tar.extract(tarinfo, path=dest_dir)
+
+    return dest_dir / tarinfo.name
 
 
 rock_name = sys.argv[1]
@@ -52,5 +72,22 @@ for duplicate in duplicates:
     lifecycle_stats = _get_stats(lifecycle_tarinfo)
 
     # If the filename is present in both layers then it's expected that the size,
-    # or ownership, or permissions, are different.
-    assert base_stats != lifecycle_stats, f"File {duplicate} is the same in both layers"
+    # or ownership, or permissions, or finally contents, are different.
+
+    if base_stats != lifecycle_stats:
+        # Different size, ownership or permissions: OK
+        continue
+
+    # If we get here we have to check the contents of the files.
+    tmp_dir = Path("tmp-diff")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir()
+
+    base_file = _get_tar_file(base_tarinfo, base_layer_sha, tmp_dir / "base")
+    lifecycle_file = _get_tar_file(
+        lifecycle_tarinfo, lifecycle_layer_sha, tmp_dir / "lifecycle"
+    )
+
+    if filecmp.cmp(base_file, lifecycle_file, shallow=False):
+        raise RuntimeError(f"File {duplicate} is the same in both layers")


### PR DESCRIPTION
The spread test for the "layer pruning" feature worked by comparing the stats of two files if they exist in both layers. These stats - filesize, ownership and permission bits - were enough up until now because the non-pruned files differed on at least the filesize.

The recent release of libuuid1 broke this expectation: this new package has a ``libuuid.so.1.3.0`` with identical file size as the previous version, but different contents. So the pruning correctly kept the file, but the test failed.

Update the test to _also_ check the files' contents if necessary.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
