### PR TITLE
add missing binaries for go extension

### DIFF
--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -68,7 +68,11 @@ class GoFramework(Extension):
             "go-framework/install-app": self._get_install_app_part(),
             "go-framework/runtime": {
                 "plugin": "nil",
-                "stage-packages": ["ca-certificates_data"],
+                "stage-packages": [
+                    "bash_bins",
+                    "coreutils_bins",
+                    "ca-certificates_data",
+                ],
             },
         }
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---

The shell and other binaries are currently missing in the go extension. This PR adds them in.