### PR TITLE
spread: don't cut dotnet slices unnecessarily

### DIFF
--- a/tests/spread/rockcraft/base-devel/rockcraft.orig.yaml
+++ b/tests/spread/rockcraft/base-devel/rockcraft.orig.yaml
@@ -11,7 +11,7 @@ platforms:
 parts:
   from-chisel-slices:
     plugin: nil
-    stage-packages: [dotnet-runtime-8.0_libs]
+    stage-packages: [coreutils_bins]
 
   from-deb:
     plugin: nil


### PR DESCRIPTION
Those slices are currently fragile due to the ongoing time_t changes. Instead, use coreutils_bins because it has fewer dependencies (but still some) and is more stable. The purpose of the test is just to check that we can cut any slices at all for base devel anyway.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
