### PR TITLE
fix: set PATH on bare-based rocks

### DIFF
--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -389,6 +389,21 @@ class Image:
         _config_image(image_path, cmd_params)
         emit.progress(f"CMD set to {opt_args}")
 
+    def set_default_path(self, base: str) -> None:
+        """Set the default PATH on the image (only for bare rocks)."""
+        if base != "bare":
+            emit.debug(f"Not setting a PATH on the image as base is {base!r}")
+            return
+
+        # Follow Pebble's lead here: if PATH is empty, use the standard one.
+        # This means that containers that bypass the pebble entrypoint will
+        # have the same behavior as PATH-less pebble services.
+        pebble_path = Pebble.DEFAULT_ENV_PATH
+        image_path = self.path / self.image_name
+
+        emit.debug(f"Setting bare-based rock PATH to {pebble_path!r}")
+        _config_image(image_path, ["--config.env", f"PATH={pebble_path}"])
+
     def set_pebble_layer(
         self,
         services: dict[str, Any],

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -151,6 +151,9 @@ class Pebble:
         **_BASE_PART_SPEC,
         "stage": [PEBBLE_BINARY_PATH_PREVIOUS],
     }
+    # This is the value that Pebble sets to the PATH env var if it's empty.
+    # (https://github.com/canonical/pebble/blob/master/internals/overlord/cmdstate/request.go#L91)
+    DEFAULT_ENV_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
     def define_pebble_layer(
         self,

--- a/rockcraft/services/package.py
+++ b/rockcraft/services/package.py
@@ -157,6 +157,8 @@ def _pack(
     if project.services and project.entrypoint_service in project.services:
         new_image.set_cmd(project.services[project.entrypoint_service].command)
 
+    new_image.set_default_path(project.base)
+
     dumped = project.marshal()
     services = cast(dict[str, typing.Any], dumped.get("services", {}))
     checks = cast(dict[str, typing.Any], dumped.get("checks", {}))

--- a/tests/spread/rockcraft/bare-base/rockcraft.orig.yaml
+++ b/tests/spread/rockcraft/bare-base/rockcraft.orig.yaml
@@ -3,7 +3,7 @@ version: latest
 summary: A tiny rock
 description: Building a tiny rock from a bare base, with just one package
 license: Apache-2.0
-build-base: ubuntu@22.04
+build-base: placeholder-base
 base: bare
 services:
   hello:
@@ -18,3 +18,4 @@ parts:
     plugin: nil
     stage-packages:
       - hello
+      - base-files # for the usrmerge symlinks in ubuntu@24.04 and newer

--- a/tests/spread/rockcraft/bare-base/task.yaml
+++ b/tests/spread/rockcraft/bare-base/task.yaml
@@ -1,6 +1,14 @@
 summary: bare base build test
+environment:
+  BASE/24_04: "ubuntu@24.04"
+  PEBBLE_DIR/24_04: "/usr/bin"
+
+  BASE/22_04: "ubuntu@22.04"
+  PEBBLE_DIR/22_04: "/bin"
 
 execute: |
+  sed "s/placeholder-base/$BASE/" rockcraft.orig.yaml  > rockcraft.yaml
+
   run_rockcraft pack
 
   test -f bare-base-test_latest_amd64.rock
@@ -15,6 +23,11 @@ execute: |
   grep_docker_log "$id" "ship it!"
   docker exec "$id" pebble services | grep hello
   docker exec "$id" pebble ls /usr/bin/hello
-  test "$(docker inspect "$id" -f '{{json .Config.Entrypoint}}')" = '["/bin/pebble","enter"]'
+  test "$(docker inspect "$id" -f '{{json .Config.Entrypoint}}')" = "[\"${PEBBLE_DIR}/pebble\",\"enter\"]"
   
+  # Bare-based rocks should have the default Ubuntu path, as an empty PATH is a
+  # security issue when containers bypass the pebble entrypoint.
+  EXPECTED_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  test "$(docker inspect "$id" -f '{{json .Config.Env}}')" = "[\"PATH=${EXPECTED_PATH}\"]"
+
   docker rm -f "$id"

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -951,3 +951,33 @@ class TestImage:
             )
         ]
         assert mock_loads.called
+
+    def test_set_path_bare(self, mock_run):
+        image = oci.Image("a:b", Path("/c"))
+
+        image.set_default_path("bare")
+
+        expected = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        assert mock_run.mock_calls == [
+            call(
+                [
+                    "umoci",
+                    "config",
+                    "--image",
+                    "/c/a:b",
+                    "--config.env",
+                    f"PATH={expected}",
+                ]
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "base",
+        ["ubuntu@24.04", "ubuntu@22.04", "ubuntu@20.04"],
+    )
+    def test_set_path_non_bare(self, mock_run, base):
+        image = oci.Image("a:b", Path("/c"))
+
+        image.set_default_path(base)
+
+        assert not mock_run.called


### PR DESCRIPTION
If the PATH is empty, Pebble will be default use the standard Ubuntu value
of "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" (see [0]).
Follow this lead and set this value on the image's PATH.

This PATH setting on the image itself has no bearing on most cases, as the
PATH that prevails is the one defined by Pebble and its services, but an
empty (or unset) PATH is a potential security issue in cases where the pebble
entrypoint is bypassed.

0: https://github.com/canonical/pebble/blob/master/internals/overlord/cmdstate/request.go#L91

Fixes #711
