### PR TITLE
docs: fix incorrect version in documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      - git fetch --tags --depth 1 # Also fetch tags
+      - git describe               # Useful for debugging
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ copyright = "2022-%s, %s" % (datetime.date.today().year, author)
 release = rockcraft.__version__
 if ".post" in release:
     # The commit hash in the dev release version confuses the spellchecker
-    release = release[0 : release.find(".post")]
+    release = "dev"
 
 # region Configuration for canonical-sphinx
 ogp_site_url = "https://canonical-rockcraft.readthedocs-hosted.com/"


### PR DESCRIPTION
This PR contains two commits:

* build(docs): fetch tags in readthedocs builds 

Readthedocs builds don't fetch tags when cloning the repo. This is a problem
for us because Rockcraft's version comes from the tag (via setuptools-scm),
so do a fetch of the tags as a post-checkout step.

* docs: use "dev" for non-release builds

The bug is this: If a build is done off of (say) 'main', the version coming
from 'git describe' will be something like 1.32.2.postXXXX. We previously
dropped the ".post*" suffix because it confused the spellchecker but that
just leaves the misleading "1.32.2" string. It's misleading because that's
an actual released version that does *not* contain a lot of the content
in 'main'.

So just use "dev" instead, to make it extra explicit that the docs refer
to an unreleased version of the software.

Fixes #584 

--------

For reference, this is the setting in RDT's configuration page that makes "stable" be the default version:
![image](https://github.com/canonical/rockcraft/assets/1951299/db1ee494-1aca-4bec-98a1-7bee209c5de1)
