### PR TITLE
build(snap): disable armhf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,8 @@ environment:
 platforms:
   amd64:
   arm64:
-  armhf:
+  # Disable armhf until the astral-uv snap is fixed.
+  # armhf:
   # riscv64 on core24 is not supported by the store at this moment.
   # riscv64:
   s390x:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ environment:
 platforms:
   amd64:
   arm64:
-  # Disable armhf until the astral-uv snap is fixed.
+  # Disable armhf until the astral-uv snap is fixed (https://github.com/lengau/uv-snap/issues/4)
   # armhf:
   # riscv64 on core24 is not supported by the store at this moment.
   # riscv64:


### PR DESCRIPTION
The `astral-uv` snap on `armhf` needs to be updated/fixed. Until then, we need to stop using it.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---
