### PR TITLE
build(deps): bump craft-parts to 1.31.0

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -10,7 +10,17 @@ Rockcraft.
 .. toctree::
    :maxdepth: 1
 
+   /common/craft-parts/reference/plugins/dotnet_plugin
+   /common/craft-parts/reference/plugins/ant_plugin
+   /common/craft-parts/reference/plugins/autotools_plugin
+   /common/craft-parts/reference/plugins/cmake_plugin
    /common/craft-parts/reference/plugins/dump_plugin
+   /common/craft-parts/reference/plugins/go_plugin
+   /common/craft-parts/reference/plugins/make_plugin
    /common/craft-parts/reference/plugins/maven_plugin
+   /common/craft-parts/reference/plugins/meson_plugin
+   /common/craft-parts/reference/plugins/nil_plugin
+   /common/craft-parts/reference/plugins/npm_plugin
    plugins/python_plugin
    /common/craft-parts/reference/plugins/rust_plugin
+   /common/craft-parts/reference/plugins/scons_plugin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ coverage==7.4.4
 craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
-craft-parts==1.29.0
+craft-parts==1.31.0
 craft-providers==1.23.1
 cryptography==42.0.5
 Deprecated==1.2.14

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -14,7 +14,7 @@ craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.29.0
+craft-parts==1.31.0
 craft-providers==1.23.1
 Deprecated==1.2.14
 distro==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ charset-normalizer==3.3.2
 craft-application==2.7.0
 craft-archives==1.1.3
 craft-cli==2.5.1
-craft-parts==1.29.0
+craft-parts==1.31.0
 craft-providers==1.23.1
 Deprecated==1.2.14
 distro==1.9.0


### PR DESCRIPTION
Version 1.31.0 brings in a new set of plugin docs.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
