### PR TITLE
docs: reference docs for remote builds

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -15,4 +15,5 @@ Rockcraft's components, commands and keywords.
    Extensions <extensions/index>
    plugins
    parts_steps
+   remote-build
    changelog

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -15,5 +15,5 @@ Rockcraft's components, commands and keywords.
    Extensions <extensions/index>
    plugins
    parts_steps
-   remote-build
+   remote-builds
    changelog

--- a/docs/reference/remote-build.rst
+++ b/docs/reference/remote-build.rst
@@ -1,0 +1,56 @@
+.. _ref-remote-build:
+
+
+*************
+Remote builds
+*************
+
+Remote build is a feature in Rockcraft that offloads the build process to
+`Launchpad`_'s `build farm`_ to build multiple rocks simultaneously, and for
+different architectures than your running machine.
+
+
+Pre-requisites
+--------------
+
+In order to perform remote builds, the following conditions must be met:
+
+- You must have a `Launchpad account`_, as the remote builds are performed on
+  Launchpad.
+- The Rockcraft project must be version-controlled by Git. This is because
+  Rockcraft uses a Git-based workflow to upload the project to Launchpad.
+- The repository hosting the Rockcraft project must not be a shallow clone,
+  because Git does not support pushing shallow clones.
+
+
+Overview
+--------
+
+Remote builds are launched by running ``rockcraft remote-build``. Rockcraft will
+upload the Git repository on the current working directory to Launchpad on your
+behalf, under your account. Next, it will trigger builds for the Rockcraft
+project present on the root of the repository and continuously monitor the
+status of the new builds.
+
+Once all builds are done (either through a successful build or a failure), the
+rock files will be downloaded to the current directory, together with the build
+logs.
+
+
+Limitations
+-----------
+
+The following is a list of the current limitations of the remote build feature,
+which are planned to be addressed in the future:
+
+- The prospective rock must be open source and public, because the remote builds
+  will be publicly available.
+- All architectures defined on the project's ``platforms`` entry - either
+  explicitly via the ``build-on`` key or implicitly through the platform
+  shorthand - will be built. There is currently no way to restrict the set of
+  platforms to build remotely.
+
+
+.. _`Launchpad`: https://launchpad.net/
+.. _`build farm`: https://launchpad.net/builders
+.. _`Launchpad account`: https://launchpad.net/+login

--- a/docs/reference/remote-build.rst
+++ b/docs/reference/remote-build.rst
@@ -5,13 +5,13 @@
 Remote builds
 *************
 
-Remote build is a feature in Rockcraft that offloads the build process to
-`Launchpad`_'s `build farm`_ to build multiple rocks simultaneously, and for
-different architectures than your running machine.
+Remote builds offload rock builds to the `build farm`_ hosted by `Launchpad`_.
+With remote builds, you can assemble multiple rocks simultaneously and build
+for all supported architectures.
 
 
-Pre-requisites
---------------
+Prerequisites
+-------------
 
 In order to perform remote builds, the following conditions must be met:
 
@@ -45,9 +45,9 @@ which are planned to be addressed in the future:
 
 - The prospective rock must be open source and public, because the remote builds
   will be publicly available.
-- All architectures defined on the project's ``platforms`` entry - either
-  explicitly via the ``build-on`` key or implicitly through the platform
-  shorthand - will be built. There is currently no way to restrict the set of
+- All architectures defined in the project's ``platforms`` entry -- either
+  explicitly through the ``build-on`` key or implicitly through the platform
+  shorthand -- are built. There's currently no way to restrict the set of
   platforms to build remotely.
 
 

--- a/docs/reference/remote-builds.rst
+++ b/docs/reference/remote-builds.rst
@@ -1,4 +1,4 @@
-.. _ref-remote-build:
+.. _ref-remote-builds:
 
 
 *************
@@ -8,6 +8,16 @@ Remote builds
 Remote builds offload rock builds to the `build farm`_ hosted by `Launchpad`_.
 With remote builds, you can assemble multiple rocks simultaneously and build
 for all supported architectures.
+
+Remote builds are launched by running ``rockcraft remote-build``. Rockcraft will
+upload the Git repository on the current working directory to Launchpad on your
+behalf, under your account. Next, it will trigger builds for the Rockcraft
+project present on the root of the repository and continuously monitor the
+status of the new builds.
+
+Once all builds are done (either through a successful build or a failure), the
+rock files will be downloaded to the current directory, together with the build
+logs.
 
 
 Prerequisites
@@ -23,20 +33,6 @@ In order to perform remote builds, the following conditions must be met:
   because Git does not support pushing shallow clones.
 
 
-Overview
---------
-
-Remote builds are launched by running ``rockcraft remote-build``. Rockcraft will
-upload the Git repository on the current working directory to Launchpad on your
-behalf, under your account. Next, it will trigger builds for the Rockcraft
-project present on the root of the repository and continuously monitor the
-status of the new builds.
-
-Once all builds are done (either through a successful build or a failure), the
-rock files will be downloaded to the current directory, together with the build
-logs.
-
-
 Limitations
 -----------
 
@@ -44,11 +40,9 @@ The following is a list of the current limitations of the remote build feature,
 which are planned to be addressed in the future:
 
 - The prospective rock must be open source and public, because the remote builds
-  will be publicly available.
-- All architectures defined in the project's ``platforms`` entry -- either
-  explicitly through the ``build-on`` key or implicitly through the platform
-  shorthand -- are built. There's currently no way to restrict the set of
-  platforms to build remotely.
+  triggered by Rockcraft are publicly available.
+- All architectures defined in the project's ``platforms`` entry are built --
+  there's currently no way to restrict the set of platforms to build remotely.
 
 
 .. _`Launchpad`: https://launchpad.net/

--- a/docs/reference/remote-builds.rst
+++ b/docs/reference/remote-builds.rst
@@ -41,7 +41,7 @@ which are planned to be addressed in the future:
 
 - The prospective rock must be open source and public, because the remote builds
   triggered by Rockcraft are publicly available.
-- All architectures defined in the project's ``platforms`` entry are built --
+- All architectures defined in the project's ``platforms`` key are built --
   there's currently no way to restrict the set of platforms to build remotely.
 
 


### PR DESCRIPTION
This is loosely inspired on the existing docs for Snapcraft, but with a different set of restrictions and no concerns about 'legacy' versus 'new' builders.

Note that this is complementary to the command reference that is autogenerated from the Python code.

Fixes #597

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
