### PR TITLE
docs: fix reference to OCI CMD

### DIFF
--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -169,9 +169,8 @@ others are optional.
 **Required**: No
 
 The optional name of the Pebble service to serve as the OCI entrypoint. If set,
-this makes Rockcraft extend ``["/bin/pebble", "enter"]`` with
-``["--args", "<serviceName>"]``. The command of the Pebble service must
-contain an optional argument that will become the OCI CMD.
+this makes Rockcraft extend the OCI entrypoint ``["/bin/pebble", "enter"]`` with
+``["--args", "<serviceName>"]``.
 
 .. warning::
    This option must only be used in cases where the targeted deployment


### PR DESCRIPTION
The existing statement isn't true, as the
OCI CMD is never used, but instead the OCI
entrypoint is extended with the Pebble service
name

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
