### PR TITLE
docs: add previous/next buttons to doc pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ html_context = {
     "discourse": "https://discourse.ubuntu.com/c/rocks/117",
     "github_url": "https://github.com/canonical/rockcraft",
     "display_contributors": False,
+    "sequential_nav": "both",
 }
 
 extensions = [

--- a/docs/how-to/chisel/index.rst
+++ b/docs/how-to/chisel/index.rst
@@ -1,5 +1,11 @@
 .. _how-to-chisel:
 
+**************
+Chisel
+**************
+
+This section contains how-to guides for Chisel
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/how-to/documentation/index.rst
+++ b/docs/how-to/documentation/index.rst
@@ -1,5 +1,11 @@
 .. _how-to-documentation:
 
+**************
+Documentation
+**************
+
+This section contains how-to guides regarding this documentation pages
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -26,7 +26,7 @@ slices.
 .. toctree::
    :maxdepth: 1
 
-   chisel <chisel/index>
+   Chisel <chisel/index>
 
 Documentation
 -------------
@@ -38,7 +38,7 @@ compiled a couple of guides for you to facilitate your contribution.
 .. toctree::
    :maxdepth: 1
 
-   documentation <documentation/index>
+   Documentation <documentation/index>
 
 Rocks
 -----
@@ -50,4 +50,4 @@ those aspects in Rockcraft and more.
 .. toctree::
    :maxdepth: 1
 
-   rocks <rocks/index>
+   Rocks <rocks/index>

--- a/docs/how-to/rocks/index.rst
+++ b/docs/how-to/rocks/index.rst
@@ -1,5 +1,11 @@
 .. _how-to-rocks:
 
+**************
+Rocks
+**************
+
+This section contains how-to guides regarding Rocks
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
Added previous/next buttons to doc pages just like in [LXD's docs](https://documentation.ubuntu.com/lxd/en/stable-5.21/#)