### PR TITLE
build(deps): bump craft-providers to 1.24.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
 craft-parts==1.33.0
-craft-providers==1.24.1
+craft-providers==1.24.2
 cryptography==42.0.7
 Deprecated==1.2.14
 dill==0.3.8

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -15,7 +15,7 @@ craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
 craft-parts==1.33.0
-craft-providers==1.24.1
+craft-providers==1.24.2
 Deprecated==1.2.14
 distro==1.9.0
 docutils==0.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ craft-archives==1.1.3
 craft-cli==2.6.0
 craft-grammar==1.2.0
 craft-parts==1.33.0
-craft-providers==1.24.1
+craft-providers==1.24.2
 Deprecated==1.2.14
 distro==1.9.0
 httplib2==0.22.0


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

### Changelog

#### 1.24.2 (2024-08-27)

- Remove Ubuntu 23.10 (Mantic) support
- Require Multipass>=1.14.1 when launching Ubuntu 24.04 (Noble) VMs

(CRAFT-3270)