### PR TITLE
Overlay ca-certificates in django/flask extensions

### DIFF
--- a/docs/how-to/code/use-flask-extension/example/rockcraft.yaml
+++ b/docs/how-to/code/use-flask-extension/example/rockcraft.yaml
@@ -2,7 +2,7 @@ name: example-flask
 summary: A Flask application
 description: A rock packing a Flask application via the flask extension
 version: "0.1"
-base: bare
+base: ubuntu@22.04
 build-base: ubuntu@22.04
 license: Apache-2.0
 

--- a/docs/how-to/code/use-flask-extension/prime_example/rockcraft.yaml
+++ b/docs/how-to/code/use-flask-extension/prime_example/rockcraft.yaml
@@ -2,7 +2,7 @@ name: example-flask
 summary: A Flask application
 description: A rock packing a Flask application via the flask extension
 version: "0.1"
-base: bare
+base: ubuntu@22.04
 build-base: ubuntu@22.04
 license: Apache-2.0
 

--- a/docs/how-to/code/use-flask-extension/prime_exclude_example/rockcraft.yaml
+++ b/docs/how-to/code/use-flask-extension/prime_exclude_example/rockcraft.yaml
@@ -2,7 +2,7 @@ name: example-flask
 summary: A Flask application
 description: A rock packing a Flask application via the flask extension
 version: "0.1"
-base: bare
+base: ubuntu@22.04
 build-base: ubuntu@22.04
 license: Apache-2.0
 

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -92,17 +92,17 @@ class _GunicornBase(Extension):
         if self.yaml_data["base"] == "bare":
             parts[f"{self.framework}-framework/runtime"] = {
                 "plugin": "nil",
+                "overlay-packages": ["ca-certificates"],
                 "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp",
                 "stage-packages": [
                     "bash_bins",
                     "coreutils_bins",
-                    "ca-certificates_data",
                 ],
             }
         else:
             parts[f"{self.framework}-framework/runtime"] = {
                 "plugin": "nil",
-                "stage-packages": ["ca-certificates_data"],
+                "overlay-packages": ["ca-certificates"],
             }
         return parts
 

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -91,7 +91,7 @@ def test_flask_extension_default(tmp_path, flask_input_yaml):
             },
             "flask-framework/runtime": {
                 "plugin": "nil",
-                "stage-packages": ["ca-certificates_data"],
+                "overlay-packages": ["ca-certificates"],
             },
             "flask-framework/statsd-exporter": {
                 "build-snaps": ["go"],
@@ -293,8 +293,9 @@ def test_flask_extension_bare(tmp_path):
     applied = extensions.apply_extensions(tmp_path, flask_input_yaml)
     assert applied["parts"]["flask-framework/runtime"] == {
         "plugin": "nil",
+        "overlay-packages": ["ca-certificates"],
         "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp",
-        "stage-packages": ["bash_bins", "coreutils_bins", "ca-certificates_data"],
+        "stage-packages": ["bash_bins", "coreutils_bins"],
     }
 
 
@@ -407,7 +408,7 @@ def test_django_extension_default(tmp_path, django_input_yaml):
             },
             "django-framework/runtime": {
                 "plugin": "nil",
-                "stage-packages": ["ca-certificates_data"],
+                "overlay-packages": ["ca-certificates"],
             },
             "django-framework/statsd-exporter": {
                 "build-snaps": ["go"],


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

As packages declared in `stage-packages` do no run maintainer scripts it is necessary to use the `overlay` step for the `ca-certificates` package to work correctly  (see https://github.com/canonical/rockcraft/issues/334). 