### PR TITLE
feat(snap): expose skopeo as rockcraft.skopeo

### DIFF
--- a/docs/how-to/code/convert-to-pebble-layer/task.yaml
+++ b/docs/how-to/code/convert-to-pebble-layer/task.yaml
@@ -13,7 +13,7 @@ execute: |
   # [docs:pack-end]
 
   # [docs:skopeo]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:custom-nginx-rock_latest_amd64.rock docker-daemon:custom-nginx-rock:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:custom-nginx-rock_latest_amd64.rock docker-daemon:custom-nginx-rock:latest
   # [docs:skopeo-end]
 
   rm custom-nginx-rock_latest_amd64.rock

--- a/docs/how-to/code/install-slice/task.yaml
+++ b/docs/how-to/code/install-slice/task.yaml
@@ -42,7 +42,7 @@ execute: |
   # [docs:pack-end]
 
   # [docs:skopeo-copy]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:custom-openssl-rock_0.0.1_amd64.rock docker-daemon:chisel-openssl:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:custom-openssl-rock_0.0.1_amd64.rock docker-daemon:chisel-openssl:latest
   # [docs:skopeo-copy-end]
 
   # [docs:docker-run]

--- a/docs/how-to/code/migrate-to-chiselled-rock/task.yaml
+++ b/docs/how-to/code/migrate-to-chiselled-rock/task.yaml
@@ -46,7 +46,7 @@ execute: |
   docker images
 
   # [docs:skopeo-copy]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:dotnet-runtime_chiselled_amd64.rock docker-daemon:dotnet-runtime:chiselled
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:dotnet-runtime_chiselled_amd64.rock docker-daemon:dotnet-runtime:chiselled
   # [docs:skopeo-copy-end]
   
   # [docs:inspect-rock]

--- a/docs/tutorials/code/chisel/task.yaml
+++ b/docs/tutorials/code/chisel/task.yaml
@@ -19,7 +19,7 @@ execute: |
   test -f chiselled-hello_latest_amd64.rock
 
   # [docs:skopeo-copy]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:chiselled-hello_latest_amd64.rock docker-daemon:chiselled-hello:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:chiselled-hello_latest_amd64.rock docker-daemon:chiselled-hello:latest
   # [docs:skopeo-copy-end]
 
   # [docs:docker-run]

--- a/docs/tutorials/code/hello-world/task.yaml
+++ b/docs/tutorials/code/hello-world/task.yaml
@@ -27,7 +27,7 @@ execute: |
   docker images
 
   # [docs:skopeo-copy]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:hello_latest_amd64.rock docker-daemon:hello:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:hello_latest_amd64.rock docker-daemon:hello:latest
   # [docs:skopeo-copy-end]
 
   rm hello_latest_amd64.rock

--- a/docs/tutorials/code/node-app/task.yaml
+++ b/docs/tutorials/code/node-app/task.yaml
@@ -18,7 +18,7 @@ execute: |
   docker images
 
   # [docs:skopeo-copy]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:my-node-app_1.0_amd64.rock docker-daemon:my-node-app:1.0
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:my-node-app_1.0_amd64.rock docker-daemon:my-node-app:1.0
   # [docs:skopeo-copy-end]
 
   rm *.rock

--- a/docs/tutorials/code/pyfiglet/task.yaml
+++ b/docs/tutorials/code/pyfiglet/task.yaml
@@ -19,7 +19,7 @@ execute: |
   # [docs:build-rock-end]  
 
   # [docs:skopeo-copy]
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:pyfiglet_0.7.6_amd64.rock docker-daemon:pyfiglet:0.7.6
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:pyfiglet_0.7.6_amd64.rock docker-daemon:pyfiglet:0.7.6
   # [docs:skopeo-copy-end]
 
   rm pyfiglet_0.7.6_amd64.rock

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,8 @@ environment:
 apps:
   rockcraft:
     command: bin/python $SNAP/bin/rockcraft
+  skopeo:
+    command: bin/skopeo
 
 build-packages:
   - libapt-pkg-dev

--- a/tests/spread/foreign/big/task.yaml
+++ b/tests/spread/foreign/big/task.yaml
@@ -21,7 +21,7 @@ execute: |
 
   # copy image to docker
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy "oci-archive:$ROCK" docker-daemon:big:latest
+  sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$ROCK" docker-daemon:big:latest
   rm "$ROCK"
 
   docker images

--- a/tests/spread/general/extension-django/task.yaml
+++ b/tests/spread/general/extension-django/task.yaml
@@ -13,7 +13,7 @@ execute: |
   # Ensure docker does not have this container image
   docker rmi --force example-django
   # Install container
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:example-django_0.1_amd64.rock docker-daemon:example-django:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:example-django_0.1_amd64.rock docker-daemon:example-django:latest
   # Ensure container exists
   docker images example-django | MATCH "example-django"
   

--- a/tests/spread/large/repo-overlay/task.yaml
+++ b/tests/spread/large/repo-overlay/task.yaml
@@ -3,7 +3,7 @@ summary: package repositories in overlays test
 execute: |
   run_rockcraft pack
 
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:repo-overlay_0.1_amd64.rock docker-daemon:repo-overlay:0.1
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:repo-overlay_0.1_amd64.rock docker-daemon:repo-overlay:0.1
 
   docker images repo-overlay | MATCH "repo-overlay"
 

--- a/tests/spread/rockcraft/bare-base/task.yaml
+++ b/tests/spread/rockcraft/bare-base/task.yaml
@@ -8,7 +8,7 @@ execute: |
 
   # test container execution
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:bare-base-test_latest_amd64.rock docker-daemon:bare-base-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:bare-base-test_latest_amd64.rock docker-daemon:bare-base-test:latest
   rm bare-base-test_latest_amd64.rock
   docker images bare-base-test:latest
   id=$(docker run --rm -d bare-base-test)

--- a/tests/spread/rockcraft/base-devel/task.yaml
+++ b/tests/spread/rockcraft/base-devel/task.yaml
@@ -25,7 +25,7 @@ execute: |
 
   # test container execution
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy \
+  sudo rockcraft.skopeo --insecure-policy copy \
       oci-archive:base-devel_0.1_amd64.rock \
       docker-daemon:base-devel:0.1
   rm base-devel_0.1_amd64.rock

--- a/tests/spread/rockcraft/chisel/task.yaml
+++ b/tests/spread/rockcraft/chisel/task.yaml
@@ -10,7 +10,7 @@ execute: |
 
   # copy image to docker
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy "oci-archive:$ROCK" "docker-daemon:$IMG_NAME:latest"
+  sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$ROCK" "docker-daemon:$IMG_NAME:latest"
   rm "$ROCK"
 
   # Check that the file "md5sum" exists in "/bin". This file is provided

--- a/tests/spread/rockcraft/craftctl/task.yaml
+++ b/tests/spread/rockcraft/craftctl/task.yaml
@@ -11,7 +11,7 @@ execute: |
 
   # test container execution
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:craftctl-test_latest_craftctl.rock docker-daemon:craftctl-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:craftctl-test_latest_craftctl.rock docker-daemon:craftctl-test:latest
   rm craftctl-test_latest_craftctl.rock
   docker images craftctl-test:latest
   docker run --rm --entrypoint /usr/bin/hello craftctl-test:latest

--- a/tests/spread/rockcraft/entrypoint-service/task.yaml
+++ b/tests/spread/rockcraft/entrypoint-service/task.yaml
@@ -6,7 +6,7 @@ execute: |
   test -f entrypoint-service-test_latest_amd64.rock
 
   # test container execution
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:entrypoint-service-test_latest_amd64.rock docker-daemon:entrypoint-service-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:entrypoint-service-test_latest_amd64.rock docker-daemon:entrypoint-service-test:latest
   rm entrypoint-service-test_latest*.rock  
   docker images entrypoint-service-test:latest
   id=$(docker run -d entrypoint-service-test)

--- a/tests/spread/rockcraft/environment/task.yaml
+++ b/tests/spread/rockcraft/environment/task.yaml
@@ -9,7 +9,7 @@ execute: |
 
   # test container execution
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:environment-test_latest_amd64v2.rock docker-daemon:environment-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:environment-test_latest_amd64v2.rock docker-daemon:environment-test:latest
   rm environment-test_latest*.rock  
   docker images environment-test:latest
   id=$(docker run --rm -d environment-test -v)

--- a/tests/spread/rockcraft/extension-flask/task.yaml
+++ b/tests/spread/rockcraft/extension-flask/task.yaml
@@ -10,7 +10,7 @@ execute: |
   # Ensure docker does not have this container image
   docker rmi --force flask-extension
   # Install container
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:flask-extension_0.1_amd64.rock docker-daemon:flask-extension:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:flask-extension_0.1_amd64.rock docker-daemon:flask-extension:latest
   # Ensure container exists
   docker images flask-extension | MATCH "flask-extension"
 

--- a/tests/spread/rockcraft/health-checks/task.yaml
+++ b/tests/spread/rockcraft/health-checks/task.yaml
@@ -8,7 +8,7 @@ execute: |
 
   # test container execution
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:healthy-rock_latest_amd64.rock docker-daemon:healthy-rock:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:healthy-rock_latest_amd64.rock docker-daemon:healthy-rock:latest
   rm healthy-rock_latest_amd64.rock
   docker images healthy-rock:latest
   id=$(docker run --rm -d healthy-rock)

--- a/tests/spread/rockcraft/init/task.yaml
+++ b/tests/spread/rockcraft/init/task.yaml
@@ -10,7 +10,7 @@ execute: |
 
   # test container execution
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:my-rock-name_0.1_amd64.rock docker-daemon:my-rock-name:0.1
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:my-rock-name_0.1_amd64.rock docker-daemon:my-rock-name:0.1
   rm my-rock-name_0.1_amd64.rock
   docker images my-rock-name:0.1
   docker run --rm my-rock-name:0.1 exec bash -c 'echo Hello World'

--- a/tests/spread/rockcraft/plugin-python-3.6/task.yaml
+++ b/tests/spread/rockcraft/plugin-python-3.6/task.yaml
@@ -13,7 +13,7 @@ execute: |
   # Build the rock & load it into docker
   run_rockcraft pack
   ROCK=$(ls ./*.rock)
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:${IMAGE}
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:"${ROCK}" docker-daemon:${IMAGE}
   rm "${ROCK}"
 
   docker run --rm $IMAGE exec python3.6 --version | MATCH "Python 3.6"

--- a/tests/spread/rockcraft/plugin-python/task.yaml
+++ b/tests/spread/rockcraft/plugin-python/task.yaml
@@ -22,7 +22,7 @@ execute: |
   # Build the rock & load it into docker
   run_rockcraft pack
   test -f ${ROCK_FILE}
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:${ROCK_FILE} docker-daemon:${IMAGE}
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:${ROCK_FILE} docker-daemon:${IMAGE}
   docker images
   rm ${ROCK_FILE}
   

--- a/tests/spread/rockcraft/prune/check_layers.py
+++ b/tests/spread/rockcraft/prune/check_layers.py
@@ -52,7 +52,7 @@ def _get_tar_file(tarinfo: tarfile.TarInfo, sha: str, dest_dir: Path) -> Path:
 rock_name = sys.argv[1]
 
 inspect = subprocess.check_output(
-    ["/snap/rockcraft/current/bin/skopeo", "inspect", f"oci-archive:{rock_name}"]
+    ["rockcraft.skopeo", "inspect", f"oci-archive:{rock_name}"]
 )
 as_json = json.loads(inspect)
 

--- a/tests/spread/rockcraft/repo-bare-base/task.yaml
+++ b/tests/spread/rockcraft/repo-bare-base/task.yaml
@@ -9,7 +9,7 @@ execute: |
   # Ensure docker does not have this container image
   docker rmi --force apt-repo-static-test
   # Install container
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:apt-repo-static-test_latest_amd64.rock docker-daemon:apt-repo-static-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:apt-repo-static-test_latest_amd64.rock docker-daemon:apt-repo-static-test:latest
   # Ensure container exists
   docker images apt-repo-static-test | MATCH "apt-repo-static-test"
   

--- a/tests/spread/rockcraft/repo-ubuntu-base/task.yaml
+++ b/tests/spread/rockcraft/repo-ubuntu-base/task.yaml
@@ -9,7 +9,7 @@ execute: |
   # Ensure docker does not have this container
   docker rmi --force apt-repo-test
   # Install container
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:apt-repo-test_latest_amd64.rock docker-daemon:apt-repo-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:apt-repo-test_latest_amd64.rock docker-daemon:apt-repo-test:latest
   # Ensure container exists
   docker images apt-repo-test | MATCH "apt-repo-test"
   

--- a/tests/spread/rockcraft/run-user-minimal/task.yaml
+++ b/tests/spread/rockcraft/run-user-minimal/task.yaml
@@ -9,7 +9,7 @@ execute: |
   # Ensure docker does not have this container image
   docker rmi --force run-user-minimal-test
   # Install container
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy \
+  sudo rockcraft.skopeo --insecure-policy copy \
     oci-archive:run-user-minimal-test_latest_amd64.rock \
     docker-daemon:run-user-minimal-test:latest
   # Ensure container exists

--- a/tests/spread/rockcraft/run-user/task.yaml
+++ b/tests/spread/rockcraft/run-user/task.yaml
@@ -9,7 +9,7 @@ execute: |
   # Ensure docker does not have this container image
   docker rmi --force run-user-test
   # Install container
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:run-user-test_latest_amd64.rock docker-daemon:run-user-test:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:run-user-test_latest_amd64.rock docker-daemon:run-user-test:latest
   # Ensure container exists
   docker images run-user-test | MATCH "run-user-test"
   docker inspect run-user-test --format '{{.Config.User}}' | MATCH "_daemon_"

--- a/tests/spread/rockcraft/usrmerge-file-collision/task.yaml
+++ b/tests/spread/rockcraft/usrmerge-file-collision/task.yaml
@@ -9,7 +9,7 @@ execute: |
 
   # copy image to docker
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:"$ROCK" docker-daemon:usrmerge:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:"$ROCK" docker-daemon:usrmerge:latest
   rm "$ROCK"
 
   docker images usrmerge:latest

--- a/tests/spread/rockcraft/usrmerge/task.yaml
+++ b/tests/spread/rockcraft/usrmerge/task.yaml
@@ -9,7 +9,7 @@ execute: |
 
   # copy image to docker
   docker images
-  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:"$ROCK" docker-daemon:usrmerge:latest
+  sudo rockcraft.skopeo --insecure-policy copy oci-archive:"$ROCK" docker-daemon:usrmerge:latest
   rm "$ROCK"
 
   docker images usrmerge:latest


### PR DESCRIPTION
skopeo was already part of our UI because a lot of our tutorials referenced /snap/rockcraft/current/bin/skopeo directly, and this has been requested by users.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
