### PR TITLE
Adds run_once_command rock build option

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -257,6 +257,7 @@ class Project(BuildPlanner, BaseProject):  # type: ignore[misc]
     services: dict[str, Service] | None = None
     checks: dict[str, Check] | None = None
     entrypoint_service: str | None = None
+    run_once_command: str | None = None
     platforms: dict[str, Platform | None]  # type: ignore[assignment]
 
     model_config = pydantic.ConfigDict(
@@ -387,6 +388,29 @@ class Project(BuildPlanner, BaseProject):  # type: ignore[misc]
             ) from ex
 
         return entrypoint_service
+
+    @pydantic.field_validator("run_once_command")
+    @classmethod
+    def _validate_run_once_command(
+        cls, run_once_command: str | None, info: pydantic.ValidationInfo
+    ) -> str | None:
+        """Verify that the entrypoint-service or the services dict are not set."""
+        if not run_once_command:
+            return run_once_command
+
+        craft_cli.emit.message(
+            "Warning: defining a run-once-command will result in a rock with an "
+            "atypical OCI Entrypoint. While that might be acceptable for testing and "
+            "personal use, it shall require prior approval before submitting to a "
+            "Canonical registry namespace."
+        )
+
+        if info.data.get("entrypoint-service") or info.data.get("services"):
+            raise ValueError(
+                "Cannot have run-once-command and entrypoint-service / services at the same time."
+            )
+
+        return run_once_command
 
     @pydantic.field_validator("environment")
     @classmethod

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -354,6 +354,17 @@ class Image:
         _config_image(image_path, params)
         emit.progress(f"Default user set to {user}")
 
+    def set_run_once_entrypoint(self, command: str) -> None:
+        """Set the OCI image entrypoint to the given command."""
+        emit.progress("Configuring entrypoint...")
+        image_path = self.path / self.image_name
+        params = ["--clear=config.entrypoint"]
+        for entry in shlex.split(command):
+            params.extend(["--config.entrypoint", entry])
+        params.extend(["--clear=config.cmd"])
+        _config_image(image_path, params)
+        emit.progress(f"Entrypoint set to {command}")
+
     def set_entrypoint(self, entrypoint_service: str | None, build_base: str) -> None:
         """Set the OCI image entrypoint. It is always Pebble."""
         emit.progress("Configuring entrypoint...")

--- a/rockcraft/services/package.py
+++ b/rockcraft/services/package.py
@@ -149,13 +149,16 @@ def _pack(
         emit.progress(f"Setting the default OCI user to be {project.run_user}")
         new_image.set_default_user(project.run_user)
 
-    emit.progress("Adding Pebble entrypoint")
-
-    new_image.set_entrypoint(
-        project.entrypoint_service, project.build_base or project.base
-    )
-    if project.services and project.entrypoint_service in project.services:
-        new_image.set_cmd(project.services[project.entrypoint_service].command)
+    if project.run_once_command:
+        emit.progress("Adding run-once-command entrypoint")
+        new_image.set_run_once_entrypoint(project.run_once_command)
+    else:
+        emit.progress("Adding Pebble entrypoint")
+        new_image.set_entrypoint(
+            project.entrypoint_service, project.build_base or project.base
+        )
+        if project.services and project.entrypoint_service in project.services:
+            new_image.set_cmd(project.services[project.entrypoint_service].command)
 
     new_image.set_default_path(project.base)
 


### PR DESCRIPTION
By default, rockcraft sets Pebble as the default entrypoint. However, if the defined service finishes faster than 1 second (either successfully or not), Pebble will ignore the ``on-success`` / ``on-failure`` settings and still continue running. [1]

This can be problematic for a few types of rocks meant to be used in Kubernetes. There are some workload types which are expected to eventually finish and stop, entering a Completed state, and Pebble can be preventing that, leading to some workloads / operators not able to work as intended. A service manager like Pebble is not needed in these cases. Some of these cases are:

- ``Jobs`` / ``CronJobs``: These are meant as tasks with a finite execution time. They will spawn Pods which are not meant to be endlessly running.
- ``InitContainers``: Pods may have these in order to initialize various things before the main workload containers start. The workload containers are not started until the InitContainers have finished executing and entered a Completed state.
- ``.*ctl`` type of images (e.g.: kubectl, falcoctl, longhornctl): These can be used in previously mentioned cases, but they may also be used standalone by the user in ephemeral Pods (kubectl run).

At the moment, the workaround is to forcefully add a 1.1 sleep to the Pebble service. However, that may not be an option for bare-based rocks, as they wouldn't have the sleep command (unless it would be sliced in, needlessly increasing the image size and rock building complexity). Plus, it is an unpleasant user experience for peple switching to ``rockcraft`` and hitting this issue mostly through trial and error (building the rock, uploading it, deploy in a Kubernetes env if you have one, see if you encounter issues with it or not, notice issue, investigate, find issue, fix, start over).

Alternatively, some Helm charts may have the option to completely override the image command / entrypoint, bypassing this issue. But a user would have to *know* about this issue (mostly through trial and error) and amend the Helm chart values accordingly, which is not great, considering that rocks should be drop-in replacements for regular images. But not all Helm charts have this option, in which case, the Helm chart would have to be patched, which is not great either.

[1] https://github.com/canonical/pebble/issues/240#issuecomment-1599722443

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
