### PR TITLE
fix(tests): don't use chisel slices in 'devel' bases

### DIFF
--- a/tests/spread/rockcraft/base-devel/rockcraft.orig.yaml
+++ b/tests/spread/rockcraft/base-devel/rockcraft.orig.yaml
@@ -9,10 +9,6 @@ platforms:
   amd64:
 
 parts:
-  from-chisel-slices:
-    plugin: nil
-    stage-packages: [coreutils_bins]
-
   from-deb:
     plugin: nil
     stage-packages: [hello]

--- a/tests/spread/rockcraft/chisel/rockcraft.yaml
+++ b/tests/spread/rockcraft/chisel/rockcraft.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 version: "0.0.1"
 
 base: bare
-build-base: devel
+build-base: ubuntu@24.04
 
 platforms:
   amd64:


### PR DESCRIPTION
The issue is that chisel releases necessarily lag behind mainline Ubuntu development, as each new series needs to be manually added to the chisel-releases repo. The case in point here is that 'devel' has just started to mean "Ubuntu 24.10", but this version is not available in chisel-releases yet.

So we drop the use of slices in 'devel' tests, which should be fine because the point is to see whether the *rest* of Rockcraft's execution works.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
