### PR TITLE
fix: change pebble dir in 24.04 from /.rock/bin to /usr/bin

### DIFF
--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -26,8 +26,6 @@ import yaml
 from craft_application.errors import CraftValidationError
 from craft_cli import emit
 
-from rockcraft.constants import ROCK_CONTROL_DIR
-
 
 def _alias_generator(name: str) -> str:
     """Convert underscores to dashes in aliases."""
@@ -168,7 +166,7 @@ class Pebble:
 
     PEBBLE_PATH = "var/lib/pebble/default"
     PEBBLE_LAYERS_PATH = f"{PEBBLE_PATH}/layers"
-    PEBBLE_BINARY_DIR = f"{ROCK_CONTROL_DIR}/bin"
+    PEBBLE_BINARY_DIR = "usr/bin"
     PEBBLE_BINARY_PATH = f"{PEBBLE_BINARY_DIR}/pebble"
     PEBBLE_BINARY_PATH_PREVIOUS = "bin/pebble"
     _BASE_PART_SPEC = {

--- a/tests/spread/rockcraft/base-devel/task.yaml
+++ b/tests/spread/rockcraft/base-devel/task.yaml
@@ -30,8 +30,9 @@ execute: |
       docker-daemon:base-devel:0.1
   rm base-devel_0.1_amd64.rock
   docker images base-devel:0.1
-  id=$(docker run --rm -d base-devel:0.1)
+  id=$(docker run -d base-devel:0.1)
   test "$(docker inspect "$id" -f '{{json .Config.Entrypoint}}')" = '["/usr/bin/pebble","enter"]'
+  docker exec "$id" pebble services
   docker rm -f "$id"
 
 restore: |

--- a/tests/spread/rockcraft/base-devel/task.yaml
+++ b/tests/spread/rockcraft/base-devel/task.yaml
@@ -31,7 +31,7 @@ execute: |
   rm base-devel_0.1_amd64.rock
   docker images base-devel:0.1
   id=$(docker run --rm -d base-devel:0.1)
-  test "$(docker inspect "$id" -f '{{json .Config.Entrypoint}}')" = '["/.rock/bin/pebble","enter"]'
+  test "$(docker inspect "$id" -f '{{json .Config.Entrypoint}}')" = '["/usr/bin/pebble","enter"]'
   docker rm -f "$id"
 
 restore: |

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -63,7 +63,7 @@ def test_application_expand_environment(new_dir, default_application):
 @pytest.mark.parametrize(
     ("base", "build_base", "expected_spec"),
     [
-        # 24.04 and beyond: pebble exists in .rock/bin/
+        # 24.04 and beyond: pebble exists in usr/bin/
         ("bare", "devel", Pebble.PEBBLE_PART_SPEC),
         ("ubuntu@24.04", "devel", Pebble.PEBBLE_PART_SPEC),
         # 20.04 and 22.04: pebble exists in bin/

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -33,7 +33,7 @@ class TestPebble:
     def test_attributes(self):
         assert Pebble.PEBBLE_PATH == "var/lib/pebble/default"
         assert Pebble.PEBBLE_LAYERS_PATH == "var/lib/pebble/default/layers"
-        assert Pebble.PEBBLE_BINARY_PATH == ".rock/bin/pebble"
+        assert Pebble.PEBBLE_BINARY_PATH == "usr/bin/pebble"
         assert Pebble.PEBBLE_BINARY_PATH_PREVIOUS == "bin/pebble"
         assert all(
             field in Pebble.PEBBLE_PART_SPEC


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

## Description
After discussion with the Starcraft team, it has been agreed on to move the `pebble` binary to `/usr/bin` instead of `/.rock/bin` for 24.04, since we're quite sure that the `/usr/bin` dir won't change for 24.04.

This PR builds over the previous PR https://github.com/canonical/rockcraft/pull/528 but replaces the pebble path for 24.04 and onwards to `/usr/bin`, and change .

## Related PRs
PR https://github.com/canonical/rockcraft/pull/528

## Testing
Aside from spread tests, this is a manual test using the Hello World rock with build-base of 24.04 to confirm the path of pebble binary.

Rock:
```yaml
name: chiselled-hello
summary: Hello world from Chisel slices
description: A "bare" rock containing the "hello" package binaries from Chisel slices.
license: Apache-2.0

version: "latest"
base: bare
build_base: ubuntu@24.04
platforms:
  amd64:

services:
  hello_service:
    startup: disabled
    command: hello
    override: replace

parts:
  hello:
    plugin: nil
    stage-packages:
      - hello_bins
```

### Results

![image](https://github.com/canonical/rockcraft/assets/719022/1358d455-76e3-439c-bc36-5f71881514f0)
