### PR TITLE
docs: fix extensions urls

### DIFF
--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -161,7 +161,7 @@ class FastAPIFramework(Extension):
             raise ExtensionError(
                 "fastapi-framework extension requires the 'prime' entry in the "
                 f"fastapi-framework/install-app part to start with {self.IMAGE_BASE_DIR}/",
-                doc_slug="/reference/extensions/fastapi-framework",
+                doc_slug="/reference/extensions/fastapi-framework.html",
                 logpath_report=False,
             )
         if not user_prime:
@@ -229,7 +229,7 @@ class FastAPIFramework(Extension):
         if error_messages:
             raise ExtensionError(
                 "\n".join("- " + message for message in error_messages),
-                doc_slug="/reference/extensions/fastapi-framework",
+                doc_slug="/reference/extensions/fastapi-framework.html",
                 logpath_report=False,
             )
 

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -98,7 +98,7 @@ class GoFramework(Extension):
         if not (self.project_root / "go.mod").exists():
             raise ExtensionError(
                 "missing go.mod file",
-                doc_slug="/reference/extensions/go-framework",
+                doc_slug="/reference/extensions/go-framework.html",
                 logpath_report=False,
             )
 
@@ -191,7 +191,7 @@ class GoFramework(Extension):
             raise ExtensionError(
                 "go-framework extension requires the 'stage' entry in the "
                 "go-framework/assets part to start with app",
-                doc_slug="/reference/extensions/go-framework",
+                doc_slug="/reference/extensions/go-framework.html",
                 logpath_report=False,
             )
         if not user_stage:

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -236,7 +236,7 @@ class FlaskFramework(_GunicornBase):
             raise ExtensionError(
                 "flask-framework extension requires the 'prime' entry in the "
                 "flask-framework/install-app part to start with flask/app",
-                doc_slug="/reference/extensions/flask-framework",
+                doc_slug="/reference/extensions/flask-framework.html",
                 logpath_report=False,
             )
         if not user_prime:
@@ -297,7 +297,7 @@ class FlaskFramework(_GunicornBase):
         if error_messages:
             raise ExtensionError(
                 "\n".join("- " + message for message in error_messages),
-                doc_slug="/reference/extensions/flask-framework",
+                doc_slug="/reference/extensions/flask-framework.html",
                 logpath_report=False,
             )
 

--- a/tests/unit/extensions/test_go.py
+++ b/tests/unit/extensions/test_go.py
@@ -82,7 +82,7 @@ def test_go_extension_no_go_mod_file_error(tmp_path, go_input_yaml):
     with pytest.raises(ExtensionError) as exc:
         extensions.apply_extensions(tmp_path, go_input_yaml)
     assert str(exc.value) == "missing go.mod file"
-    assert str(exc.value.doc_slug) == "/reference/extensions/go-framework"
+    assert str(exc.value.doc_slug) == "/reference/extensions/go-framework.html"
 
 
 @pytest.mark.usefixtures("go_extension")


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---

The current URLs raise 404s since they don't have the `.html` extension:. [/reference/extensions/go-framework](https://documentation.ubuntu.com/rockcraft/en/1.8.0/reference/extensions/go-framework) vs [/reference/extensions/go-framework.html](https://documentation.ubuntu.com/rockcraft/en/1.8.0/reference/extensions/go-framework.html)