### PR TITLE
fix(docs/Makefile): added workaround for doc tool 'woke' skipping …

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,6 +10,11 @@ BUILDDIR      = _build
 VENV          = env/bin/activate
 PORT = 8080
 
+# Locate this directory relative to the repository root. See woke recipe.
+REPOROOT = $(shell git rev-parse --show-toplevel)
+RELCWD = $(shell realpath --relative-to=$(REPOROOT) $(CURDIR))
+
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -39,7 +44,12 @@ linkcheck:
 
 woke:
 	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }
-	woke *.rst **/*.rst -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml
+
+	# Woke appears to have a issue where it skips .*ignore files unless it is executed from the repo root.
+	# This is mitigated by changing to the repo root and running woke on the relative docs path.
+	cd ..; woke $(RELCWD)/**/*.rst \
+		-c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml  \
+		--exit-1-on-failure
 
 .PHONY: help Makefile
 


### PR DESCRIPTION
Test Build for fix(docs/Makefile): added workaround for doc tool 'woke' skipping .*ignore files


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
