### PR TITLE
fix: update plugin build error message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "craft-application",
     "craft-archives",
     "craft-cli",
-    "craft-parts",
+    "craft-parts @ git+https://github.com/canonical/craft-parts@CRAFT-4070-Error-presentation-sometimes-omits-the-last-lines",
     "craft-platforms",
     "craft-providers",
     "overrides",

--- a/tests/spread/rockcraft/plugin-python/task.yaml
+++ b/tests/spread/rockcraft/plugin-python/task.yaml
@@ -20,6 +20,7 @@ execute: |
   cp -r ../src .
 
   # Build the rock & load it into docker
+  run_rockcraft clean
   run_rockcraft pack
   test -f ${ROCK_FILE}
   sudo rockcraft.skopeo --insecure-policy copy oci-archive:${ROCK_FILE} docker-daemon:${IMAGE}


### PR DESCRIPTION
Update craft-parts to obtain the combined output in case of a
plugin build error. This results in better information on the causes
of the failure.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---
