### PR TITLE
refactor: use default BuildPlanner

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.5.1
-craft-application==2.9.0
+craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -10,7 +10,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==2.9.0
+craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
-craft-application==2.9.0
+craft-application==3.1.0
 craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -301,7 +301,6 @@ class Project(YamlModelMixin, BuildPlanner, BaseProject):  # type: ignore[misc]
         :param base: The base name.
 
         :returns: The BaseAlias for the base or None for bare bases.
-
         :raises ValueError: If the project's base cannot be determined.
         """
         if base == "bare":

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -54,7 +54,14 @@
       "title": "Platforms",
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/Platform"
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "$ref": "#/definitions/Platform"
+          }
+        ]
       }
     },
     "contact": {
@@ -174,13 +181,21 @@
           }
         },
         "build-for": {
-          "title": "Build-For",
-          "minItems": 1,
-          "uniqueItems": true,
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "oneOf": [
+            {
+              "title": "Build-For",
+              "minItems": 1,
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "title": "Build-For",
+              "type": "string"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -52,7 +52,10 @@
     },
     "platforms": {
       "title": "Platforms",
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Platform"
+      }
     },
     "contact": {
       "title": "Contact",
@@ -156,6 +159,32 @@
   ],
   "additionalProperties": false,
   "definitions": {
+    "Platform": {
+      "title": "Platform",
+      "description": "Rockcraft project platform definition.",
+      "type": "object",
+      "properties": {
+        "build-on": {
+          "title": "Build-On",
+          "minItems": 1,
+          "uniqueItems": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "build-for": {
+          "title": "Build-For",
+          "minItems": 1,
+          "uniqueItems": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "Service": {
       "title": "Service",
       "description": "Lightweight schema validation for a Pebble service.\n\nBased on\nhttps://github.com/canonical/pebble#layer-specification",

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 packages = find:
 zip_safe = False
 install_requires =
-    craft-application>=1.0.0
+    craft-application>=3.1.0
     craft-archives>=1.1.0
     craft-cli
     craft-parts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,8 @@ def extra_project_params():
 @pytest.fixture()
 def default_project(extra_project_params):
     from craft_application.models import VersionStr
-    from rockcraft.models.project import NameStr, Project
+
+    from rockcraft.models.project import NameStr, Project, Platform
 
     parts = extra_project_params.pop("parts", {})
 
@@ -124,7 +125,7 @@ def default_project(extra_project_params):
         base="ubuntu@22.04",
         parts=parts,
         license="MIT",
-        platforms={"amd64": None},
+        platforms={"amd64": Platform(build_on=["amd64"], build_for=["amd64"])},
         **extra_project_params,
     )
 

--- a/tests/unit/commands/test_expand_extensions.py
+++ b/tests/unit/commands/test_expand_extensions.py
@@ -42,7 +42,11 @@ EXPECTED_EXPAND_EXTENSIONS = textwrap.dedent(
     base: ubuntu@22.04
     build-base: ubuntu@22.04
     platforms:
-      amd64: {}
+      amd64:
+        build-on:
+        - amd64
+        build-for:
+        - amd64
     license: Apache-2.0
     parts:
       foo:

--- a/tests/unit/commands/test_expand_extensions.py
+++ b/tests/unit/commands/test_expand_extensions.py
@@ -42,9 +42,7 @@ EXPECTED_EXPAND_EXTENSIONS = textwrap.dedent(
     base: ubuntu@22.04
     build-base: ubuntu@22.04
     platforms:
-      amd64:
-        build_on: null
-        build_for: null
+      amd64: {}
     license: Apache-2.0
     parts:
       foo:

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -27,6 +27,7 @@ import yaml
 from craft_application.errors import CraftValidationError
 from craft_application.models import BuildInfo
 from craft_providers.bases import BaseName, ubuntu
+
 from rockcraft.errors import ProjectLoadError
 from rockcraft.models import Project
 from rockcraft.models.project import INVALID_NAME_MESSAGE, Platform, load_project

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -138,10 +138,12 @@ def test_project_unmarshal(check, yaml_loaded_data):
             # platforms get mutated at validation time
             assert getattr(project, attr).keys() == v.keys()
             assert all(
-                "build_on" in platform for platform in getattr(project, attr).values()
+                hasattr(platform, "build_on")
+                for platform in getattr(project, attr).values()
             )
             assert all(
-                "build_for" in platform for platform in getattr(project, attr).values()
+                hasattr(platform, "build_for")
+                for platform in getattr(project, attr).values()
             )
             continue
         if attr == "services":
@@ -420,8 +422,8 @@ def test_project_all_platforms_invalid(yaml_loaded_data):
 
     expected = (
         "Bad rockcraft.yaml content:\n"
-        "- error for platform entry 'foo': 'build-for' expects 'build-on' "
-        "to also be provided. (in field 'platforms')"
+        "- 'build-for' expects 'build-on' to also be provided."
+        " (in field 'platforms.foo')"
     )
 
     assert reload_project_platforms(mock_platforms) == expected
@@ -652,18 +654,16 @@ description: this is an example of a rockcraft.yaml for the purpose of testing r
 base: ubuntu@20.04
 build-base: ubuntu@20.04
 platforms:
-  {BUILD_ON_ARCH}:
-    build_on: null
-    build_for: null
+  {BUILD_ON_ARCH}: {{}}
   some-text:
-    build_on:
+    build-on:
     - {BUILD_ON_ARCH}
-    build_for:
+    build-for:
     - {BUILD_ON_ARCH}
   same-with-different-syntax:
-    build_on:
+    build-on:
     - {BUILD_ON_ARCH}
-    build_for:
+    build-for:
     - {BUILD_ON_ARCH}
 license: Apache-2.0
 parts:

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -437,15 +437,15 @@ def test_project_all_platforms_invalid(yaml_loaded_data):
     mock_platforms = {
         "mock": {"build-on": ["arm64a", "noarch"], "build-for": ["amd64"]}
     }
-    assert "none of these build architectures is supported" in reload_project_platforms(
-        mock_platforms
+    assert (
+        "Invalid architecture: 'arm64a' must be a valid debian architecture."
+        in reload_project_platforms(mock_platforms)
     )
 
-    mock_platforms = {
-        "mock": {"build-on": ["arm64a", "arm64"], "build-for": ["noarch"]}
-    }
-    assert "build rock for target architecture noarch" in reload_project_platforms(
-        mock_platforms
+    mock_platforms = {"mock": {"build-on": ["arm64", "arm64"], "build-for": ["noarch"]}}
+    assert (
+        "Invalid architecture: 'noarch' must be a valid debian architecture."
+        in reload_project_platforms(mock_platforms)
     )
 
 
@@ -654,7 +654,11 @@ description: this is an example of a rockcraft.yaml for the purpose of testing r
 base: ubuntu@20.04
 build-base: ubuntu@20.04
 platforms:
-  {BUILD_ON_ARCH}: {{}}
+  {BUILD_ON_ARCH}:
+    build-on:
+    - {BUILD_ON_ARCH}
+    build-for:
+    - {BUILD_ON_ARCH}
   some-text:
     build-on:
     - {BUILD_ON_ARCH}

--- a/tools/schema/schema.py
+++ b/tools/schema/schema.py
@@ -60,6 +60,25 @@ def generate_project_schema() -> str:
     # combine both schemas
     project_schema = {**initial_schema, **project_schema}
 
+    # tweak the platforms definition on the Project (each value can be empty)
+    project_schema["properties"]["platforms"]["additionalProperties"] = {
+        "oneOf": [{"type": "null"}, {"$ref": "#/definitions/Platform"}]
+    }
+
+    # tweak the Platform (build-for can be a single string)
+    project_schema["definitions"]["Platform"]["properties"]["build-for"] = {
+        "oneOf": [
+            {
+                "title": "Build-For",
+                "minItems": 1,
+                "uniqueItems": True,
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            {"title": "Build-For", "type": "string"},
+        ]
+    }
+
     # project.schema() will define the `parts` field as an `object`
     # so we need to manually add the schema for parts by running
     # schema() on part.spec and add the outcome project schema's definitions


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This is a test PR for https://github.com/canonical/craft-application/pull/326, to see if the default BuildPlanner will work for rockcraft.

There are a few pre-requisite commits to be compatible with the latest craft-application.

I wasn't able to get pydantic to use [this](https://github.com/canonical/craft-application/pull/326/files#diff-d49e733a1e99a8cc3fe98cb7d956b735159c60342405692603fe5fcf8a970edaR111) upstream validator but everything else seems to be in working order.

(CRAFT-2824)