### PR TITLE
chore: unshallow clone used in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,8 @@ build:
     python: "3.10"
   jobs:
     post_checkout:
-      - git fetch --tags --depth 1 # Also fetch tags
-      - git describe               # Useful for debugging
+      - git fetch --tags --unshallow  # Also fetch tags
+      - git describe                  # Make sure we get a proper version
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -370,7 +370,7 @@ The updated application should respond with the current date and time (e.g.
 .. note::
 
     If you are getting a ``404`` for the ``/time/`` endpoint, check the
-    :ref:`troubleshooting` steps below.
+    :ref:`troubleshooting-django` steps below.
 
 Cleanup
 ~~~~~~~
@@ -415,7 +415,7 @@ following:
 
 ----
 
-.. _troubleshooting:
+.. _troubleshooting-django:
 
 Troubleshooting
 ===============

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -357,7 +357,7 @@ The updated application should respond with the current date and time (e.g.
 .. note::
 
     If you are getting a ``404`` for the ``/time`` endpoint, check the
-    :ref:`troubleshooting` steps below.
+    :ref:`troubleshooting-flask` steps below.
 
 Cleanup
 ~~~~~~~
@@ -402,7 +402,7 @@ following:
 
 ----
 
-.. _troubleshooting:
+.. _troubleshooting-flask:
 
 Troubleshooting
 ===============


### PR DESCRIPTION
The readthedocs build started sporadically failing; what I *think* is happening is that the latest tag (1.5.3) is far enough from the HEAD of main (over 50 commits) that the previous command of fetching the tags was no longer sufficient to have "git describe" be able to reach the tag.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
