### PR TITLE
refactor: use craft-platform for the build plans

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,7 @@ craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
+craft-platforms==0.3.0
 craft-providers==2.0.1
 cryptography==43.0.1
 cssutils==2.11.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
-craft-platforms==0.3.0
+craft-platforms==0.3.1
 craft-providers==2.0.1
 cryptography==43.0.1
 cssutils==2.11.1

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -21,7 +21,7 @@ craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
-craft-platforms==0.3.0
+craft-platforms==0.3.1
 craft-providers==2.0.1
 cssutils==2.11.1
 dict2css==0.3.0.post1

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -21,6 +21,7 @@ craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
+craft-platforms==0.3.0
 craft-providers==2.0.1
 cssutils==2.11.1
 dict2css==0.3.0.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
-craft-platforms==0.3.0
+craft-platforms==0.3.1
 craft-providers==2.0.1
 distro==1.9.0
 httplib2==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ craft-archives==2.0.0
 craft-cli==2.7.0
 craft-grammar==2.0.1
 craft-parts==2.1.1
+craft-platforms==0.3.0
 craft-providers==2.0.1
 distro==1.9.0
 httplib2==0.22.0

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -24,19 +24,22 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import craft_cli
+import craft_platforms
 import pydantic
 import spdx_lookup  # type: ignore
 import yaml
 from craft_application.errors import CraftValidationError
 from craft_application.models import (
-    BuildPlanner as BaseBuildPlanner,
-)
-from craft_application.models import (
+    BuildInfo,
     Platform,
     get_validator_by_regex,
 )
+from craft_application.models import (
+    BuildPlanner as BaseBuildPlanner,
+)
 from craft_application.models import Project as BaseProject
 from craft_application.models.base import alias_generator
+from craft_platforms import rock
 from craft_providers import bases
 from craft_providers.errors import BaseConfigurationError
 from typing_extensions import Annotated, override
@@ -218,6 +221,28 @@ class BuildPlanner(BaseBuildPlanner):
     @classmethod
     def model_reference_slug(cls) -> str | None:
         return "/reference/rockcraft.yaml"
+
+    @override
+    def get_build_plan(self) -> list[BuildInfo]:
+        platforms = typing.cast(
+            # https://github.com/canonical/craft-platforms/issues/43
+            craft_platforms.Platforms,  # pyright: ignore[reportPrivateImportUsage]
+            {name: platform.marshal() for name, platform in self.platforms.items()},
+        )
+        build_infos = rock.get_rock_build_plan(
+            base=self.base,
+            build_base=self.build_base,
+            platforms=platforms,
+        )
+        return [
+            BuildInfo(
+                platform=info.platform,
+                build_on=str(info.build_on),
+                build_for=str(info.build_for),
+                base=self.effective_base,
+            )
+            for info in build_infos
+        ]
 
 
 class Project(BuildPlanner, BaseProject):  # type: ignore[misc]

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -225,8 +225,7 @@ class BuildPlanner(BaseBuildPlanner):
     @override
     def get_build_plan(self) -> list[BuildInfo]:
         platforms = typing.cast(
-            # https://github.com/canonical/craft-platforms/issues/43
-            craft_platforms.Platforms,  # pyright: ignore[reportPrivateImportUsage]
+            craft_platforms.Platforms,
             {name: platform.marshal() for name, platform in self.platforms.items()},
         )
         build_infos = rock.get_rock_build_plan(

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     craft-archives>=2.0.0
     craft-cli
     craft-parts>=2.0.0
+    craft-platforms~=0.3
     craft-providers>=2.0.0
     overrides
     spdx-lookup


### PR DESCRIPTION
The semantics are the same; the goal is to have a single source of build plans that is used both by Rockcraft and by whatever other code (e.g. remote builds) might need it.

Fixes #698

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
