### PR TITLE
Fix docs build languange tests

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,6 +10,10 @@ BUILDDIR      = _build
 VENV          = env/bin/activate
 PORT = 8080
 
+# Locate this directory relative to the repository root. See woke recipe.
+REPOROOT = $(shell git rev-parse --show-toplevel)
+RELCWD = $(shell realpath --relative-to=$(REPOROOT) $(CURDIR))
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -39,7 +43,12 @@ linkcheck:
 
 woke:
 	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }
-	woke *.rst **/*.rst -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml
+
+	# Woke appears to have a issue where it skips .*ignore files unless it is executed from the repo root.
+	# This is mitigated by changing to the repo root and running woke on the relative docs path.
+	# Tested on 19/07/24 with woke 0.19.0-4-g5d52c15
+	cd ..; woke $(RELCWD)/**/*.rst $(RELCWD)/*.rst \
+		-c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml 
 
 .PHONY: help Makefile
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,7 +47,7 @@ woke:
 	# Woke appears to have an issue where it skips .*ignore files unless it is executed from the repo root.
 	# This is mitigated by changing to the repo root and running woke on the relative docs path.
 	# Tested on 19/07/24 with woke 0.19.0-4-g5d52c15
-	cd ..; woke $(RELCWD)/**/*.rst $(RELCWD)/*.rst \
+	cd $(REPOROOT); woke $(RELCWD)/**/*.rst $(RELCWD)/*.rst \
 		-c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml \
 		--disable-default-rules \
 		--exit-1-on-failure

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -49,6 +49,7 @@ woke:
 	# Tested on 19/07/24 with woke 0.19.0-4-g5d52c15
 	cd ..; woke $(RELCWD)/**/*.rst $(RELCWD)/*.rst \
 		-c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml \
+		--disable-default-rules \
 		--exit-1-on-failure
 
 .PHONY: help Makefile

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,7 +44,7 @@ linkcheck:
 woke:
 	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }
 
-	# Woke appears to have a issue where it skips .*ignore files unless it is executed from the repo root.
+	# Woke appears to have an issue where it skips .*ignore files unless it is executed from the repo root.
 	# This is mitigated by changing to the repo root and running woke on the relative docs path.
 	# Tested on 19/07/24 with woke 0.19.0-4-g5d52c15
 	cd ..; woke $(RELCWD)/**/*.rst $(RELCWD)/*.rst \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,7 +48,8 @@ woke:
 	# This is mitigated by changing to the repo root and running woke on the relative docs path.
 	# Tested on 19/07/24 with woke 0.19.0-4-g5d52c15
 	cd ..; woke $(RELCWD)/**/*.rst $(RELCWD)/*.rst \
-		-c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml 
+		-c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml \
+		--exit-1-on-failure
 
 .PHONY: help Makefile
 


### PR DESCRIPTION
This PR includes several fixes for the language tests in our docs/Makefile:

- Fixed woke utility skipping .*ignore files. This appears to be a bug in the utility. I'll raise this issue with the maintainer.
- Disabled default woke configuration and exclusively test ours in canonical/Inclusive-naming.
- Enabled error exit status. The Tests action will now show if there are language issues.


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
