### PR TITLE
fix: don't raise CraftValidationErrors in validators

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,10 +20,10 @@ colorama==0.4.6
 coverage==7.5.1
 craft-application @ git+https://github.com/canonical/craft-application@rockcraft
 craft-archives==1.1.3
-craft-cli==2.5.1
+craft-cli @ git+https://github.com/canonical/craft-cli@rockcraft
 craft-grammar==1.2.0
 craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
-craft-providers==1.23.1
+craft-providers @ git+https://github.com/canonical/craft-providers@rockcraft
 cryptography==42.0.7
 Deprecated==1.2.14
 dill==0.3.8

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -12,10 +12,10 @@ click==8.1.7
 colorama==0.4.6
 craft-application @ git+https://github.com/canonical/craft-application@rockcraft
 craft-archives==1.1.3
-craft-cli==2.5.1
+craft-cli @ git+https://github.com/canonical/craft-cli@rockcraft
 craft-grammar==1.2.0
 craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
-craft-providers==1.23.1
+craft-providers @ git+https://github.com/canonical/craft-providers@rockcraft
 Deprecated==1.2.14
 distro==1.9.0
 docutils==0.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 craft-application @ git+https://github.com/canonical/craft-application@rockcraft
 craft-archives==1.1.3
-craft-cli==2.5.1
+craft-cli @ git+https://github.com/canonical/craft-cli@rockcraft
 craft-grammar==1.2.0
 craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
-craft-providers==1.23.1
+craft-providers @ git+https://github.com/canonical/craft-providers@rockcraft
 Deprecated==1.2.14
 distro==1.9.0
 httplib2==0.22.0

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -183,9 +183,7 @@ class BuildPlanner(BaseBuildPlanner):
             try:
                 platform = Platform(**platform).dict()
             except pydantic.ValidationError as err:
-                errors = []
-                for err_dict in err.errors():
-                    errors.append(err_dict["msg"])
+                errors = [err_dict["msg"] for err_dict in err.errors()]
                 full_errors = ",".join(errors)
                 raise ValueError(f"{error_prefix}: {full_errors}") from None
 

--- a/tests/spread/rockcraft/invalid-name/task.yaml
+++ b/tests/spread/rockcraft/invalid-name/task.yaml
@@ -4,5 +4,5 @@ execute: |
   for name in a_a a@a a--a aa-
   do
     sed "s/placeholder-name/$name/" rockcraft.orig.yaml  > rockcraft.yaml
-    rockcraft pack 2>&1 >/dev/null | MATCH "Invalid name for rock"
+    rockcraft pack 2>&1 >/dev/null | MATCH "invalid name for rock"
   done


### PR DESCRIPTION
The rule is this: in validators, always raise the types that Pydantic expects (ValueErrors, AssertionErrors, TypeError, and subclasses of these). This allows Pydantic to capture all errors and group them into a single ValidationError, which we can then convert into a single CraftValidationError in from_yaml_data(). This provides a more uniform UI for the reporting of validation errors on the project.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
