### PR TITLE
build(deps): use proper versions for craft- libs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,7 @@ exclude_patterns = [
     "common/craft-parts/explanation/how_parts_are_built.rst",
     "common/craft-parts/explanation/overlay_step.rst",
     "common/craft-parts/how-to/craftctl.rst",
+    "common/craft-parts/reference/partition_specific_output_directory_variables.rst",
     "common/craft-parts/reference/parts_steps.rst",
     "common/craft-parts/reference/step_execution_environment.rst",
     "common/craft-parts/reference/step_output_directories.rst",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,12 +18,12 @@ click==8.1.7
 codespell==2.2.6
 colorama==0.4.6
 coverage==7.5.1
-craft-application @ git+https://github.com/canonical/craft-application@rockcraft
+craft-application==2.9.0
 craft-archives==1.1.3
-craft-cli @ git+https://github.com/canonical/craft-cli@rockcraft
+craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
-craft-providers @ git+https://github.com/canonical/craft-providers@rockcraft
+craft-parts==1.33.0
+craft-providers==1.24.1
 cryptography==42.0.7
 Deprecated==1.2.14
 dill==0.3.8

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -10,12 +10,12 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-craft-application @ git+https://github.com/canonical/craft-application@rockcraft
+craft-application==2.9.0
 craft-archives==1.1.3
-craft-cli @ git+https://github.com/canonical/craft-cli@rockcraft
+craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
-craft-providers @ git+https://github.com/canonical/craft-providers@rockcraft
+craft-parts==1.33.0
+craft-providers==1.24.1
 Deprecated==1.2.14
 distro==1.9.0
 docutils==0.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
-craft-application @ git+https://github.com/canonical/craft-application@rockcraft
+craft-application==2.9.0
 craft-archives==1.1.3
-craft-cli @ git+https://github.com/canonical/craft-cli@rockcraft
+craft-cli==2.6.0
 craft-grammar==1.2.0
-craft-parts @ git+https://github.com/canonical/craft-parts@rockcraft
-craft-providers @ git+https://github.com/canonical/craft-providers@rockcraft
+craft-parts==1.33.0
+craft-providers==1.24.1
 Deprecated==1.2.14
 distro==1.9.0
 httplib2==0.22.0


### PR DESCRIPTION
Now that those libs have been released we can use proper version ids again.

Fixes #619 