### PR TITLE
docs: update pebble page and add references to pebble docs

### DIFF
--- a/docs/explanation/lifecycle-layer.rst
+++ b/docs/explanation/lifecycle-layer.rst
@@ -126,9 +126,9 @@ example, consider again the contents of the previous rock's prime directory:
    $ ls bin/
    pebble
 
-So ``bin/`` is a regular directory and contains the ``pebble`` binary, to
-serve as the rock's entrypoint. However, consider the base directory structure
-of an Ubuntu system:
+So ``bin/`` is a regular directory and contains the :ref:`pebble_explanation_page`
+binary, to serve as the rock's entrypoint. However, consider the base directory
+structure of an Ubuntu system:
 
 .. code-block:: bash
 

--- a/docs/explanation/pebble.rst
+++ b/docs/explanation/pebble.rst
@@ -6,13 +6,14 @@ Pebble
 .. important::
     **Pebble is the default entrypoint for all rocks!**
 
-Similar to other well-known process managers such as *supervisord*, *runit*, or
-*s6*, `Pebble`_ is a service manager that enables the seamless orchestration of
-a collection of local service processes as an organised set. The main difference
-is that `Pebble`_ has been designed with custom-tailored features that
-significantly enhance the overall container experience, making it the ideal
-candidate for the container's init process (also known as the entrypoint,
-with PID=1).
+    More information about it can be found at `Pebble docs`_.
+    This page will address how it works inside containers,
+    more specifically, rocks.
+
+Pebble is a lightweight service manager that has been designed with
+custom-tailored features to significantly enhance the overall container
+experience, making it the ideal candidate for the container's init process
+(also known as the entrypoint, with PID=1).
 
 Multiple processes in a container?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -80,7 +81,8 @@ services defined in :doc:`/reference/rockcraft.yaml`.
 convert a Docker entrypoint to a Pebble layer.
 
 
-.. _Pebble: https://github.com/canonical/pebble
+.. _Pebble: https://documentation.ubuntu.com/rockcraft/en/latest/explanation/pebble/
+.. _Pebble docs: https://documentation.ubuntu.com/rockcraft/en/latest/explanation/pebble/
 .. _tini: https://github.com/krallin/tini
 .. _s6-overlay: https://github.com/just-containers/s6-overlay
 .. _imperative wrapper scripts (as suggested in the Docker documentation): https://docs.docker.com/engine/containers/multi-service_container/#use-a-wrapper-script

--- a/docs/how-to/rocks/convert-to-pebble-layer.rst
+++ b/docs/how-to/rocks/convert-to-pebble-layer.rst
@@ -2,9 +2,9 @@ How to convert an entrypoint to a Pebble layer
 ***********************************************
 
 This guide will show you how to take an existing Docker image entrypoint
-and convert it into a Pebble layer, aka the list of one or more services
-which is defined in the project file and then taken by the rock's
-Pebble entrypoint.
+and convert it into a :ref:`pebble_explanation_page` layer, aka the
+list of one or more services which is defined in the project file and then
+taken by the rock's :ref:`pebble_explanation_page` entrypoint.
 
 
 Reference entrypoint

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -58,7 +58,7 @@ Gunicorn worker selection
 =========================
 
 If the project has gevent as a dependency, Rockcraft automatically updates the
-pebble plan to spawn asynchronous Gunicorn workers.
+:ref:`pebble_explanation_page` plan to spawn asynchronous Gunicorn workers.
 
 When the project instead needs synchronous workers, you can override the worker
 type by adding ``--args django sync`` to the Docker command that launches the

--- a/docs/reference/extensions/flask-framework.rst
+++ b/docs/reference/extensions/flask-framework.rst
@@ -56,7 +56,7 @@ Gunicorn worker selection
 =========================
 
 If the project has gevent as a dependency, Rockcraft automatically updates the
-pebble plan to spawn asynchronous Gunicorn workers.
+:ref:`pebble_explanation_page` plan to spawn asynchronous Gunicorn workers.
 
 When the project instead needs synchronous workers, you can override the worker
 type by adding ``--args flask sync`` to the Docker command that launches the

--- a/docs/reference/rockcraft.yaml.rst
+++ b/docs/reference/rockcraft.yaml.rst
@@ -23,8 +23,8 @@ Format specification
 
 **Required**: Yes
 
-The name of the rock. This value must conform with Pebble's format for layer
-files, meaning that the ``name``:
+The name of the rock. This value must conform with :ref:`pebble_explanation_page`'s
+format for layer files, meaning that the ``name``:
 
 - must start with a lowercase letter [a-z];
 - must contain only lowercase letters [a-z], numbers [0-9] or hyphens;

--- a/docs/tutorial/node-app.rst
+++ b/docs/tutorial/node-app.rst
@@ -43,7 +43,7 @@ Add the metadata that describes your rock, such as its name and licence:
     :start-at: name: my-node-app
     :end-at: amd64:
 
-Add the container entrypoint, as a `Pebble`_ service:
+Add the container entrypoint, as a :ref:`pebble_explanation_page` service:
 
 .. literalinclude:: code/node-app/rockcraft.yaml
     :caption: rockcraft.yaml
@@ -151,5 +151,4 @@ The sample app code comes from the "Hello world example" Express tutorial,
 available at https://expressjs.com/en/starter/hello-world.html.
 
 
-.. _`Pebble`:  https://github.com/canonical/pebble
 .. _`NodeSource`: https://nodesource.com/


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR adds references to [pebble docs](https://documentation.ubuntu.com/pebble/) in the Pebble page inside rockcraft documentation. This page only keeps the information from pebble related to container images and rocks.

Additionally, other pages have been modified so when Pebble is mentioned it links to the pebble page.

---

See built page here: (waiting CI)