### PR TITLE
feat: add org.opencontainers.image.description to rocks

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -442,7 +442,7 @@ class Project(BuildPlanner, BaseProject):  # type: ignore[misc]
             "org.opencontainers.image.ref.name": self.name,
             "org.opencontainers.image.created": generation_time,
             "org.opencontainers.image.base.digest": base_digest.hex(),
-            "org.opencontainers.image.description": f"{self.summary}\n\n{self.description}"
+            "org.opencontainers.image.description": f"{self.summary}\n\n{self.description}",
         }
         if self.license:
             annotations["org.opencontainers.image.licenses"] = self.license

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -442,6 +442,7 @@ class Project(BuildPlanner, BaseProject):  # type: ignore[misc]
             "org.opencontainers.image.ref.name": self.name,
             "org.opencontainers.image.created": generation_time,
             "org.opencontainers.image.base.digest": base_digest.hex(),
+            "org.opencontainers.image.description": f"{self.summary}\n\n{self.description}"
         }
         if self.license:
             annotations["org.opencontainers.image.licenses"] = self.license

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -635,7 +635,7 @@ def test_project_generate_metadata(yaml_loaded_data):
         "org.opencontainers.image.licenses": yaml_loaded_data["license"],
         "org.opencontainers.image.created": now,
         "org.opencontainers.image.base.digest": digest,
-        "org.opencontainers.image.description": f"{yaml_loaded_data['summary']}\n\n{yaml_loaded_data['description']}"
+        "org.opencontainers.image.description": f"{yaml_loaded_data['summary']}\n\n{yaml_loaded_data['description']}",
     }
     assert rock_metadata == {
         "name": yaml_loaded_data["name"],

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -635,6 +635,7 @@ def test_project_generate_metadata(yaml_loaded_data):
         "org.opencontainers.image.licenses": yaml_loaded_data["license"],
         "org.opencontainers.image.created": now,
         "org.opencontainers.image.base.digest": digest,
+        "org.opencontainers.image.description": f"{yaml_loaded_data['summary']}\n\n{yaml_loaded_data['description']}"
     }
     assert rock_metadata == {
         "name": yaml_loaded_data["name"],


### PR DESCRIPTION
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---

Added `org.opencontainers.image.description` OCI annotation to all rocks. This annotation uses a combination of `summary` + `description` fields from `rockcraft.yaml` file, following this format:

```
<summary>

<description>
```

The annotation is addded to the `Config.Labels` field in Docker.

---

Example for the `hello-world` rock:

Input:
`docker image inspect hello:latest | jq -r .[0].Config.Labels`

Output:
![image](https://github.com/user-attachments/assets/599ba789-3e81-4555-be1e-6407965877e9)
