### PR TITLE
chore: point to temporary build dependencies

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -22,5 +22,6 @@ Rockcraft.
    /common/craft-parts/reference/plugins/nil_plugin
    /common/craft-parts/reference/plugins/npm_plugin
    plugins/python_plugin
+   /common/craft-parts/reference/plugins/qmake_plugin
    /common/craft-parts/reference/plugins/rust_plugin
    /common/craft-parts/reference/plugins/scons_plugin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,11 +18,11 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.5.1
-craft-application==2.7.0
+craft-application @ git+https://github.com/canonical/craft-application@rockcraft
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.31.0
+craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
 craft-providers==1.23.1
 cryptography==42.0.7
 Deprecated==1.2.14

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -10,11 +10,11 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application==2.7.0
+craft-application @ git+https://github.com/canonical/craft-application@rockcraft
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.31.0
+craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
 craft-providers==1.23.1
 Deprecated==1.2.14
 distro==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
-craft-application==2.7.0
+craft-application @ git+https://github.com/canonical/craft-application@rockcraft
 craft-archives==1.1.3
 craft-cli==2.5.1
 craft-grammar==1.2.0
-craft-parts==1.31.0
+craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
 craft-providers==1.23.1
 Deprecated==1.2.14
 distro==1.9.0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -63,7 +63,7 @@ def test_run_pack_services(mocker, monkeypatch, tmp_path):
 
     cli.run()
 
-    lifecycle_mocks["run"].assert_called_once_with(step_name="prime", part_names=[])
+    lifecycle_mocks["run"].assert_called_once_with(step_name="prime")
 
     package_mocks["write_metadata"].assert_called_once_with(fake_prime_dir)
     package_mocks["pack"].assert_called_once_with(fake_prime_dir, Path())


### PR DESCRIPTION
Use the `rockcraft` branch from the `craft-parts` and `craft-application` repos.