### PR TITLE
fix: accept a 'pebble' part if its the same as ours

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -508,7 +508,8 @@ def _add_pebble_data(yaml_data: dict[str, Any]) -> None:
     (eventually) used as the image's entrypoint.
 
     :param yaml_data: The project spec loaded from "rockcraft.yaml".
-    :raises CraftValidationError: If `yaml_data` already contains a "pebble" part.
+    :raises CraftValidationError: If `yaml_data` already contains a "pebble" part,
+      and said part's contents are different from the contents of the part we add.
     """
     if "parts" not in yaml_data:
         # Invalid project: let it return to fail in the regular validation flow.
@@ -526,6 +527,6 @@ def _add_pebble_data(yaml_data: dict[str, Any]) -> None:
             return
         # Project already has a pebble part, and it's different from ours;
         # this is currently not supported.
-        raise CraftValidationError('Cannot override the default "pebble" part')
+        raise CraftValidationError('Cannot change the default "pebble" part')
 
     parts["pebble"] = pebble_part

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -514,13 +514,18 @@ def _add_pebble_data(yaml_data: dict[str, Any]) -> None:
         # Invalid project: let it return to fail in the regular validation flow.
         return
 
-    parts = yaml_data["parts"]
-    if "pebble" in parts:
-        # Project already has a pebble part: this is not supported.
-        raise CraftValidationError('Cannot override the default "pebble" part')
-
     # do not modify the original data with pre-validators
     model = BuildPlanner.unmarshal(copy.deepcopy(yaml_data))
     build_base = model.build_base if model.build_base else model.base
+    pebble_part = Pebble.get_part_spec(build_base)
 
-    parts["pebble"] = Pebble.get_part_spec(build_base)
+    parts = yaml_data["parts"]
+    if "pebble" in parts:
+        if parts["pebble"] == pebble_part:
+            # Project already has the correct pebble part.
+            return
+        # Project already has a pebble part, and it's different from ours;
+        # this is currently not supported.
+        raise CraftValidationError('Cannot override the default "pebble" part')
+
+    parts["pebble"] = pebble_part

--- a/tests/spread/rockcraft/expand-extensions/task.yaml
+++ b/tests/spread/rockcraft/expand-extensions/task.yaml
@@ -1,0 +1,14 @@
+summary: test that the output expand-extensions can be packed
+
+execute: |
+  run_rockcraft init
+
+  run_rockcraft expand-extensions > new-rockcraft.yaml
+  mv new-rockcraft.yaml rockcraft.yaml
+
+  run_rockcraft pack
+
+  test -f expand-extensions*.rock
+
+restore: |
+  rm -f expand-extensions*.rock

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -17,7 +17,6 @@
 import datetime
 import os
 import subprocess
-import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +29,7 @@ from craft_providers.bases import BaseName, ubuntu
 from rockcraft.errors import ProjectLoadError
 from rockcraft.models import Project
 from rockcraft.models.project import MESSAGE_INVALID_NAME, Platform, load_project
-from rockcraft.pebble import Service
+from rockcraft.pebble import Pebble, Service
 
 _ARCH_MAPPING = {"x86": "amd64", "x64": "amd64"}
 try:
@@ -555,14 +554,13 @@ def test_project_load(check, yaml_data, yaml_loaded_data, pebble_part, tmp_path)
     check.equal(project_yaml["environment"], expected_ordered_environment)
 
 
-def test_project_unmarshal_existing_pebble(tmp_path):
-    """Test that trying to load a project that already has a "pebble" part fails."""
-    yaml_data = textwrap.dedent(
+def pebble_project(pebble_spec) -> str:
+    yaml_data = yaml.safe_load(
         """
         name: pebble-part
         title: Rock with Pebble
         version: latest
-        base: ubuntu@20.04
+        base: ubuntu@24.04
         summary: Rock with Pebble
         description: Rock with Pebble
         license: Apache-2.0
@@ -579,6 +577,20 @@ def test_project_unmarshal_existing_pebble(tmp_path):
                 source-branch: new-pebble-work
     """
     )
+    yaml_data["parts"]["pebble"] = pebble_spec
+    return yaml.dump(yaml_data)
+
+
+def test_project_unmarshal_existing_pebble_different(tmp_path):
+    """Test that loading a project that already has a "pebble" part fails if that
+    part is different from what we'd create."""
+    yaml_data = pebble_project(
+        {
+            "plugin": "go",
+            "source": "https://github.com/fork/pebble.git",
+            "source-branch": "new-pebble-work",
+        }
+    )
     rockcraft_file = tmp_path / "rockcraft.yaml"
     rockcraft_file.write_text(
         yaml_data,
@@ -587,6 +599,21 @@ def test_project_unmarshal_existing_pebble(tmp_path):
 
     with pytest.raises(CraftValidationError):
         load_project(rockcraft_file)
+
+
+def test_project_unmarshal_existing_pebble_same(tmp_path):
+    """Test that loading a project that already has a "pebble" part works if that
+    part is the same as what we'd create."""
+
+    yaml_data = pebble_project(Pebble.get_part_spec("ubuntu@24.04"))
+    rockcraft_file = tmp_path / "rockcraft.yaml"
+    rockcraft_file.write_text(
+        yaml_data,
+        encoding="utf-8",
+    )
+
+    # Must not raise any errors
+    _ = load_project(rockcraft_file)
 
 
 def test_project_load_error():


### PR DESCRIPTION
The use-case that this enables is packing the output of 'expand-extensions'. Previously, this would fail because the expanded yaml contains the 'pebble' part that Rockcraft adds, and then Rockcraft itself would complain that the project already has a part called 'pebble'.

This commit makes Rockcraft accept an existing part called 'pebble' if the contents of said part are the same as the one we would add.

Fixes #749

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
