### PR TITLE
docs(build): switch to extensionless URLs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
 


### PR DESCRIPTION
This should force Sphinx to use the dirhtml builder, which will enforce clean
URLs instead of .html

- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---
