### PR TITLE
chore: set UV_USE_IO_URING=0 on npm builds

### DIFF
--- a/docs/tutorial/code/expressjs/task.yaml
+++ b/docs/tutorial/code/expressjs/task.yaml
@@ -12,6 +12,7 @@ summary: Getting started with ExpressJS tutorial
 priority: -200
 
 environment:
+  UV_USE_IO_URING: "0"
 
 execute: |
   # [docs:install-deps]

--- a/docs/tutorial/code/node-app/rockcraft.yaml
+++ b/docs/tutorial/code/node-app/rockcraft.yaml
@@ -23,3 +23,11 @@ parts:
     npm-include-node: True
     npm-node-version: "21.1.0"
     source: src/
+    build-environment:
+      # NOTE: There's currently a bad interaction between the nodejs version in the
+      # archives and the kernel, causing an infinite hang during 'npm install':
+      # - https://github.com/npm/cli/issues/4028
+      # - https://github.com/amazonlinux/amazon-linux-2023/issues/856
+      # For now we need to disable libuv's use of io_uring; this should be able to
+      # be reverted in a few months (as of April 2025).
+      - UV_USE_IO_URING: "0"

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -152,6 +152,14 @@ class ExpressJSFramework(Extension):
             install_app_part["npm-node-version"] = self._user_install_app_part.get(
                 "npm-node-version"
             )
+
+        # NOTE: There's currently a bad interaction between the nodejs version in the
+        # archives and the kernel, causing an infinite hang during 'npm install':
+        # - https://github.com/npm/cli/issues/4028
+        # - https://github.com/amazonlinux/amazon-linux-2023/issues/856
+        # For now we need to disable libuv's use of io_uring; this should be able to
+        # be reverted in a few months (as of April 2025).
+        install_app_part["build-environment"] = [{"UV_USE_IO_URING": "0"}]
         return install_app_part
 
     def _gen_app_build_packages(self) -> list[str]:

--- a/tests/spread/rockcraft/extension-expressjs/task.yaml
+++ b/tests/spread/rockcraft/extension-expressjs/task.yaml
@@ -3,6 +3,7 @@ environment:
   SCENARIO/bare: bare
   SCENARIO/base_2404: ubuntu-24.04
   ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
+  UV_USE_IO_URING: "0"
 
 execute: |
   NAME="expressjs-${SCENARIO//./-}"

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -88,6 +88,7 @@ def package_json_file(app_path):
                         ),
                         "build-packages": ["nodejs", "npm"],
                         "stage-packages": ["ca-certificates_data", "nodejs_bins"],
+                        "build-environment": [{"UV_USE_IO_URING": "0"}],
                     },
                     "expressjs-framework/runtime": {
                         "plugin": "nil",
@@ -129,6 +130,7 @@ def package_json_file(app_path):
                         "plugin": "npm",
                         "source": "app/",
                         "stage-packages": ["ca-certificates_data"],
+                        "build-environment": [{"UV_USE_IO_URING": "0"}],
                     }
                 },
                 "platforms": {
@@ -180,6 +182,7 @@ def package_json_file(app_path):
                             "ca-certificates_data",
                             "coreutils_bins",
                         ],
+                        "build-environment": [{"UV_USE_IO_URING": "0"}],
                     },
                     "expressjs-framework/runtime": {
                         "plugin": "nil",
@@ -235,6 +238,7 @@ def package_json_file(app_path):
                             "ca-certificates_data",
                             "coreutils_bins",
                         ],
+                        "build-environment": [{"UV_USE_IO_URING": "0"}],
                     },
                     "expressjs-framework/runtime": {
                         "plugin": "nil",


### PR DESCRIPTION
I should note for the rustaceans in the crowd that this refers to [libuv](https://github.com/libuv/libuv), which node uses to do async io