### PR TITLE
remove experimental flag for flask-framework extension

### DIFF
--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -259,7 +259,7 @@ Extensions to enable when building the ROCK.
 
 Currently supported extensions:
 
-- ``flask`` (experimental)
+- ``flask-framework``
 
 Example
 =======

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""An experimental extension for the Gunicorn based Python WSGI application extensions."""
+"""An extension for the Gunicorn based Python WSGI application extensions."""
 import abc
 import ast
 import fnmatch
@@ -194,6 +194,12 @@ class FlaskFramework(_GunicornBase):
     def framework(self) -> str:
         """Return the wsgi framework name, e.g. flask, django."""
         return "flask"
+
+    @staticmethod
+    @override
+    def is_experimental(base: str | None) -> bool:
+        """Check if the extension is in an experimental state."""
+        return False
 
     @override
     def gen_install_app_part(self) -> Dict[str, Any]:

--- a/tests/spread/rockcraft/extension-flask/task.yaml
+++ b/tests/spread/rockcraft/extension-flask/task.yaml
@@ -1,8 +1,6 @@
 summary: flask extension test
 
 execute: |
-  export ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=true
-  
   run_rockcraft init --name flask-extension --profile flask-framework
   run_rockcraft pack
 
@@ -15,15 +13,15 @@ execute: |
   sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:flask-extension_0.1_amd64.rock docker-daemon:flask-extension:latest
   # Ensure container exists
   docker images flask-extension | MATCH "flask-extension"
-  
+
   # ensure container doesn't exist
   docker rm -f flask-extension-container
-  
+
   # test the flask project is ready to run inside the container
   docker run --rm --entrypoint /bin/python3 flask-extension -m gunicorn --chdir /flask/app --check-config app:app
   docker run --rm --entrypoint /bin/python3 flask-extension -c "import pathlib;assert pathlib.Path('/flask/app/static/js/test.js').is_file()"
   docker run --rm --entrypoint /bin/python3 flask-extension -c "import pathlib;assert not pathlib.Path('/flask/app/node_modules').exists()"
-  
+
   # test the default flask service
   docker run --name flask-extension-container -d -p 8137:8000 flask-extension
   retry -n 5 --wait 2 curl localhost:8137

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -21,8 +21,7 @@ from rockcraft.errors import ExtensionError
 
 
 @pytest.fixture
-def flask_extension(mock_extensions, monkeypatch):
-    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
+def flask_extension(mock_extensions):
     extensions.register("flask-framework", extensions.FlaskFramework)
 
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

We have now tested the extension with the web team and they are happy with. This means we're ready to move the flask-framework extension to be stable.