### PR TITLE
docs: add references to lifecycle and part properties

### DIFF
--- a/docs/explanation/lifecycle-layer.rst
+++ b/docs/explanation/lifecycle-layer.rst
@@ -3,7 +3,7 @@ From prime step to OCI layer
 ============================
 
 Rockcraft is a tool that creates OCI images using the same concepts and
-mechanisms that create snaps and charms: the lifecycle language from
+mechanisms that create snaps and charms: the `lifecycle`_ language from
 Craft Parts. There is a significant difference between the way the Craft
 lifecycle works and the OCI specification, and one of Rockcraft's jobs is to
 bridge the gap between these two worlds. This page describes how this is
@@ -207,3 +207,4 @@ pruned or symbolic links that need to be taken into account.
 .. _tar archive: https://github.com/opencontainers/image-spec/blob/main/layer.md
 .. _usrmerge: https://wiki.debian.org/UsrMerge
 .. _Dive: https://github.com/wagoodman/dive
+.. _lifecycle: /explanation/lifecycle.html

--- a/docs/explanation/overlay-step.rst
+++ b/docs/explanation/overlay-step.rst
@@ -8,7 +8,7 @@ five separate steps: pull, overlay, build, stage and prime.
 
 The overlay step is specific to rocks and is configured with overlay parameters.
 To learn more about pull, build, stage and prime see
-:doc:`/common/craft-parts/reference/part_properties`
+:doc:`/explanation/lifecycle`
 
 The overlay step provides the means to modify the base filesystem before the
 build step is applied. If ``overlay-packages`` is used, those packages will be

--- a/docs/how-to/chisel/install-slice.rst
+++ b/docs/how-to/chisel/install-slice.rst
@@ -73,11 +73,11 @@ section):
     :language: yaml
 
 The "build-context" part allows you to send the local ``chisel-releases``
-folder into the builder. The "override-build" enables you to install your
+folder into the builder. The `override-build`_ enables you to install your
 custom slice.
 Please note that this level of customisation is only needed when you want to
 install from a custom Chisel release. If the desired slice definitions are
-already upstream, then you can simply use ``stage-packages``, as demonstrated
+already upstream, then you can simply use `stage-packages`_, as demonstrated
 in :ref:`here <chisel-example>`.
 
 Build your rock with:
@@ -162,3 +162,6 @@ The output of the Docker command will be OpenSSL's default help message:
 
 And that's it! You've now built your own rock from a custom Chisel release.
 Next step: share your slice definitions file with others!
+
+.. _override-build: /common/craft-parts/reference/part_properties.html#override-build
+.. _stage-packages: /common/craft-parts/reference/part_properties.html#stage-packages

--- a/docs/how-to/rocks/chisel-existing-rock.rst
+++ b/docs/how-to/rocks/chisel-existing-rock.rst
@@ -98,7 +98,7 @@ Python components that are not needed for the final application.
 In this example, the Python application is a very simple "Hello, world", which
 means we need nothing else but the core Python modules. For that, copy the
 previous ``rockcraft.yaml`` to a new directory and simply append the desired
-package slice names to the list of ``stage-packages``, like this:
+package slice names to the list of `stage-packages`_, like this:
 
 .. literalinclude:: ../code/chisel-existing-rock/chiselled-rock/rockcraft.yaml
     :caption: rockcraft.yaml
@@ -133,3 +133,5 @@ size even further by an **additional ~37%** of its original size! In short:
 +===============+==================+===========+
 | 42MB          | 28MB             | 13MB      |
 +---------------+------------------+-----------+
+
+.. _stage-packages: /common/craft-parts/reference/part_properties.html#stage-packages


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR add references to lifecycle docs page and part properties on every occurrence of <lifecycle step>

Also check the PR for craft-parts: https://github.com/canonical/craft-parts/pull/1053

---

See built page [here] (waiting CI)