### PR TITLE
fix(spread): Pebble no longer supports -v with exec

### DIFF
--- a/tests/spread/rockcraft/chisel/task.yaml
+++ b/tests/spread/rockcraft/chisel/task.yaml
@@ -18,4 +18,4 @@ execute: |
   # only succeed if:
   #   * the "/bin -> usr/bin" symlink is correct, and;
   #   * pebble itself is found and working correctly (for the exec call).
-  docker run --rm $IMG_NAME -v exec test -f /bin/md5sum
+  docker run --rm $IMG_NAME exec test -f /bin/md5sum


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

Pebble `enter` no longer supports using `-v` with the `exec` command. This PR fixes a spread test that is failing because of that.