### PR TITLE
cherry pick fixes to main

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -61,7 +61,9 @@ prepare: |
   else
     tests.pkgs remove lxd
   fi
-  snap install lxd --channel=latest/stable
+
+  # 5.21/stable is the latest stable LTS
+  snap install lxd --channel=5.21/stable
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -83,7 +83,7 @@ def test_package_repositories_in_overlay(new_dir, mocker, run_lifecycle):
     assert overlay_apt.is_dir()
 
     # Checking that the files are present should be enough
-    assert (overlay_apt / "keyrings/craft-CE49EC21.gpg").is_file()
+    assert (overlay_apt / "keyrings/craft-9BE21867.gpg").is_file()
     assert (overlay_apt / "sources.list.d/craft-ppa-mozillateam_ppa.sources").is_file()
     assert (overlay_apt / "preferences.d/craft-archives").is_file()
 


### PR DESCRIPTION
These are two fixes done in `feature/pydantic-2`, cherry-picked here to unbreak `main`