### PR TITLE
fix: bare base gunicorn based extensions

### DIFF
--- a/rockcraft/extensions/_constants.py
+++ b/rockcraft/extensions/_constants.py
@@ -1,0 +1,27 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Constants for extensions."""
+
+_PYTHON_3_10 = "3.10"
+_PYTHON_3_12 = "3.12"
+
+UBUNTU_PYTHON_VERSION_MAP = {
+    "ubuntu@22.04": _PYTHON_3_10,
+    "ubuntu:22.04": _PYTHON_3_10,
+    "ubuntu@24.04": _PYTHON_3_12,
+    "ubuntu:24.04": _PYTHON_3_12,
+}

--- a/rockcraft/extensions/_utils.py
+++ b/rockcraft/extensions/_utils.py
@@ -20,6 +20,7 @@ import copy
 from pathlib import Path
 from typing import Any, cast
 
+from ._constants import UBUNTU_PYTHON_VERSION_MAP
 from .extension import Extension
 from .registry import get_extension_class
 
@@ -116,3 +117,8 @@ def _remove_list_duplicates(seq: list[str]) -> list[str]:
             deduped.append(item)
 
     return deduped
+
+
+def find_ubuntu_base_python_version(base: str) -> str | None:
+    """Find the Python version for the given base."""
+    return UBUNTU_PYTHON_VERSION_MAP.get(base, None)

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -28,6 +28,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 
 from ..errors import ExtensionError
 from ._python_utils import has_global_variable
+from ._utils import find_ubuntu_base_python_version
 from .extension import Extension, get_extensions_data_dir
 
 
@@ -70,8 +71,19 @@ class _GunicornBase(Extension):
         stage_packages = ["python3-venv"]
         build_environment = []
         if self.yaml_data["base"] == "bare":
-            stage_packages = ["python3.10-venv_ensurepip"]
-            build_environment = [{"PARTS_PYTHON_INTERPRETER": "python3.10"}]
+            python_version = find_ubuntu_base_python_version(
+                base=self.yaml_data["build-base"]
+            )
+            if not python_version:
+                raise ExtensionError(
+                    "Unable to determine the Python version for the base",
+                    doc_slug="/reference/extensions/gunicorn",
+                    logpath_report=False,
+                )
+            stage_packages = [f"python{python_version}-venv_ensurepip"]
+            build_environment = [
+                {"PARTS_PYTHON_INTERPRETER": f"python{python_version}"}
+            ]
 
         parts: dict[str, Any] = {
             f"{self.framework}-framework/dependencies": {

--- a/tests/spread/rockcraft/extension-django/task.yaml
+++ b/tests/spread/rockcraft/extension-django/task.yaml
@@ -1,6 +1,8 @@
 summary: django extension test
 
 environment:
+  SCENARIO/bare_2204: bare-22.04
+  SCENARIO/bare_2404: bare-24.04
   SCENARIO/base_2204: ubuntu-22.04
   SCENARIO/base_2404: ubuntu-24.04
 
@@ -8,7 +10,16 @@ execute: |
 
   run_rockcraft init --name example-django --profile django-framework
 
-  sed -i "s/base: .*/base: ${SCENARIO//-/@}/g" rockcraft.yaml
+  if [[ "${SCENARIO}" == bare* ]]; then
+    # Split SCENARIO by '-' and assign the last part to BUILD_BASE
+    IFS='-' read -ra parts <<< "$SCENARIO"
+    BUILD_BASE="${parts[-1]}"
+    echo "build-base: ubuntu@${BUILD_BASE}" >> rockcraft.yaml
+    sed -i "s/^base: .*/base: bare/g" rockcraft.yaml
+  else
+    # Replace base with ubuntu@<base>
+    sed -i "s/^base: .*/base: ${SCENARIO//-/@}/g" rockcraft.yaml
+  fi
 
   run_rockcraft pack
 


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---

Fixes issues with using hardcoded Python 3.10 for gunicorn based extensions. As we add support for more bases, different python versions for different bases should be added accordingly.
