### PR TITLE
lint: suppress linter warning

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -480,10 +480,10 @@ def load_project(filename: Path) -> dict[str, Any]:
         with open(filename, encoding="utf-8") as yaml_file:
             yaml_data = yaml.safe_load(yaml_file)
     except OSError as err:
-        msg = err.strerror
+        msg = err.strerror or "unknown"
         if err.filename:
             msg = f"{msg}: {err.filename!r}."
-        raise ProjectLoadError(msg) from err  # type: ignore
+        raise ProjectLoadError(msg) from err
 
     return transform_yaml(filename.parent, yaml_data)
 

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -483,7 +483,7 @@ def load_project(filename: Path) -> dict[str, Any]:
         msg = err.strerror
         if err.filename:
             msg = f"{msg}: {err.filename!r}."
-        raise ProjectLoadError(msg) from err
+        raise ProjectLoadError(msg) from err  # type: ignore
 
     return transform_yaml(filename.parent, yaml_data)
 


### PR DESCRIPTION
pyright complains about assigning str | None type in constructor to a str type.
Exception can not be None, strerror is declared as str. We can do a str() when assigning msg, but this seems a pyright issue, so probably it is best to suppress the type check.

Apparently the declaration does not match the actual returned type: https://github.com/python/typeshed/issues/9864, so using `or "unknown"` as suggested.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
