### PR TITLE
build(snap): drop 'riscv64' for now

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,8 @@ platforms:
   amd64:
   arm64:
   armhf:
-  riscv64:
+  # riscv64 on core24 is not supported by the store at this moment.
+  # riscv64:
   s390x:
   ppc64el:
 


### PR DESCRIPTION
Looks like the combination of core24 + riscv64 is not supported by the store currently, which means that 'edge' hasn't been following 'main' since we updated the snap to core24.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
