### PR TITLE
doc: add explanation and guide for "bases"

### DIFF
--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -14,6 +14,7 @@ the motivations behind its development.
    chisel
    overlay-step
    rocks
+   bases
    pebble
    lifecycle-layer
    filesets

--- a/docs/explanation/rocks.rst
+++ b/docs/explanation/rocks.rst
@@ -15,6 +15,8 @@ Interoperability between rocks and other containers also extends to how
 container images are built, allowing rocks to be used as bases for existing
 build recipes, such as Dockerfiles, for further customisation and development.
 
+.. _what-sets-rocks-apart:
+
 What sets rocks apart?
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/how-to/chisel/index.rst
+++ b/docs/how-to/chisel/index.rst
@@ -7,3 +7,4 @@
    Create a package slice for Chisel <create-slice>
    Install a custom package slice <install-slice>
    Publish a slice definition <publish-slice>
+   Chisel an existing rock <chisel-existing-rock>

--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -67,6 +67,8 @@ A longer, possibly multi-line description of the rock.
 
 The rock version, used to tag the OCI image and name the rock file.
 
+.. _rockcraft_yaml_base:
+
 ``base``
 --------
 
@@ -84,14 +86,12 @@ which is typically used with static binaries or
    The notation "ubuntu:<channel>" is also supported for some channels, but this
    format is deprecated and should be avoided.
 
-.. note::
-   Base ``ubuntu@24.04`` is still unstable and under active development. To use
-   it, ``build-base`` *must* be ``devel``.
+.. _rockcraft_yaml_build_base:
 
 ``build-base``
 --------------
 
-**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | devel``
+**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | ubuntu@24.04 | devel``
 
 **Required**: Yes, if ``base`` is ``bare``
 

--- a/rockcraft/commands/init.py
+++ b/rockcraft/commands/init.py
@@ -59,6 +59,8 @@ class InitCommand(AppCommand):
         "simple": textwrap.dedent(
             """\
                 name: {name}
+                # see https://documentation.ubuntu.com/rockcraft/en/stable/explanation/bases/
+                # for more information about bases and using 'bare' bases for chiselled rocks
                 base: ubuntu@22.04 # the base environment for this rock
                 version: '0.1' # just for humans. Semantic versioning is recommended
                 summary: Single-line elevator pitch for your amazing rock # 79 char long summary
@@ -68,7 +70,7 @@ class InitCommand(AppCommand):
                     we live in tweetspace and your description wants to look good in the
                     container registries out there.
                 license: GPL-3.0 # your application's SPDX license
-                platforms: # The platforms this rock should be built on and run on
+                platforms: # the platforms this rock should be built on and run on
                     amd64:
 
                 parts:
@@ -79,6 +81,8 @@ class InitCommand(AppCommand):
         "flask-framework": textwrap.dedent(
             """\
                 name: {name}
+                # see https://documentation.ubuntu.com/rockcraft/en/stable/explanation/bases/
+                # for more information about bases and using 'bare' bases for chiselled rocks
                 base: ubuntu@22.04 # the base environment for this Flask application
                 version: '0.1' # just for humans. Semantic versioning is recommended
                 summary: A summary of your Flask application # 79 char long summary
@@ -88,16 +92,16 @@ class InitCommand(AppCommand):
                     we live in tweetspace and your description wants to look good in the
                     container registries out there.
                 license: GPL-3.0 # your application's SPDX license
-                platforms: # The platforms this rock should be built on and run on
+                platforms: # the platforms this rock should be built on and run on
                     amd64:
 
-                # To ensure the flask-framework extension works properly, your Flask application
+                # to ensure the flask-framework extension works properly, your Flask application
                 # should have an `app.py` file with an `app` object as the WSGI entrypoint.
                 extensions:
                     - flask-framework
 
 
-                # Uncomment the sections you need and adjust according to your requirements.
+                # uncomment the sections you need and adjust according to your requirements.
                 # parts:
                 #   flask-framework/dependencies:
                 #     stage-packages:
@@ -106,11 +110,11 @@ class InitCommand(AppCommand):
                 #
                 #   flask-framework/install-app:
                 #     prime:
-                #       # By default, only the files in app/, templates/, static/, and app.py
+                #       # by default, only the files in app/, templates/, static/, and app.py
                 #       # are copied into the image. You can modify the list below to override
                 #       # the default list and include or exclude specific files/directories
                 #       # in your project.
-                #       # Note: Prefix each entry with "flask/app/" followed by the local path.
+                #       # note: prefix each entry with "flask/app/" followed by the local path.
                 #       - flask/app/.env
                 #       - flask/app/app.py
                 #       - flask/app/webapp
@@ -121,6 +125,8 @@ class InitCommand(AppCommand):
         "django-framework": textwrap.dedent(
             """\
                 name: {name}
+                # see https://documentation.ubuntu.com/rockcraft/en/stable/explanation/bases/
+                # for more information about bases and using 'bare' bases for chiselled rocks
                 base: ubuntu@22.04 # the base environment for this Django application
                 version: '0.1' # just for humans. Semantic versioning is recommended
                 summary: A summary of your Django application # 79 char long summary
@@ -130,10 +136,10 @@ class InitCommand(AppCommand):
                     we live in tweetspace and your description wants to look good in the
                     container registries out there.
                 license: GPL-3.0 # your application's SPDX license
-                platforms: # The platforms this rock should be built on and run on
+                platforms: # the platforms this rock should be built on and run on
                     amd64:
 
-                # To ensure the django-framework extension functions properly, your Django project
+                # to ensure the django-framework extension functions properly, your Django project
                 # should have a structure similar to the following with ./{snake_name}/{snake_name}/wsgi.py
                 # being the WSGI entry point and contain an application object.
                 # +-- {snake_name}
@@ -151,7 +157,7 @@ class InitCommand(AppCommand):
                 extensions:
                     - django-framework
 
-                # Uncomment the sections you need and adjust according to your requirements.
+                # uncomment the sections you need and adjust according to your requirements.
                 # parts:
                 #   django-framework/dependencies:
                 #     stage-packages:


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

This PR adds a new explanation page for "Bases", which then refers to another new How-to guide on how to use `base` to go from a rock to a baseless and then chiselled rock.

This PR also fixes the `devel` reference in the reference docs and add doc links to the `rockcraft init` YAML template