### PR TITLE
fix: sanitize summary for OCI annotation

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -441,7 +441,8 @@ class Project(BuildPlanner, BaseProject):  # type: ignore[misc]
             "org.opencontainers.image.ref.name": self.name,
             "org.opencontainers.image.created": generation_time,
             "org.opencontainers.image.base.digest": base_digest.hex(),
-            "org.opencontainers.image.description": f"{self.summary}\n\n{self.description}",
+            "org.opencontainers.image.description": re.sub(r"\n{2,}", " ", self.summary)
+            + f"\n\n{self.description}",
         }
         if self.license:
             annotations["org.opencontainers.image.licenses"] = self.license

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -441,7 +441,9 @@ class Project(BuildPlanner, BaseProject):  # type: ignore[misc]
             "org.opencontainers.image.ref.name": self.name,
             "org.opencontainers.image.created": generation_time,
             "org.opencontainers.image.base.digest": base_digest.hex(),
-            "org.opencontainers.image.description": re.sub(r"\n{2,}", " ", self.summary)
+            "org.opencontainers.image.description": re.sub(
+                r"\n{2,}", "\n", self.summary
+            )
             + f"\n\n{self.description}",
         }
         if self.license:

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -650,7 +650,7 @@ def test_project_generate_metadata(yaml_loaded_data):
     # Redo test with multi-line summary
     multi_line_summary = "one\n\ntwo\n\n\n\n\nthree"
     project = Project.unmarshal({**yaml_loaded_data, **{"summary": multi_line_summary}})
-    sanitized_summary = "one two three"
+    sanitized_summary = "one\ntwo\nthree"
 
     oci_annotations, rock_metadata = project.generate_metadata(
         now, bytes.fromhex(digest)

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -647,6 +647,20 @@ def test_project_generate_metadata(yaml_loaded_data):
         "base-digest": digest,
     }
 
+    # Redo test with multi-line summary
+    multi_line_summary = "one\n\ntwo\n\n\n\n\nthree"
+    project = Project.unmarshal({**yaml_loaded_data, **{"summary": multi_line_summary}})
+    sanitized_summary = "one two three"
+
+    oci_annotations, rock_metadata = project.generate_metadata(
+        now, bytes.fromhex(digest)
+    )
+    assert oci_annotations["org.opencontainers.image.description"] == (
+        f"{sanitized_summary}\n\n{yaml_loaded_data['description']}"
+    )
+
+    assert rock_metadata["summary"] == yaml_loaded_data["summary"]
+
 
 def test_metadata_base_devel(yaml_loaded_data):
     yaml_loaded_data["base"] = "ubuntu@24.04"

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -659,7 +659,7 @@ def test_project_generate_metadata(yaml_loaded_data):
         f"{sanitized_summary}\n\n{yaml_loaded_data['description']}"
     )
 
-    assert rock_metadata["summary"] == yaml_loaded_data["summary"]
+    assert rock_metadata["summary"] == multi_line_summary
 
 
 def test_metadata_base_devel(yaml_loaded_data):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Sanitize the `summary` field before constructing the `"org.opencontainers.image.description"` annotation, such that we avoid causes where the `summary` itself already includes multiple consecutive `\n` chars, thus breaking the existing convention of a double-newline-delimiter for the annotation.