### PR TITLE
build(snap): update stage-packages for armhf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -155,9 +155,9 @@ parts:
         mkdir "$CRAFT_PART_INSTALL"/bin
         install -m755 skopeo "$CRAFT_PART_INSTALL"/bin/skopeo
     stage-packages:
-        - libgpgme11
+        - libgpgme11t64
         - libassuan0
-        - libbtrfs0
+        - libbtrfs0t64
         - libdevmapper1.02.1
     build-attributes:
         - enable-patchelf


### PR DESCRIPTION
libgpgme11 and libbtrfs0 don't exist on armhf, so we must use the 't64' packages that exist in all archs.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
