### PR TITLE
tests(spread): use LXD from `5.21/candidate`

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -62,8 +62,9 @@ prepare: |
     tests.pkgs remove lxd
   fi
 
-  # 5.21/stable is the latest stable LTS
-  snap install lxd --channel=5.21/stable
+  # 5.21/stable is the latest stable LTS. Use 5.21/candidate as a "first line of
+  # defense" against LXD regressions.
+  snap install lxd --channel=5.21/candidate
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"


### PR DESCRIPTION
This serves two purposes:

a) It un-breaks `main` as `5.21/candidate` has the fixes for the regressions
   when mounting the overlay filesystems;
b) It lets the spread tests act as a line of defense against further LTS
   regressions, without being too exposed to breakage by using something like
   `latest/edge`.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
