### PR TITLE
feat: make 'license' an optional field

### DIFF
--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -115,7 +115,7 @@ the value of ``base``.
 
 **Type**: string, in `SPDX format <https://spdx.org/licenses/>`_
 
-**Required**: Yes
+**Required**: No
 
 The license of the software packaged inside the rock. This must match the SPDX
 format, but is case insensitive (e.g. both ``MIT`` and ``mit`` are valid).

--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -117,8 +117,9 @@ the value of ``base``.
 
 **Required**: No
 
-The license of the software packaged inside the rock. This must match the SPDX
-format, but is case insensitive (e.g. both ``MIT`` and ``mit`` are valid).
+The license of the software packaged inside the rock. This must either be
+"proprietary" or match the SPDX format. It is case insensitive (e.g. both
+``MIT`` and ``mit`` are valid).
 
 ``run-user``
 ------------

--- a/rockcraft/commands/init.py
+++ b/rockcraft/commands/init.py
@@ -67,7 +67,6 @@ class InitCommand(AppCommand):
                     most important story about it. Keep it under 100 words though,
                     we live in tweetspace and your description wants to look good in the
                     container registries out there.
-                license: GPL-3.0 # your application's SPDX license
                 platforms: # The platforms this rock should be built on and run on
                     amd64:
 
@@ -87,7 +86,6 @@ class InitCommand(AppCommand):
                     most important story about it. Keep it under 100 words though,
                     we live in tweetspace and your description wants to look good in the
                     container registries out there.
-                license: GPL-3.0 # your application's SPDX license
                 platforms: # The platforms this rock should be built on and run on
                     amd64:
 
@@ -129,7 +127,6 @@ class InitCommand(AppCommand):
                     most important story about it. Keep it under 100 words though,
                     we live in tweetspace and your description wants to look good in the
                     container registries out there.
-                license: GPL-3.0 # your application's SPDX license
                 platforms: # The platforms this rock should be built on and run on
                     amd64:
 

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -347,7 +347,7 @@ class Project(YamlModelMixin, BuildPlanner, BaseProject):  # type: ignore[misc]
         lic: spdx_lookup.License | None = spdx_lookup.by_id(license)  # type: ignore[reportUnknownMemberType]
         if lic is None:
             raise CraftValidationError(
-                f"License {license} not valid. It must be valid and in SPDX format.",
+                f"License {license} not valid. It must be either 'proprietary' or in SPDX format.",
                 docs_url="https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml/#license",
             )
         return str(lic.id)  # type: ignore[reportUnknownMemberType]

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -333,7 +333,9 @@ class Project(YamlModelMixin, BuildPlanner, BaseProject):  # type: ignore[misc]
 
     @pydantic.validator("license", always=True)
     @classmethod
-    def _validate_license(cls, license: str | None) -> str | None:
+    def _validate_license(
+        cls, license: str | None  # pylint: disable=redefined-builtin
+    ) -> str | None:
         """Make sure the provided license is valid and in SPDX format."""
         if not license:
             return None
@@ -344,10 +346,9 @@ class Project(YamlModelMixin, BuildPlanner, BaseProject):  # type: ignore[misc]
 
         lic: spdx_lookup.License | None = spdx_lookup.by_id(license)  # type: ignore[reportUnknownMemberType]
         if lic is None:
-            docs_url = "https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml/#license"
             raise CraftValidationError(
-                f"License {license} not valid. It must be valid and in SPDX format.\n"
-                f"See {docs_url}"
+                f"License {license} not valid. It must be valid and in SPDX format.",
+                docs_url="https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml/#license",
             )
         return str(lic.id)  # type: ignore[reportUnknownMemberType]
 

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -152,8 +152,7 @@
     "description",
     "base",
     "platforms",
-    "parts",
-    "license"
+    "parts"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -54,6 +54,7 @@ version: latest
 base: ubuntu@20.04
 summary: "example for unit tests"
 description: "this is an example of a rockcraft.yaml for the purpose of testing rockcraft"
+license: Apache-2.0
 environment:
     BAZ: value1
     FOO: value3
@@ -251,6 +252,13 @@ def test_project_license_clean_name(yaml_loaded_data):
 
     project = Project.unmarshal(yaml_loaded_data)
     assert project.license == "MIT"
+
+
+def test_project_license_empty(yaml_loaded_data):
+    del yaml_loaded_data["license"]
+
+    project = Project.unmarshal(yaml_loaded_data)
+    assert project.license is None
 
 
 def test_project_title_empty(yaml_loaded_data):
@@ -453,9 +461,7 @@ def test_project_version_invalid(yaml_loaded_data):
     assert message.endswith(expected_suffix)
 
 
-@pytest.mark.parametrize(
-    "field", ["name", "base", "parts", "description", "summary", "license"]
-)
+@pytest.mark.parametrize("field", ["name", "base", "parts", "description", "summary"])
 def test_project_missing_field(yaml_loaded_data, field):
     del yaml_loaded_data[field]
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -243,7 +243,7 @@ def test_project_license_invalid(yaml_loaded_data):
     with pytest.raises(CraftValidationError) as err:
         load_project_yaml(yaml_loaded_data)
     assert str(err.value) == (
-        f"License {yaml_loaded_data['license']} not valid. It must be valid and in SPDX format."
+        f"License {yaml_loaded_data['license']} not valid. It must be either 'proprietary' or in SPDX format."
     )
 
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -54,7 +54,6 @@ version: latest
 base: ubuntu@20.04
 summary: "example for unit tests"
 description: "this is an example of a rockcraft.yaml for the purpose of testing rockcraft"
-license: Apache-2.0
 environment:
     BAZ: value1
     FOO: value3
@@ -134,11 +133,6 @@ def test_project_unmarshal(check, yaml_loaded_data):
     project = Project.unmarshal(yaml_loaded_data)
 
     for attr, v in yaml_loaded_data.items():
-        if attr == "license":
-            # The var license is a built-in,
-            # so we workaround it by using an alias
-            attr = "rock_license"
-
         if attr == "platforms":
             # platforms get mutated at validation time
             assert getattr(project, attr).keys() == v.keys()
@@ -256,7 +250,7 @@ def test_project_license_clean_name(yaml_loaded_data):
     yaml_loaded_data["license"] = "mIt"
 
     project = Project.unmarshal(yaml_loaded_data)
-    assert project.rock_license == "MIT"
+    assert project.license == "MIT"
 
 
 def test_project_title_empty(yaml_loaded_data):


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

`license` becomes an optional field, and as a result, it no longer shows up in the templated `rockcraft.yaml` file, for any profile.