### PR TITLE
chore: remove flake8 and pydocstyle

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,15 +38,9 @@ jobs:
       - name: Run codespell
         run: |
           make test-codespell
-      - name: Run flake8
-        run: |
-          make test-flake8
       - name: Run mypy
         run: |
           make test-mypy
-      - name: Run pydocstyle
-        run: |
-          make test-pydocstyle
       - name: Run pyright
         run: |
           sudo snap watch --last=install

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ autoformat: ## Run automatic code formatters.
 ifndef RUFF
 	$(error "Ruff not installed. Install it with `sudo snap install ruff` or using the official installation instructions: https://docs.astral.sh/ruff/installation/")
 endif
-	autoflake rockcraft/ tests/
 	black .
 	ruff check --fix-only rockcraft tests
 
@@ -74,7 +73,7 @@ install: clean ## Install python package.
 	python setup.py install
 
 .PHONY: lint
-lint: test-black test-codespell test-flake8 test-mypy test-pydocstyle test-pyright test-ruff test-sphinx-lint test-shellcheck ## Run all linting tests.
+lint: test-black test-codespell test-mypy test-pyright test-ruff test-sphinx-lint test-shellcheck ## Run all linting tests.
 
 .PHONY: release
 release: dist ## Release with twine.
@@ -87,10 +86,6 @@ test-black:
 .PHONY: test-codespell
 test-codespell:
 	codespell rockcraft tests
-
-.PHONY: test-flake8
-test-flake8:
-	flake8 rockcraft tests
 
 .PHONY: test-ruff
 test-ruff:
@@ -106,10 +101,6 @@ test-integrations: ## Run integration tests.
 .PHONY: test-mypy
 test-mypy:
 	mypy rockcraft tests
-
-.PHONY: test-pydocstyle
-test-pydocstyle:
-	pydocstyle rockcraft
 
 .PHONY: test-pylint
 test-pylint:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,8 +20,6 @@ apeye-core==1.1.5
     # via apeye
 autodocsumm==0.2.13
     # via sphinx-toolbox
-autoflake==1.7.8
-    # via rockcraft (setup.py)
 babel==2.16.0
     # via sphinx
 backports-tarfile==1.2.0
@@ -130,8 +128,6 @@ filelock==3.16.1
     #   sphinx-toolbox
     #   tox
     #   virtualenv
-flake8==4.0.1
-    # via rockcraft (setup.py)
 furo==2024.8.6
     # via canonical-sphinx
 gitdb==4.0.11
@@ -208,7 +204,6 @@ markupsafe==3.0.1
     #   sphinx-jinja2-compat
 mccabe==0.6.1
     # via
-    #   flake8
     #   rockcraft (setup.py)
 mdit-py-plugins==0.4.2
     # via myst-parser
@@ -267,8 +262,6 @@ pluggy==1.5.0
     #   tox
 polib==1.2.0
     # via sphinx-lint
-pycodestyle==2.8.0
-    # via flake8
 pycparser==2.22
     # via cffi
 pydantic==2.9.2
@@ -282,10 +275,6 @@ pydantic-core==2.23.4
     # via pydantic
 pydocstyle==6.3.0
     # via rockcraft (setup.py)
-pyflakes==2.4.0
-    # via
-    #   autoflake
-    #   flake8
 pygit2==1.14.1
     # via craft-application
 pygments==2.18.0
@@ -455,7 +444,6 @@ tabulate==0.9.0
     #   sphinx-toolbox
 tomli==2.0.2
     # via
-    #   autoflake
     #   black
     #   mypy
     #   pyproject-api

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,9 +61,7 @@ test =
     coverage
     black
     codespell
-    flake8>=4.0.1
     mypy
-    pydocstyle
     pytest
     pytest-check>=2.0
     pytest-mock
@@ -74,7 +72,6 @@ test =
     types-pyyaml
     types-tabulate>=0.9.0.2
 dev =
-    autoflake
     %(doc)s
     %(release)s
     %(test)s
@@ -92,34 +89,11 @@ quiet-level = 3
 skip = ./docs/_build,.direnv,.git,.mypy_cache,.pytest_cache,.venv,__pycache__,venv
 ignore-words-list = warmup,buildd,astroid
 
-[flake8]
-exclude = .direnv .git .mypy_cache .pytest_cache .venv __pycache__ venv
-max-line-length = 88
-# E203 whitespace before ':'
-# E501 line too long
-extend-ignore = E203,E501
-
-[autoflake]
-remove-all-unused-imports=true
-ignore-init-module-imports=true
-recursive=true
-in-place=true
-
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
-
-[pydocstyle]
-# D105 Missing docstring in magic method (reason: magic methods already have definitions)
-# D107 Missing docstring in __init__ (reason: documented in class docstring)
-# D203 1 blank line required before class docstring (reason: pep257 default)
-# D213 Multi-line docstring summary should start at the second line (reason: pep257 default)
-# D215 Section underline is over-indented (reason: pep257 default)
-ignore = D105, D107, D203, D213, D215
-# Allow missing docstrings in methods that are overridden
-ignore_decorators = override
 
 [aliases]
 test = pytest


### PR DESCRIPTION
Both of these have been replaced with ruff.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
