### PR TITLE
docs: maintain project file terminology

### DIFF
--- a/docs/explanation/bases.rst
+++ b/docs/explanation/bases.rst
@@ -3,10 +3,10 @@
 Bases
 =====
 
-One mandatory field for every rock project is the
+One mandatory key for every rock project is the
 :ref:`base <rockcraft_yaml_base>`.
 
-This field defines the baseline system upon which the rock's contents shall be
+This key defines the baseline system upon which the rock's contents shall be
 layered on. Only Ubuntu and ``bare``
 :ref:`bases <rockcraft_yaml_base>` are supported.
 
@@ -54,8 +54,8 @@ Note that, when using the ``bare``
 as the :ref:`build environment <rockcraft_yaml_build_base>` for the rock.
 
 For example, if the goal is to have a tiny chiselled rock with software
-components coming from the Ubuntu 24.04 release, then the *rockcraft.yaml*
-file must have ``base: bare`` and ``build-base: ubuntu@24.04``.
+components coming from the Ubuntu 24.04 release, then the project file must have
+``base: bare`` and ``build-base: ubuntu@24.04``.
 
 The guide ":ref:`chisel_existing_rock`" provides a practical example on how to
 start from a rock with an Ubuntu :ref:`base <rockcraft_yaml_base>` and

--- a/docs/explanation/lifecycle-layer.rst
+++ b/docs/explanation/lifecycle-layer.rst
@@ -15,12 +15,12 @@ accomplished.
    a given rock are the way they are.
 
 
-Consider the following snippet of a ``rockcraft.yaml`` that creates a rock
+Consider the following snippet of a project file that creates a rock
 containing a bare-bones Python 3.10 interpreter:
 
 .. code-block:: yaml
+   :caption: rockcraft.yaml
 
-   # (...)
    base: ubuntu@22.04
 
    parts:

--- a/docs/explanation/rocks.rst
+++ b/docs/explanation/rocks.rst
@@ -13,7 +13,8 @@ tool (e.g. Docker, Podman, Kubernetes,...).
 
 Interoperability between rocks and other containers also extends to how
 container images are built, allowing rocks to be used as bases for existing
-build recipes, such as Dockerfiles, for further customisation and development.
+build instructions, such as Dockerfiles, for further customisation and
+development.
 
 .. _what-sets-rocks-apart:
 

--- a/docs/how-to/build-a-12-factor-app-rock.rst
+++ b/docs/how-to/build-a-12-factor-app-rock.rst
@@ -18,14 +18,14 @@ the root of the project:
 - ``static``
 - ``templates``
 
-To change this list, add the following snippet to the
-``rockcraft.yaml``:
+To change this list, add the following snippet to the project file:
 
 .. tabs::
 
    .. group-tab:: Flask
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              flask-framework/install-app:
@@ -46,6 +46,7 @@ To change this list, add the following snippet to the
    .. group-tab:: FastAPI
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              fastapi-framework/install-app:
@@ -62,6 +63,7 @@ To change this list, add the following snippet to the
    .. group-tab:: Go
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              go-framework/assets:
@@ -77,13 +79,14 @@ Include additional debs in the OCI image
 ----------------------------------------
 
 If your app requires debs -- for example, to connect to a database -- add the
-following snippet to ``rockcraft.yaml``:
+following snippet to the project file:
 
 .. tabs::
 
    .. group-tab:: Flask
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              flask-framework/dependencies:
@@ -94,6 +97,7 @@ following snippet to ``rockcraft.yaml``:
    .. group-tab:: Django
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              django-framework/dependencies:
@@ -104,6 +108,7 @@ following snippet to ``rockcraft.yaml``:
    .. group-tab:: FastAPI
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              fastapi-framework/dependencies:
@@ -114,6 +119,7 @@ following snippet to ``rockcraft.yaml``:
    .. group-tab:: Go
 
       .. code-block:: yaml
+         :caption: rockcraft.yaml
 
            parts:
              runtime-debs:

--- a/docs/how-to/chisel/install-slice.rst
+++ b/docs/how-to/chisel/install-slice.rst
@@ -64,11 +64,12 @@ Start by initialising a new Rockcraft project:
 After this command, you should find a new ``rockcraft.yaml`` file in your
 current path.
 
-Adjust the ``rockcraft.yaml`` file according to the following content (feel
+Adjust the project file according to the following content (feel
 free to adjust the metadata, but pay special attention to the ``parts``
 section):
 
 .. literalinclude:: ../code/install-slice/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 The "build-context" part allows you to send the local ``chisel-releases``

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -44,7 +44,7 @@ Rocks
 -----
 
 Learn about how to pack a rock, how to migrate a Dockerfile to a rock, or how
-to use services in your rockcraft.yaml. Those guides will help you explore all
+to use services in your project file. Those guides will help you explore all
 those aspects in Rockcraft and more.
 
 .. toctree::

--- a/docs/how-to/outsource-rock-builds-to-launchpad.rst
+++ b/docs/how-to/outsource-rock-builds-to-launchpad.rst
@@ -50,6 +50,7 @@ For example, if you need to build rocks for AMD64, ARM64 and RISC-V 64-bit
 architectures, your project file would declare:
 
 .. code-block:: yaml
+    :caption: rockcraft.yaml
 
     platforms:
       amd64:

--- a/docs/how-to/rocks/add-internal-user-to-a-rock.rst
+++ b/docs/how-to/rocks/add-internal-user-to-a-rock.rst
@@ -3,10 +3,10 @@
 How to add a new internal user to a rock
 *****************************************
 
-You can declare :ref:`run-user <rockcraft_yaml_run_user>` in ``rockcraft.yaml``
-to specify which user you want to run a rock's services with. If you don't
-specify a user, the services run as root by default. The ``run-user`` key
-only accepts a limited number of users, which could be a constraint for certain
+You can declare :ref:`run-user <rockcraft_yaml_run_user>` in a rock's project
+file to specify which user you want to run a its services with. If you don't
+specify a user, the services run as root by default. The ``run-user`` key only
+accepts a limited number of users, which could be a constraint for certain
 container applications.
 
 Mandatory packages or slices
@@ -23,7 +23,7 @@ Creating the user and/or group
 
 Invoking the ``useradd`` and ``groupadd`` commands can take place in a part's
 :ref:`build <lifecycle>` step. This can be done by writing those commands in
-``override-build`` field. However, the changes made by those commands will be
+``override-build`` key. However, the changes made by those commands will be
 only applied on the build instance, and will not be available in the resulting
 rock. Hence, ``$CRAFT_PART_INSTALL`` should be passed as the root directory to
 those two commands.
@@ -31,8 +31,8 @@ those two commands.
 A full example
 --------------
 
-The following ``rockcraft.yaml`` illustrates how to use the ``useradd`` command
-in the ``override-build`` field inside a part.
+The following project file illustrates how to use the ``useradd`` command
+in the ``override-build`` key inside a part.
 
 For an example of how to access the user inside the rock, here's a simple
 Python web service. The script will return an HTTP response containing the
@@ -41,9 +41,10 @@ user that is running the web service:
 .. literalinclude:: ../code/internal-user/serve_user.py
     :language: python
 
-Then, add a service to ``rockcraft.yaml`` that runs the web service:
+Then, add a service to that runs the web service:
 
 .. literalinclude:: ../code/internal-user/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
     :start-after: [docs:rock-services]
     :end-before: [docs:rock-services-end]
@@ -53,13 +54,15 @@ new group. We will also copy the Python script to a ``cgi-bin`` folder, and
 give it the execute permission:
 
 .. literalinclude:: ../code/internal-user/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
     :start-after: [docs:rock-build]
     :end-before: [docs:rock-build-end]
 
-The final ``rockcraft.yaml`` file will look like this:
+The final project file will look like this:
 
 .. literalinclude:: ../code/internal-user/rockcraft-clean.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 With the part and web service in place, build the rock:
@@ -93,4 +96,3 @@ The response should contain the new user name:
 .. code-block::
 
     Serving by myuser on port 8080
-

--- a/docs/how-to/rocks/chisel-existing-rock.rst
+++ b/docs/how-to/rocks/chisel-existing-rock.rst
@@ -18,9 +18,10 @@ A Python rock
 -------------
 
 Our starting point is an Ubuntu 22.04-based Python rock, described by the
-following *rockcraft.yaml* file:
+following project file:
 
 .. literalinclude:: ../code/chisel-existing-rock/rock/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 This rock can be built by running:
@@ -51,13 +52,14 @@ When starting to prepare the rock for production, the main goal is to get rid
 of all the software that is not necessary at runtime, and the first step
 towards achieving that goal is to use a ``bare`` base.
 
-In a separate directory, copy the *rockcraft.yaml* from above and replace
-``base: ubuntu@22.04`` with ``base: bare``. With this change, you must also
-remember to tell Rockcraft which Ubuntu release to use for its build
+In a separate directory, copy the contents of ``rockcraft.yaml`` from above and
+replace ``base: ubuntu@22.04`` with ``base: bare``. With this change, you must
+also remember to tell Rockcraft which Ubuntu release to use for its build
 environment. Do this by adding ``build-base: ubuntu@22.04`` to the
-*rockcraft.yaml* file, which should now look like this:
+project file, which should now look like this:
 
 .. literalinclude:: ../code/chisel-existing-rock/bare-rock/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 Pack this rock with the same ``rockcraft`` command as above:
@@ -95,10 +97,11 @@ Python components that are not needed for the final application.
 
 In this example, the Python application is a very simple "Hello, world", which
 means we need nothing else but the core Python modules. For that, copy the
-previous *rockcraft.yaml* file to a new directory and simply append the desired
+previous ``rockcraft.yaml`` to a new directory and simply append the desired
 package slice names to the list of ``stage-packages``, like this:
 
 .. literalinclude:: ../code/chisel-existing-rock/chiselled-rock/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 Pack it with:
@@ -122,7 +125,7 @@ And the "Hello, world" script still works:
 few YAML lines and no code whatsoever! Then, by changing a couple of YAML
 fields (the ``base``), you've achieved a **~33% size reduction** while
 maintaining functionality. Finally, by appending two words (literally, just
-the slice names) to the *rockcraft.yaml*, you were able to reduce the rock's
+the slice names) to the project file, you were able to reduce the rock's
 size even further by an **additional ~37%** of its original size! In short:
 
 +---------------+------------------+-----------+

--- a/docs/how-to/rocks/convert-to-pebble-layer.rst
+++ b/docs/how-to/rocks/convert-to-pebble-layer.rst
@@ -3,7 +3,7 @@ How to convert an entrypoint to a Pebble layer
 
 This guide will show you how to take an existing Docker image entrypoint
 and convert it into a Pebble layer, aka the list of one or more services
-which is defined in ``rockcraft.yaml`` and then taken by the rock's
+which is defined in the project file and then taken by the rock's
 Pebble entrypoint.
 
 
@@ -29,7 +29,7 @@ A `Pebble layer
 <https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/
 layer-specification/>`_
 is composed of metadata, checks and services. The latter is present in
-``rockcraft.yaml`` as a `top-level field
+the project file as a `top-level key
 <https://canonical-rockcraft.readthedocs-hosted.com/en/latest/reference/
 rockcraft.yaml/#format-specification>`_
 and it represents the services which are loaded by the Pebble entrypoint when
@@ -40,6 +40,7 @@ one for ``nginx`` and another for ``nginx-debug``. The following ``services``
 snippet does just that:
 
 .. literalinclude:: ../code/convert-to-pebble-layer/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
     :start-after: Pebble entrypoint
 
@@ -50,17 +51,18 @@ different commands (``nginx`` and ``nginx-debug``).
 Build the rock
 --------------
 
-Copy the above snippet and incorporate it into the ``rockcraft.yaml`` file
+Copy the above snippet and incorporate it into the project file
 which will be used to build your rock, as shown below:
 
 .. literalinclude:: ../code/convert-to-pebble-layer/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
-This Rockcraft recipe is almost fully declarative, with the creation of the
+This project file is almost fully declarative, with the creation of the
 "nginx" user being the only scripted step.
 
 To reproduce what the reference NGINX Dockerfile is doing, notice the use of
-``package-repositories`` in this ``rockcraft.yaml`` file, allowing you to also
+``package-repositories`` in this project file, allowing you to also
 make use of NGINX's 3rd party package repository (even using the same
 GPG key ID as the one used in `the Dockerfile
 <https://github.com/nginxinc/docker-nginx/blob/
@@ -136,8 +138,8 @@ start the ``nginx`` service by typing:
     :end-before: [docs:service-start-end]
     :dedent: 2
 
-We could have chosen to make one of the two services run on startup by changing
-its corresponding ``startup`` field value to ``enabled``.
+We could have chosen to make one of the two services run on startup by setting
+its corresponding ``startup`` key to ``enabled``.
 
 Once you start one of the services, your container should be deployed and
 running the ``nginx`` or ``nginx-debug`` service, and you should be able to see

--- a/docs/how-to/rocks/migrate-to-chiselled-rock.rst
+++ b/docs/how-to/rocks/migrate-to-chiselled-rock.rst
@@ -122,8 +122,8 @@ The output should look as follows:
     https://aka.ms/dotnet/runtimes-sdk-info
 
 
-Convert Dockerfile to rockcraft.yaml file
------------------------------------------
+Convert Dockerfile to ``rockcraft.yaml`` file
+---------------------------------------------
 
 From a quick analysis of the reference Dockerfile above, the following
 requirements must be met:
@@ -138,10 +138,11 @@ from above, write the following into a text editor and save it as
 ``rockcraft.yaml``:
 
 .. literalinclude:: ../code/migrate-to-chiselled-rock/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
-Note the subtle chiselling of the .NET Runtime package in the ``rockcraft.yaml``
-file above. You are requesting Rockcraft to install the ``libs`` slice of the
+Note the subtle chiselling of the .NET Runtime package in ``rockcraft.yaml``.
+You are requesting Rockcraft to install the ``libs`` slice of the
 ``dotnet-runtime`` deb, which is defined in the
 `ubuntu-22.04 Chisel release
 <https://github.com/canonical/chisel-releases/blob/ubuntu-22.04/slices/>`_.
@@ -294,9 +295,9 @@ The output should be similar to:
 Conclusion
 ----------
 
-In this tutorial, you have migrated from an imperative container build recipe
-(Dockerfile) to a declarative one (``rockcraft.yaml``), without any overhead
-on the final recipe's size or complexity.
+In this tutorial, you have migrated from an imperative container build
+instructions (Dockerfile) to a declarative one (``rockcraft.yaml``), without any
+overhead on the final file's size or complexity.
 
 The resulting rock ended up being 63MB smaller than the reference one, while
 offering the same .NET Runtime functionality.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,8 +46,8 @@ allowing complex operations to be declared at build time.
 
    .. grid-item-card:: :ref:`Reference <reference>`
 
-      **Technical information** - understand how to use every field in
-      ``rockcraft.yaml``.
+      **Technical information** - understand how to use every key in a project
+      file.
 
    .. grid-item-card:: :ref:`Explanation <explanation>`
 
@@ -67,4 +67,3 @@ and constructive feedback.
 * `Ubuntu Code of Conduct <https://ubuntu.com/community/code-of-conduct>`_
 * `Canonical contributor license agreement
   <https://ubuntu.com/legal/contributors>`_
-

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -27,10 +27,10 @@ There are 2 requirements to be able to use the ``django-framework`` extension:
 
 1. There must be a ``requirements.txt`` file in the root directory of the
    project with ``Django`` declared as a dependency.
-2. The project must be named the same as the ``name`` in ``rockcraft.yaml`` with
+2. The project must be named the same as the ``name`` in the project file, with
    any ``-`` replaced by ``_``, i.e., the ``manage.py`` must be located at
    ``./<Rock name with - replaced by _>/<Rock name with - replaced by _>/manage.py``
-   relative to the ``rockcraft.yaml`` file.
+   relative to the project file.
 
 For the project to make use of asynchronous Gunicorn workers:
 
@@ -44,12 +44,13 @@ You can use this key to specify any dependencies required for your Django
 application. In the following example we use it to specify ``libpq-dev``:
 
 .. code-block:: yaml
+   :caption: rockcraft.yaml
 
-  parts:
-    django-framework/dependencies:
-      stage-packages:
-        # list required packages or slices for your Django application below.
-        - libpq-dev
+   parts:
+      django-framework/dependencies:
+         stage-packages:
+         # list required packages or slices for your Django application below.
+         - libpq-dev
 
 .. _django-gunicorn-worker-selection:
 

--- a/docs/reference/extensions/fastapi-framework.rst
+++ b/docs/reference/extensions/fastapi-framework.rst
@@ -28,7 +28,7 @@ There are 2 requirements to be able to use the ``fastapi-framework`` extension:
    * ``main.py``
    * ``__init__.py``, ``app.py`` or ``main.py`` within the ``app`` or ``src``
      directory or within a directory with the name of the rock as declared in
-     ``rockcraft.yaml``.
+     the project file.
 
 ``parts`` > ``fastapi-framework/dependencies:`` > ``stage-packages``
 ====================================================================
@@ -37,6 +37,7 @@ You can use this key to specify any dependencies required for your FastAPI
 application. In the following example we use it to specify ``libpq-dev``:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
   parts:
     fastapi-framework/dependencies:
@@ -53,6 +54,7 @@ your rock upon ``rockcraft pack``. Follow the ``app/<filename>`` notation. For
 example:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
   parts:
     fastapi-framework/install-app:

--- a/docs/reference/extensions/flask-framework.rst
+++ b/docs/reference/extensions/flask-framework.rst
@@ -42,6 +42,7 @@ You can use this key to specify any dependencies required for your Flask
 application. In the following example we use it to specify ``libpq-dev``:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
   parts:
     flask-framework/dependencies:
@@ -74,6 +75,7 @@ your rock upon ``rockcraft pack``. Follow the ``flask/app/<filename>``
 notation. For example:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
   parts:
     flask-framework/install-app:

--- a/docs/reference/extensions/go-framework.rst
+++ b/docs/reference/extensions/go-framework.rst
@@ -36,6 +36,7 @@ and you can override the main application to use the binary with the
 next snippet:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
   parts:
     go-framework/install-app:
@@ -55,6 +56,7 @@ You can customise the files to include by overriding the ``stage`` property
 of the ``go-framework/assets`` part:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
   parts:
     go-framework/assets:

--- a/docs/reference/plugins/_python_common.rst
+++ b/docs/reference/plugins/_python_common.rst
@@ -15,6 +15,7 @@ Ubuntu 22.04. However, other versions can be used by explicitly declaring them -
 here's an example that uses ``python3.12-venv`` from the Deadsnakes ppa:
 
 .. code-block:: yaml
+  :caption: rockcraft.yaml
 
    package-repositories:
      - type: apt

--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -6,11 +6,11 @@ rockcraft.yaml
 
 .. include:: rock_parts/toc.rst
 
-A Rockcraft project is defined in a YAML file named ``rockcraft.yaml``
-at the root of the project tree in the filesystem.
+A Rockcraft project is defined in a YAML file named ``rockcraft.yaml`` at the
+root of the project tree in the filesystem. This file is commonly known as the
+*project file*.
 
-This Reference section is for when you need to know which options can be
-used, and how, in this ``rockcraft.yaml`` file.
+This reference describes the configuration keys available in this file.
 
 
 Format specification
@@ -97,7 +97,7 @@ which is typically used with static binaries or
 
 The system and version that will be used during the rock's build, but not
 included in the final rock itself. It comprises the set of tools and libraries
-that Rockcraft will use when building the rock's contents. This field is
+that Rockcraft will use when building the rock's contents. This key is
 mandatory if ``base`` is ``bare``, but otherwise it is optional and defaults to
 the value of ``base``.
 
@@ -158,7 +158,7 @@ to the base image's OCI environment.
 
 A list of services for the Pebble entrypoint. It uses Pebble's layer
 specification syntax exactly, with each entry defining a Pebble service. For
-each service, the ``override`` and ``command`` fields are mandatory, but all
+each service, the ``override`` and ``command`` keys are mandatory, but all
 others are optional.
 
 ``entrypoint-service``
@@ -249,7 +249,7 @@ The set of parts that compose the rock's contents
 
 
 .. note::
-   The fields ``entrypoint``, ``cmd`` and ``env`` are not supported in
+   The keys ``entrypoint``, ``cmd`` and ``env`` are not supported in
    Rockcraft. All rocks have Pebble as their entrypoint, and thus you must use
    ``services`` to define your container application.
 
@@ -273,6 +273,7 @@ Example
 =======
 
 .. literalinclude:: code/example/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -129,11 +129,11 @@ development keeps pace with the OS's new releases and support lifecycle.
   form "is now [x]" or "now [does x]". For example, "We understand that some
   authors may not want to have their snaps publicly ranked. If you prefer to
   disable ranking for your snap, we added the ``feedback`` key in Snapcraft
-  recipes, which contains child keys for controlling many of the rating and
-  feedback features in the store. You can declare ``voting: false`` to disable
-  voting." Another example: "The Maven and Ant plugins now generate the more
-  standard path to the Java runtime executable instead of an unconventional one,
-  making their locations more predictable.">
+  project files, which contains child keys for controlling many of the rating
+  and feedback features in the store. You can declare ``voting: false`` to
+  disable voting." Another example: "The Maven and Ant plugins now generate the
+  more standard path to the Java runtime executable instead of an unconventional
+  one, making their locations more predictable.">
 
   <Paragraph 3, optional: Provide a call to action. This could take several
   forms, such as a call to immediately perform a relevant action in Starcraft,

--- a/docs/tutorial/chisel.rst
+++ b/docs/tutorial/chisel.rst
@@ -19,6 +19,7 @@ Create a new directory, write the following into a text editor and save it as
 .. _chisel-example:
 
 .. literalinclude:: code/chisel/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 Note that this Rockcraft file uses the ``hello_bins`` Chisel slice to generate

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -74,7 +74,7 @@ The Django application looks good, so let's stop it for now by pressing
 Pack the Django application into a rock
 =======================================
 
-First, we'll need a ``rockcraft.yaml`` file. Rockcraft will automate its
+First, we'll need a project file. Rockcraft will automate its
 creation and tailoring for a Django application by using the
 ``django-framework`` profile:
 
@@ -84,11 +84,11 @@ creation and tailoring for a Django application by using the
     :end-before: [docs:create-rockcraft-yaml-end]
     :dedent: 2
 
-The ``rockcraft.yaml`` file will automatically be created in the working
-directory. Open it in a text editor and check that the ``name`` is
+The project file will automatically be created in the working directory as
+``rockcraft.yaml``. Open it in a text editor and check that the ``name`` is
 ``django-hello-world``. Ensure that ``platforms`` includes the host
-architecture. For example, if the host uses the ARM architecture,
-include ``arm64`` in ``platforms``.
+architecture. For example, if the host uses the ARM architecture, include
+``arm64`` in ``platforms``.
 
 .. note::
     For this tutorial, we'll use the ``name`` ``django-hello-world`` and assume
@@ -124,7 +124,7 @@ The created rock is about 75MB in size. We will reduce its size later in this
 tutorial.
 
 .. note::
-    If we changed the ``name`` or ``version`` in ``rockcraft.yaml`` or are not
+    If we changed the ``name`` or ``version`` in the project file or are not
     on an ``amd64`` platform, the name of the ``.rock`` file will be
     different.
 
@@ -241,7 +241,7 @@ in a much smaller rock with a reduced attack surface.
 
 The first step towards chiselling the rock is to ensure we are using a
 ``bare`` :ref:`base <bases_explanation>`.
-In ``rockcraft.yaml``, change the ``base`` to ``bare`` and add
+In the project file, change the ``base`` to ``bare`` and add
 ``build-base: ubuntu@22.04``:
 
 .. literalinclude:: code/django/task.yaml
@@ -250,7 +250,7 @@ In ``rockcraft.yaml``, change the ``base`` to ``bare`` and add
     :end-before: [docs:change-base-end]
     :dedent: 2
 
-So that we can compare the size after chiselling, open the ``rockcraft.yaml``
+So that we can compare the size after chiselling, open the project
 file and change the ``version`` (e.g. to ``0.1-chiselled``). Pack the rock with
 the new ``bare`` :ref:`base <bases_explanation>`:
 
@@ -334,7 +334,7 @@ the following:
     :language: python
 
 Since we are creating a new version of the application, go back to the
-tutorial root directory using ``cd ..`` and open the ``rockcraft.yaml`` file and
+tutorial root directory using ``cd ..`` and open the project file and
 change the ``version`` (e.g. to ``0.2``).
 
 .. note::

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -71,7 +71,7 @@ The application looks good, so let's stop it for now by pressing :kbd:`Ctrl` +
 Pack the FastAPI application into a rock
 ========================================
 
-First, we'll need a ``rockcraft.yaml`` file. Rockcraft will automate its
+First, we'll need a project file. Rockcraft will automate its
 creation and tailoring for a FastAPI application by using the
 ``fastapi-framework`` profile:
 
@@ -81,11 +81,11 @@ creation and tailoring for a FastAPI application by using the
     :end-before: [docs:create-rockcraft-yaml-end]
     :dedent: 2
 
-The ``rockcraft.yaml`` file will automatically be created in the project's
-working directory. Open it in a text editor and check that the ``name`` is
-``fastapi-hello-world``. Ensure that ``platforms`` includes the architecture of
-the host. For example, if the host uses the ARM
-architecture, include ``arm64`` in ``platforms``.
+The project file will automatically be created in the project's working
+directory as ``rockcraft.yaml``. Open it in a text editor and check that the
+``name`` is ``fastapi-hello-world``. Ensure that ``platforms`` includes the
+architecture of the host. For example, if the host uses the ARM architecture,
+include ``arm64`` in ``platforms``.
 
 .. note::
     For this tutorial, we'll use the ``name`` ``fastapi-hello-world`` and assume
@@ -124,7 +124,7 @@ The created rock is about 75MB in size. We will reduce its size later in this
 tutorial.
 
 .. note::
-    If we changed the ``name`` or ``version`` in ``rockcraft.yaml`` or are not
+    If we changed the ``name`` or ``version`` in the project file or are not
     on an ``amd64`` platform, the name of the ``.rock`` file will be
     different.
 
@@ -242,7 +242,7 @@ in a much smaller rock with a reduced attack surface.
 
 The first step towards chiselling the rock is to ensure we are using a
 ``bare`` :ref:`base <bases_explanation>`.
-In ``rockcraft.yaml``, change the ``base`` to ``bare`` and add
+In the project file, change the ``base`` to ``bare`` and add
 ``build-base: ubuntu@24.04``:
 
 .. literalinclude:: code/fastapi/task.yaml
@@ -252,11 +252,11 @@ In ``rockcraft.yaml``, change the ``base`` to ``bare`` and add
     :dedent: 2
 
 .. note::
-    The ``sed`` command replaces the current ``base`` in ``rockcraft.yaml`` with
+    The ``sed`` command replaces the current ``base`` in the project file with
     the ``bare`` base. The command also adds a ``build-base`` which is required
     when using the ``bare`` base.
 
-So that we can compare the size after chiselling, open the ``rockcraft.yaml``
+So that we can compare the size after chiselling, open the project
 file and change the ``version`` (e.g. to ``0.1-chiselled``). Pack the rock with
 the new ``bare`` :ref:`base <bases_explanation>`:
 
@@ -324,7 +324,7 @@ look like the following:
     :language: python
 
 Since we are creating a new version of the application, open the
-``rockcraft.yaml`` file and change the ``version`` (e.g. to ``0.2``).
+project file and change the ``version`` (e.g. to ``0.2``).
 
 .. note::
 

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -72,7 +72,7 @@ The Flask application looks good, so let's stop it for now by pressing
 Pack the Flask application into a rock
 ======================================
 
-First, we'll need a ``rockcraft.yaml`` file. Rockcraft will automate its
+First, we'll need a project file. Rockcraft will automate its
 creation and tailoring for a Flask application by using the
 ``flask-framework`` profile:
 
@@ -82,11 +82,11 @@ creation and tailoring for a Flask application by using the
     :end-before: [docs:create-rockcraft-yaml-end]
     :dedent: 2
 
-The ``rockcraft.yaml`` file will automatically be created in the project's
-working directory. Open it in a text editor and check that the ``name`` is
-``flask-hello-world``. Ensure that ``platforms`` includes the host
-architecture. For example, if the host uses the ARM
-architecture, include ``arm64`` in ``platforms``.
+The project file will automatically be created in the project's working
+directory as ``rockcraft.yaml``. Open it in a text editor and check that the
+``name`` is ``flask-hello-world``. Ensure that ``platforms`` includes the host
+architecture. For example, if the host uses the ARM architecture, include
+``arm64`` in ``platforms``.
 
 .. note::
     For this tutorial, we'll use the ``name`` ``flask-hello-world`` and assume
@@ -122,7 +122,7 @@ The created rock is about 65MB in size. We will reduce its size later in this
 tutorial.
 
 .. note::
-    If we changed the ``name`` or ``version`` in ``rockcraft.yaml`` or are not
+    If we changed the ``name`` or ``version`` in the project file or are not
     on an ``amd64`` platform, the name of the ``.rock`` file will be different.
 
     The size of the rock may vary depending on factors like the architecture
@@ -238,7 +238,7 @@ in a much smaller rock with a reduced attack surface.
 
 The first step towards chiselling the rock is to ensure we are using a
 ``bare`` :ref:`base <bases_explanation>`.
-In ``rockcraft.yaml``, change the ``base`` to ``bare`` and add
+In the project file, change the ``base`` to ``bare`` and add
 ``build-base: ubuntu@22.04``:
 
 .. literalinclude:: code/flask/task.yaml
@@ -252,7 +252,7 @@ In ``rockcraft.yaml``, change the ``base`` to ``bare`` and add
     the ``bare`` base. The command also adds a ``build-base`` which is required
     when using the ``bare`` base.
 
-So that we can compare the size after chiselling, open the ``rockcraft.yaml``
+So that we can compare the size after chiselling, open the project
 file and change the ``version`` (e.g. to ``0.1-chiselled``). Pack the rock with
 the new ``bare`` :ref:`base <bases_explanation>`:
 
@@ -320,7 +320,7 @@ look like the following:
     :language: python
 
 Since we are creating a new version of the application, open the
-``rockcraft.yaml`` file and change the ``version`` (e.g. to ``0.2``).
+project file and change the ``version`` (e.g. to ``0.2``).
 
 .. note::
 

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -101,7 +101,7 @@ Pack the Go application into a rock
 ===================================
 
 
-First, we'll need a ``rockcraft.yaml`` file. Rockcraft will automate its
+First, we'll need a project file. Rockcraft will automate its
 creation and tailor it for a Go application when we tell it to use the
 ``go-framework`` profile:
 
@@ -259,9 +259,8 @@ look like the following:
 .. literalinclude:: code/go/main.go.time
     :language: go
 
-Since we are creating a new version of the application, open the
-
-``rockcraft.yaml`` file and set ``version: "0.2"``.
+Since we are creating a new version of the application, open the project
+file and set ``version: "0.2"``.
 
 .. note::
 

--- a/docs/tutorial/hello-world.rst
+++ b/docs/tutorial/hello-world.rst
@@ -13,13 +13,14 @@ Create a new directory and write the following into a text editor and
 save it as ``rockcraft.yaml``:
 
 .. literalinclude:: code/hello-world/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 This file instructs Rockcraft to build a rock that **only** has the ``hello``
 package (and its dependencies) inside. For more information about the ``parts``
-section, check :ref:`part_properties`. The remaining YAML fields correspond to
+section, check :ref:`part_properties`. The remaining YAML keys correspond to
 metadata that help define and describe the rock. For more information about all
-available fields check :doc:`/reference/rockcraft.yaml`.
+available keys, check :doc:`/reference/rockcraft.yaml`.
 
 Pack the rock with Rockcraft
 ----------------------------

--- a/docs/tutorial/node-app.rst
+++ b/docs/tutorial/node-app.rst
@@ -33,7 +33,7 @@ The second file is our sample app, a simple "hello world" server. Still inside
 
 Next, we'll setup the Rockcraft project. In the original empty folder, create
 an empty file called ``rockcraft.yaml``. Then add the following snippets, one
-after the other:
+after the other.
 
 Add the metadata that describes your rock, such as its name and licence:
 

--- a/docs/tutorial/pypi-package.rst
+++ b/docs/tutorial/pypi-package.rst
@@ -32,6 +32,7 @@ To create a new Rockcraft project, create a new directory and change into it:
 Next, create a file called ``rockcraft.yaml`` with the following contents:
 
 .. literalinclude:: code/pyfiglet/rockcraft.yaml
+    :caption: rockcraft.yaml
     :language: yaml
 
 
@@ -89,4 +90,3 @@ using bash, via:
     | '_ \| |
     | | | | |
     |_| |_|_|
-


### PR DESCRIPTION
- Replace "recipe" with "project file" where appropriate.
- Adjust indentation and language of some code blocks.
- Add filename caption to rockcraft.yaml snippets.
- Replace some instances of "field" with "key".

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---
