### PR TITLE
docs: add a note explaining why python3-venv is required

### DIFF
--- a/docs/tutorial/pypi-package.rst
+++ b/docs/tutorial/pypi-package.rst
@@ -35,6 +35,14 @@ Next, create a file called ``rockcraft.yaml`` with the following contents:
     :caption: rockcraft.yaml
     :language: yaml
 
+.. note::
+
+    This example uses ``python`` plugin along ``python-packages``, so ``pip`` is
+    invoked implicitly to install such packages. `PEP 668`_ changes the
+    behaviour of Python package managers like ``pip`` by introducing a special
+    marker (``EXTERNALLY-MANAGED``) that prevents ``pip`` from installing
+    packages outside a virtual environment. Thus, ``python3-venv`` is required
+    as a stage package.
 
 Pack the rock with Rockcraft
 ----------------------------
@@ -46,8 +54,6 @@ To build the rock, run:
     :start-after: [docs:build-rock]
     :end-before: [docs:build-rock-end]
     :dedent: 2
-
-
 
 Run the rock in Docker
 ----------------------
@@ -90,3 +96,5 @@ using bash, via:
     | '_ \| |
     | | | | |
     |_| |_|_|
+
+.. _`PEP 668`: https://peps.python.org/pep-0668/


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR adds a note explaining why `python3-venv` is required in `stage-packages` inside pypi tutorial.

---

See [built docs](waiting CI)