### PR TITLE
refactor: port code to latest craft-app update

### DIFF
--- a/docs/how-to/code/use-flask-extension/example/rockcraft.yaml
+++ b/docs/how-to/code/use-flask-extension/example/rockcraft.yaml
@@ -3,7 +3,11 @@ summary: A Flask application
 description: A rock packing a Flask application via the flask extension
 version: "0.1"
 base: bare
+build-base: ubuntu@22.04
 license: Apache-2.0
 
 extensions:
   - flask-framework
+
+platforms:
+  amd64:

--- a/docs/how-to/code/use-flask-extension/prime_example/rockcraft.yaml
+++ b/docs/how-to/code/use-flask-extension/prime_example/rockcraft.yaml
@@ -3,10 +3,14 @@ summary: A Flask application
 description: A rock packing a Flask application via the flask extension
 version: "0.1"
 base: bare
+build-base: ubuntu@22.04
 license: Apache-2.0
 
 extensions:
   - flask-framework
+
+platforms:
+  amd64:
 
 # [docs:parts-start]
 parts:

--- a/docs/how-to/code/use-flask-extension/prime_exclude_example/rockcraft.yaml
+++ b/docs/how-to/code/use-flask-extension/prime_exclude_example/rockcraft.yaml
@@ -3,10 +3,14 @@ summary: A Flask application
 description: A rock packing a Flask application via the flask extension
 version: "0.1"
 base: bare
+build-base: ubuntu@22.04
 license: Apache-2.0
 
 extensions:
   - flask-framework
+
+platforms:
+  amd64:
 
 # [docs:parts-start]
 parts:

--- a/rockcraft/application.py
+++ b/rockcraft/application.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from craft_application import Application, AppMetadata, util
+from craft_application import Application, AppMetadata
 from craft_parts.plugins.plugins import PluginType
 from overrides import override  # type: ignore[reportUnknownVariableType]
 
@@ -41,21 +41,27 @@ class Rockcraft(Application):
     """Rockcraft application definition."""
 
     @override
-    def _extra_yaml_transform(self, yaml_data: dict[str, Any]) -> dict[str, Any]:
+    def _extra_yaml_transform(
+        self,
+        yaml_data: dict[str, Any],
+        *,
+        build_on: str,  # noqa: ARG002 (Unused method argument)
+        build_for: str | None,  # noqa: ARG002 (Unused method argument)
+    ) -> dict[str, Any]:
         return models.transform_yaml(Path.cwd(), yaml_data)
 
     @override
-    def _configure_services(self, platform: str | None, build_for: str | None) -> None:
-        if build_for is None:
-            build_for = util.get_host_architecture()
-
-        self.services.set_kwargs("image", work_dir=self._work_dir, build_for=build_for)
+    def _configure_services(self, provider_name: str | None) -> None:
+        self.services.set_kwargs(
+            "image",
+            work_dir=self._work_dir,
+            build_plan=self._build_plan,
+        )
         self.services.set_kwargs(
             "package",
-            platform=platform,
-            build_for=build_for,
+            build_plan=self._build_plan,
         )
-        super()._configure_services(platform, build_for)
+        super()._configure_services(provider_name)
 
     @override
     def _get_app_plugins(self) -> dict[str, PluginType]:

--- a/rockcraft/services/lifecycle.py
+++ b/rockcraft/services/lifecycle.py
@@ -27,6 +27,7 @@ from rockcraft import layers
 from rockcraft.models.project import Project
 
 # Enable the craft-parts features that we use
+Features.reset()
 Features(enable_overlay=True)
 
 

--- a/rockcraft/services/package.py
+++ b/rockcraft/services/package.py
@@ -21,11 +21,12 @@ import pathlib
 import typing
 from typing import cast
 
-from craft_application import AppMetadata, PackageService, models, util
+from craft_application import AppMetadata, PackageService, errors, models
+from craft_application.models import BuildInfo
 from craft_cli import emit
 from overrides import override  # type: ignore[reportUnknownVariableType]
 
-from rockcraft import errors, oci
+from rockcraft import oci
 from rockcraft.models import Project
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
@@ -42,12 +43,10 @@ class RockcraftPackageService(PackageService):
         services: "RockcraftServiceFactory",
         *,
         project: models.Project,
-        platform: str | None,
-        build_for: str,
+        build_plan: list[BuildInfo],
     ) -> None:
         super().__init__(app, services, project=project)
-        self._platform = platform
-        self._build_for = build_for
+        self._build_plan = build_plan
 
     @override
     def pack(self, prime_dir: pathlib.Path, dest: pathlib.Path) -> list[pathlib.Path]:
@@ -64,27 +63,14 @@ class RockcraftPackageService(PackageService):
         image_service = services.image
         image_info = image_service.obtain_image()
 
-        platform = self._platform
+        if not self._build_plan:
+            raise errors.EmptyBuildPlanError()
 
-        if platform is None:
-            # This should only happen in destructive mode, in which case we
-            # can only pack a single rock.
-            build_on = util.get_host_architecture()
-            base_build_plan = self._project.get_build_plan()
-            build_plan = [
-                plan for plan in base_build_plan if plan.build_for == self._build_for
-            ]
-            build_plan = [plan for plan in build_plan if plan.build_on == build_on]
+        if len(self._build_plan) > 1:
+            raise errors.MultipleBuildsError()
 
-            if len(build_plan) != 1:
-                message = "Unable to determine which platform to build."
-                details = f"Possible values are: {[info.platform for info in base_build_plan]}."
-                resolution = 'Choose a platform with the "--platform" parameter.'
-                raise errors.RockcraftError(
-                    message=message, details=details, resolution=resolution
-                )
-
-            platform = build_plan[0].platform
+        platform = self._build_plan[0].platform
+        build_for = self._build_plan[0].build_for
 
         archive_name = _pack(
             prime_dir=prime_dir,
@@ -92,7 +78,7 @@ class RockcraftPackageService(PackageService):
             project_base_image=image_info.base_image,
             base_digest=image_info.base_digest,
             rock_suffix=platform,
-            build_for=self._build_for,
+            build_for=build_for,
             base_layer_dir=image_info.base_layer_dir,
         )
 
@@ -139,8 +125,12 @@ def _pack(
       The directory where the rock's base image was extracted.
     """
     emit.progress("Creating new layer")
+
+    # At this point the version must be set, otherwise it would have failed earlier.
+    version = cast(str, project.version)
+
     new_image = project_base_image.add_layer(
-        tag=project.version,
+        tag=version,
         new_layer_dir=prime_dir,
         base_layer_dir=base_layer_dir,
     )
@@ -151,7 +141,7 @@ def _pack(
         new_image.add_user(
             prime_dir=prime_dir,
             base_layer_dir=base_layer_dir,
-            tag=project.version,
+            tag=version,
             username=project.run_user,
             uid=SUPPORTED_GLOBAL_USERNAMES[project.run_user]["uid"],
         )
@@ -174,7 +164,7 @@ def _pack(
             services=services,
             checks=checks,
             name=project.name,
-            tag=project.version,
+            tag=version,
             summary=project.summary,
             description=project.description,
             base_layer_dir=base_layer_dir,
@@ -199,7 +189,7 @@ def _pack(
 
     emit.progress("Exporting to OCI archive")
     archive_name = f"{project.name}_{project.version}_{rock_suffix}.rock"
-    new_image.to_oci_archive(tag=project.version, filename=archive_name)
+    new_image.to_oci_archive(tag=version, filename=archive_name)
     emit.progress(f"Exported to OCI archive '{archive_name}'")
 
     return archive_name

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -94,6 +94,10 @@
       "title": "License",
       "type": "string"
     },
+    "adopt-info": {
+      "title": "Adopt-Info",
+      "type": "string"
+    },
     "parts": {
       "title": "Parts",
       "type": "object",
@@ -143,7 +147,6 @@
   },
   "required": [
     "name",
-    "version",
     "summary",
     "description",
     "base",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,7 @@ def default_build_plan(default_project):
 
 
 @pytest.fixture()
-def default_factory(default_project):
+def default_factory(default_project, default_build_plan):
     from rockcraft.application import APP_METADATA
     from rockcraft.services import RockcraftServiceFactory
 
@@ -146,7 +146,7 @@ def default_factory(default_project):
         app=APP_METADATA,
         project=default_project,
     )
-    factory.set_kwargs("image", work_dir=Path("work"), build_for="amd64")
+    factory.set_kwargs("image", work_dir=Path("work"), build_plan=default_build_plan)
     return factory
 
 
@@ -170,7 +170,7 @@ def default_application(default_factory, default_project):
 
 
 @pytest.fixture()
-def image_service(default_project, default_factory, tmp_path):
+def image_service(default_project, default_factory, tmp_path, default_build_plan):
     from rockcraft.application import APP_METADATA
     from rockcraft.services import RockcraftImageService
 
@@ -179,7 +179,7 @@ def image_service(default_project, default_factory, tmp_path):
         project=default_project,
         services=default_factory,
         work_dir=tmp_path,
-        build_for="amd64",
+        build_plan=default_build_plan,
     )
 
 
@@ -198,7 +198,7 @@ def provider_service(default_project, default_build_plan, default_factory, tmp_p
 
 
 @pytest.fixture()
-def package_service(default_project, default_factory):
+def package_service(default_project, default_factory, default_build_plan):
     from rockcraft.application import APP_METADATA
     from rockcraft.services import RockcraftPackageService
 
@@ -206,13 +206,12 @@ def package_service(default_project, default_factory):
         app=APP_METADATA,
         project=default_project,
         services=default_factory,
-        platform=None,
-        build_for="amd64",
+        build_plan=default_build_plan,
     )
 
 
 @pytest.fixture()
-def lifecycle_service(default_project, default_factory):
+def lifecycle_service(default_project, default_factory, default_build_plan):
     from rockcraft.application import APP_METADATA
     from rockcraft.services import RockcraftLifecycleService
 
@@ -222,7 +221,7 @@ def lifecycle_service(default_project, default_factory):
         services=default_factory,
         work_dir=Path("work/"),
         cache_dir=Path("cache/"),
-        build_for="amd64",
+        build_plan=default_build_plan,
     )
 
 
@@ -234,12 +233,23 @@ def mock_obtain_image(default_factory, mocker):
 
 
 @pytest.fixture()
-def run_lifecycle(mocker):
+def run_lifecycle(mocker, default_build_plan):
     """Helper to call testing.run_mocked_lifecycle()."""
 
     def _inner(**kwargs):
         from tests.testing.lifecycle import run_mocked_lifecycle
 
-        return run_mocked_lifecycle(mocker=mocker, **kwargs)
+        return run_mocked_lifecycle(
+            mocker=mocker, build_plan=default_build_plan, **kwargs
+        )
 
     return _inner
+
+
+@pytest.fixture()
+def enable_overlay_feature():
+    """Enable the overlay feature."""
+    from craft_parts import Features
+
+    Features.reset()
+    Features(enable_overlay=True)

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -24,7 +24,10 @@ from craft_parts import overlays
 from tests.testing.project import create_project
 from tests.util import jammy_only
 
-pytestmark = [jammy_only, pytest.mark.usefixtures("reset_callbacks")]
+pytestmark = [
+    jammy_only,
+    pytest.mark.usefixtures("reset_callbacks", "enable_overlay_feature"),
+]
 
 # pyright: reportPrivateImportUsage=false
 

--- a/tests/testing/lifecycle.py
+++ b/tests/testing/lifecycle.py
@@ -18,6 +18,8 @@
 import pathlib
 from typing import cast
 
+from craft_application import models
+
 from rockcraft.application import APP_METADATA
 from rockcraft.models import Project
 from rockcraft.services import RockcraftLifecycleService, RockcraftServiceFactory
@@ -31,6 +33,7 @@ def run_mocked_lifecycle(
     mocker,
     base_layer_dir: pathlib.Path | None = None,
     step: str = "stage",
+    build_plan: list[models.BuildInfo]
 ) -> RockcraftLifecycleService:
     """Run a project's lifecycle with a mocked base image."""
 
@@ -39,12 +42,12 @@ def run_mocked_lifecycle(
         "lifecycle",
         work_dir=work_dir,
         cache_dir=work_dir / "cache_dir",
-        build_for="amd64",
+        build_plan=build_plan,
     )
     factory.set_kwargs(
         "image",
         work_dir=work_dir,
-        build_for="amd64",
+        build_plan=build_plan,
     )
     factory.project = project
 

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from craft_application import util
+from craft_application.util import repositories
 from craft_parts import (
     LifecycleManager,
     Part,
@@ -29,7 +31,6 @@ from craft_parts import (
     callbacks,
 )
 from craft_parts.state_manager.prime_state import PrimeState
-from craft_application.util import repositories
 
 from rockcraft.services import lifecycle as lifecycle_module
 
@@ -68,16 +69,21 @@ def test_lifecycle_args(
         ignore_local_sources=["*.rock"],
         package_repositories=[{"ppa": "ppa/ppa", "type": "apt"}],
         parallel_build_count=4,
+        partitions=None,
         project_name="default",
-        # project_vars={"version": "1.0"},
+        project_vars={"version": "1.0"},
+        project_vars_part_name=None,
         work_dir=Path("work"),
         rootfs_dir=Path("."),
+        track_stage_packages=True,
     )
 
 
 def test_lifecycle_package_repositories(
-    extra_project_params, lifecycle_service, default_project, mocker
+    extra_project_params, lifecycle_service, default_project, mocker, default_build_plan
 ):
+    base = default_build_plan[0].base
+    mocker.patch.object(util, "get_host_base", return_value=base)
     fake_repositories = extra_project_params["package_repositories"]
     lifecycle_service._lcm = mock.MagicMock(spec=LifecycleManager)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -52,6 +52,7 @@ def test_run_pack_services(mocker, monkeypatch, tmp_path):
         setup=DEFAULT,
         prime_dir=fake_prime_dir,
         run=DEFAULT,
+        project_info=DEFAULT,
     )
 
     package_mocks = mocker.patch.multiple(

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -26,7 +26,6 @@ import pytest
 import yaml
 from craft_application.errors import CraftValidationError
 from craft_application.models import BuildInfo
-from craft_parts import Features
 from craft_providers.bases import BaseName
 
 from rockcraft.errors import ProjectLoadError
@@ -95,11 +94,7 @@ entrypoint-service: test-service
 """
 
 
-@pytest.fixture(autouse=True)
-def enable_overlay_feature():
-    """Enable the overlay feature to make this test module standalone."""
-    Features.reset()
-    Features(enable_overlay=True)
+pytestmark = [pytest.mark.usefixtures("enable_overlay_feature")]
 
 
 @pytest.fixture()
@@ -462,7 +457,7 @@ def test_project_version_invalid(yaml_loaded_data):
 
 
 @pytest.mark.parametrize(
-    "field", ["name", "version", "base", "parts", "description", "summary", "license"]
+    "field", ["name", "base", "parts", "description", "summary", "license"]
 )
 def test_project_missing_field(yaml_loaded_data, field):
     del yaml_loaded_data[field]


### PR DESCRIPTION
The brunt of the update is updating usages of platform/build-for to the build plan. This largely affects the image and package services, but the semantics should be unchanged because it's the same data just delivered differently.

A bit more context here is that the `feature/craft-application` branch already had a bunch of migration work done, so I just rebased that branch and created this one off it. That branch bumps craft-application to 2.3.0.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
