### PR TITLE
fix(docs/tutorial/flask.rst): fixed misspelt filename in tutorial

### DIFF
--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -315,7 +315,7 @@ look like the following:
     :language: python
 
 Since you are creating a new version of your application, **open the**
-``rockfile.yaml`` file and change the ``version`` (e.g. to ``0.2``).
+``rockcraft.yaml`` file and change the ``version`` (e.g. to ``0.2``).
 
 Pack and run the rock using similar commands as before:
 


### PR DESCRIPTION
A small PR to fix a filename in the flask Tutorial.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
