### PR TITLE
Delete pyproject.toml in override-build in flask/django

### DIFF
--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -22,6 +22,7 @@ import os.path
 import pathlib
 import posixpath
 import re
+import textwrap
 from typing import Any, Dict, Tuple
 
 from overrides import override
@@ -73,6 +74,12 @@ class _GunicornBase(Extension):
                 "source": ".",
                 "python-packages": ["gunicorn"],
                 "python-requirements": ["requirements.txt"],
+                "override-build": textwrap.dedent(
+                    """\
+                    rm -f pyproject.toml
+                    craftctl default
+                    """
+                ),
             },
             f"{self.framework}-framework/install-app": self.gen_install_app_part(),
             f"{self.framework}-framework/config-files": {

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -14,8 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
+import textwrap
 
+import pytest
 from rockcraft import extensions
 from rockcraft.errors import ExtensionError
 
@@ -78,6 +79,12 @@ def test_flask_extension_default(tmp_path, flask_input_yaml):
                 "python-requirements": ["requirements.txt"],
                 "source": ".",
                 "stage-packages": ["python3-venv"],
+                "override-build": textwrap.dedent(
+                    """\
+                    rm -f pyproject.toml
+                    craftctl default
+                    """
+                ),
             },
             "flask-framework/install-app": {
                 "organize": {
@@ -276,6 +283,12 @@ def test_flask_extension_override_parts(tmp_path, flask_input_yaml):
         "python-requirements": ["requirements.txt", "requirements-jammy.txt"],
         "source": ".",
         "stage-packages": ["python3-venv"],
+        "override-build": textwrap.dedent(
+            """\
+            rm -f pyproject.toml
+            craftctl default
+            """
+        ),
     }
 
 
@@ -399,6 +412,12 @@ def test_django_extension_default(tmp_path, django_input_yaml):
                 "python-requirements": ["requirements.txt"],
                 "source": ".",
                 "stage-packages": ["python3-venv"],
+                "override-build": textwrap.dedent(
+                    """\
+                    rm -f pyproject.toml
+                    craftctl default
+                    """
+                ),
             },
             "django-framework/install-app": {
                 "organize": {"*": "django/app/", ".*": "django/app/"},


### PR DESCRIPTION
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

File `pyproject.toml` is not necessary for django/flask extensions, as there is no need to create a Python package.

Besides, for some project like NetBox, the `pyproject.toml` breaks the build.