### PR TITLE
feat(snap): add git as craft.git to rockcraft

### DIFF
--- a/snap/local/craft.git
+++ b/snap/local/craft.git
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+GIT_EXEC_PATH="${SNAP}/usr/lib/git-core" exec "${SNAP}/usr/lib/git-core/git" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,6 +71,9 @@ parts:
       - "usr/lib/x86_64-linux-gnu/libpsl*"
       - "usr/lib/x86_64-linux-gnu/librtmp*"
       - "usr/lib/x86_64-linux-gnu/libnghttp2*"
+      - "usr/lib/x86_64-linux-gnu/libldap*"
+      - "usr/lib/x86_64-linux-gnu/liblber*"
+      - "usr/lib/x86_64-linux-gnu/libsasl2*"
 
   libgit2: # part came from snapcraft@5fbaab144842f
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,14 +65,8 @@ parts:
     build-attributes:
       - enable-patchelf
     prime:
-      - "-usr/bin"
-      - "-usr/share/doc"
-      - "-usr/share/man"
-      # perl is part of the core22 / core24
-      - "-usr/share/perl"
-      - "-usr/lib/x86_64-linux-gnu/perl"
-      - "-usr/lib/x86_64-linux-gnu/libperl*"
-      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
+      - "usr/lib/git-core"
+      - "usr/share/git-core"
 
   libgit2: # part came from snapcraft@5fbaab144842f
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,11 +67,10 @@ parts:
     prime:
       - "usr/lib/git-core"
       - "usr/share/git-core"
-      - "usr/lib/x86_64-linux-gnu"
-      # perl is part of the core22 / core24
-      - "-usr/lib/x86_64-linux-gnu/perl"
-      - "-usr/lib/x86_64-linux-gnu/libperl*"
-      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
+      - "usr/lib/x86_64-linux-gnu/libcurl-gnutls*"
+      - "usr/lib/x86_64-linux-gnu/libpsl*"
+      - "usr/lib/x86_64-linux-gnu/librtmp*"
+      - "usr/lib/x86_64-linux-gnu/libnghttp2*"
 
   libgit2: # part came from snapcraft@5fbaab144842f
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,6 +53,27 @@ parts:
     organize:
         "usr/bin/fuse-overlayfs": "libexec/rockcraft/fuse-overlayfs"
 
+  rockcraft-scripts:
+    source: ./snap/local
+    plugin: dump
+    organize:
+      craft.git: libexec/rockcraft/craft.git
+
+  git:
+    plugin: nil
+    stage-packages: [git]
+    build-attributes:
+      - enable-patchelf
+    prime:
+      - "-usr/bin"
+      - "-usr/share/doc"
+      - "-usr/share/man"
+      # perl is part of the core22 / core24
+      - "-usr/share/perl"
+      - "-usr/lib/x86_64-linux-gnu/perl"
+      - "-usr/lib/x86_64-linux-gnu/libperl*"
+      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
+
   libgit2: # part came from snapcraft@5fbaab144842f
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz
     source-checksum: sha256/17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,6 +67,11 @@ parts:
     prime:
       - "usr/lib/git-core"
       - "usr/share/git-core"
+      - "usr/lib/x86_64-linux-gnu"
+      # perl is part of the core22 / core24
+      - "-usr/lib/x86_64-linux-gnu/perl"
+      - "-usr/lib/x86_64-linux-gnu/libperl*"
+      - "-usr/lib/x86_64-linux-gnu/libgdbm*"
 
   libgit2: # part came from snapcraft@5fbaab144842f
     source: https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz

--- a/tests/spread/rockcraft/craftgit/rockcraft.yaml
+++ b/tests/spread/rockcraft/craftgit/rockcraft.yaml
@@ -1,0 +1,25 @@
+name: craftgit-test
+version: latest
+base: ubuntu@24.04
+summary: Echo
+description: Just a dummy build to check if craft.git from package works
+platforms:
+  amd64:
+
+parts:
+  craftgit-test:
+    plugin: nil
+    source: .
+    override-pull: |
+      echo "checking if craft.git from snap is available during pull"
+      which craft.git | grep "$SNAP/libexec/rockcraft/craft.git"
+      craft.git clone --depth 1 https://git.launchpad.net/ubuntu/+source/hello
+    override-build: |
+      echo "checking if craft.git from snap is available during build"
+      which craft.git | grep "$SNAP/libexec/rockcraft/craft.git"
+    override-stage: |
+      echo "checking if craft.git from snap is available during stage"
+      which craft.git | grep "$SNAP/libexec/rockcraft/craft.git"
+    override-prime: |
+      echo "checking if craft.git from snap is available during prime"
+      which craft.git | grep "$SNAP/libexec/rockcraft/craft.git"

--- a/tests/spread/rockcraft/craftgit/task.yaml
+++ b/tests/spread/rockcraft/craftgit/task.yaml
@@ -1,0 +1,7 @@
+summary: craft.git tool test
+
+execute: |
+  run_rockcraft pack
+
+  test -f craftgit-test_latest_amd64.rock
+  test ! -d parts -a ! -d stage -a ! -d prime

--- a/tests/spread/rockcraft/craftgit/task.yaml
+++ b/tests/spread/rockcraft/craftgit/task.yaml
@@ -4,4 +4,6 @@ execute: |
   run_rockcraft pack
 
   test -f craftgit-test_latest_amd64.rock
-  test ! -d parts -a ! -d stage -a ! -d prime
+
+restore: |
+  rm -v craftgit-test_latest_amd64.rock


### PR DESCRIPTION
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

This PR adds stages `git` in the `rockcraft` snap package, to enable `git`-based operations for `craft` libraries.

(CRAFT-3548)