### PR TITLE
build: fix snap build in non-amd64 archs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,7 @@ apps:
 
 build-packages:
   - libapt-pkg-dev
+  - libffi-dev # for cffi (via pygit2)
   - libyaml-dev
   - python3.10-dev
   - pkg-config
@@ -50,6 +51,19 @@ parts:
     organize:
         "usr/bin/fuse-overlayfs": "libexec/rockcraft/fuse-overlayfs"
 
+  libgit2: # part came from snapcraft@5fbaab144842f
+    source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz
+    source-checksum: sha256/17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+    build-packages:
+      - libssl-dev
+    build-attributes:
+      - enable-patchelf
+    prime:
+      - -usr/include
+
   rockcraft:
     source: .
     plugin: python
@@ -77,6 +91,7 @@ parts:
       sed -i -e '1 s|^#!/.*|#!/snap/rockcraft/current/bin/python -E|' $CRAFT_PART_INSTALL/bin/craftctl
     after:
       - rockcraft-libs
+      - libgit2
 
   umoci:
     plugin: make


### PR DESCRIPTION
Some archs don't have wheels for some of the dependencies (like pygit2).

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Tested using remote-build for arm64, armhf, ppc64el, riscv64, s390x
