### PR TITLE
fix: improve `platforms.<platform>.build-on` validation

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -64,6 +64,14 @@ class Platform(pydantic.BaseModel):
             "_", "-"
         )
 
+    @pydantic.validator("build_on", pre=True)
+    @classmethod
+    def _helpful_error_for_non_list_build_on(cls, val: list[str] | Any) -> list[str]:
+        """Provide helpful error when 'build_on' is not a list."""
+        if not isinstance(val, (list, type(None))):
+            raise ValueError("'build-on' field must be a list of strings.")
+        return val
+
     @pydantic.validator("build_for", pre=True)
     @classmethod
     def _vectorise_build_for(cls, val: str | list[str]) -> list[str]:


### PR DESCRIPTION
Provide a helpful error message if `rockcraft.yaml` contains a `platforms.<platform>.build-on` which is not a list.

Fixes #632.

- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)? *

\* my employing organization should have signed it AFAIK.

Example of change
-----

Given this snipped of a `rockcraft.yaml`:

```yaml
...
platforms:
  arm64:
    build-on: amd64
...
```

### Before:

```bash
$ rockcraft build --debug
Bad rockcraft.yaml content:
- error for platform entry 'arm64': value is not a valid list (in field 'platforms')                                                                 
For more information, check out: https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml
```

#### After:

```bash
$ rockcraft build --debug
Bad rockcraft.yaml content:
- error for platform entry 'arm64': 'build-on' field must be a list of strings. (in field 'platforms')
For more information, check out: https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml
```