### PR TITLE
ci: adjust tags for spread runs

### DIFF
--- a/.github/workflows/spread-large.yaml
+++ b/.github/workflows/spread-large.yaml
@@ -25,7 +25,7 @@ jobs:
 
   snap-tests:
     if: ${{ github.event.label.name == 'run-large-spread' || github.event_name == 'schedule' }}
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: [snap-build]
 
     steps:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -25,7 +25,7 @@ jobs:
           path: ${{ steps.rockcraft.outputs.snap }}
 
   snap-tests:
-    runs-on: self-hosted
+    runs-on: [spread-installed]
     needs: [snap-build]
 
     steps:


### PR DESCRIPTION
This ensures we can use any machine with the spread-installed tag. Necessary for upcoming changes to Canonical's self-hosted runners.

Spread will fail until a repo admin adjusts the runner tags.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
