### PR TITLE
feat(project): use the newest craft-app schema

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -53,8 +53,6 @@ jobs:
       - name: Install ajv cli
         run: npm install -g ajv-cli
 
-      - name: Run ajv
+      - name: Validate rockcraft.yaml files against the schema
         run: |
-          ajv validate -s $ROCKCRAFT_JSON \
-            -d docs/reference/code/example/rockcraft.yaml \
-            --strict=false --spec=draft2020
+          make validate-schema

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,17 @@ publish: publish-pypi  ## Publish packages
 publish-pypi: clean package-pip lint-twine  ##- Publish Python packages to pypi
 	uv tool run twine upload dist/*
 
+schema: install-uv  ## Generate the schema file.
+	mkdir -p schema
+	uv run python tools/schema/schema.py > schema/rockcraft.json
+
+validate-schema: install-ajv-cli
+	# Find all the rockcraft.yaml files that don't contain "# pragma: no-schema-validate"
+	find . -type f -name rockcraft.yaml -exec grep -HL '# pragma: no-schema-validate' '{}' '+' | \
+	xargs -I {} ajv validate --strict=false --spec=draft2020 -s schema/rockcraft.json -d {}
+#	The line below can be used to use the go-based jv command instead.
+# 	xargs -I {} sh -c 'echo "\e[32mValidating {}\e[0m"; jv schema/rockcraft.json {}'
+
 # Find dependencies that need installing
 APT_PACKAGES :=
 ifeq ($(wildcard /usr/include/libxml2/libxml/xpath.h),)
@@ -73,3 +84,11 @@ endif
 # If additional build dependencies need installing in order to build the linting env.
 .PHONY: install-lint-build-deps
 install-lint-build-deps:
+
+
+.PHONY: install-ajv-cli
+install-ajv-cli: install-npm
+ifneq ($(shell which ajv),)
+else
+	npm install -g ajv-cli
+endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ name = "rockcraft"
 description = "Create rocks"
 dynamic = ["version", "readme"]
 dependencies = [
-    "craft-application>=5.0.1",
+    # "craft-application>=5.0.1",
+    # Undo before merge
+    "craft-application @ git+https://github.com/canonical/craft-application.git@work/CRAFT-4421",
     "craft-archives",
     "craft-cli",
     "craft-parts",

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -99,7 +99,6 @@ class Project(BaseProject):
     services: dict[str, Service] | None = None
     checks: dict[str, Check] | None = None
     entrypoint_service: str | None = None
-    platforms: dict[str, Platform | None]  # type: ignore[assignment]
     base: BaseT  # type: ignore[reportIncompatibleVariableOverride]
     build_base: BuildBaseT = None  # type: ignore[reportIncompatibleVariableOverride]
 

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -242,16 +242,23 @@
     },
     "Platform": {
       "additionalProperties": false,
-      "description": "Project platform definition.\n\nThis model defines how the ``platforms`` key works for a project.",
+      "description": "Project platform definition.\n\nThis model defines how a single value under the ``platforms`` key works for a project.",
       "properties": {
         "build-on": {
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Build-On",
-          "type": "array",
-          "uniqueItems": true
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "minLength": 1,
+          "title": "Build-On"
         },
         "build-for": {
           "oneOf": [
@@ -6908,6 +6915,51 @@
             "$ref": "#/$defs/Platform"
           }
         ]
+      },
+      "patternProperties": {
+        "(amd64|arm64|armhf|i386|ppc64el|riscv64|s390x)": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "properties": {
+                "build-on": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "title": "Build-On"
+                },
+                "build-for": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "title": "Build-For"
+                }
+              },
+              "required": [
+                "build-on"
+              ],
+              "type": "object"
+            }
+          ]
+        }
       },
       "title": "Platforms",
       "type": "object"

--- a/tests/spread/manual/repo-overlay/rockcraft.yaml
+++ b/tests/spread/manual/repo-overlay/rockcraft.yaml
@@ -3,7 +3,7 @@ name: repo-overlay
 summary: Package repositories in overlay
 license: Apache-2.0
 description: Install overlay-packages that come from `package-repositories`.
-version: 0.1
+version: "0.1"
 
 base: ubuntu@22.04
 platforms:

--- a/tests/spread/rockcraft/plugin-jlink/bare-build-2404/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-jlink/bare-build-2404/rockcraft.yaml
@@ -1,3 +1,4 @@
+# pragma: no-schema-validate
 base: bare
 build-base: ubuntu@24.04
 name: bare-build-2404

--- a/tests/spread/rockcraft/plugin-jlink/base-2404/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-jlink/base-2404/rockcraft.yaml
@@ -1,2 +1,3 @@
+# pragma: no-schema-validate
 base: ubuntu@24.04
 name: base-2404

--- a/tests/spread/rockcraft/plugin-python/bare-build-2004/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-python/bare-build-2004/rockcraft.yaml
@@ -1,3 +1,4 @@
+# pragma: no-schema-validate
 name: bare-build-2004
 base: bare
 build-base: ubuntu@20.04

--- a/tests/spread/rockcraft/plugin-python/bare-build-2204/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-python/bare-build-2204/rockcraft.yaml
@@ -1,3 +1,4 @@
+# pragma: no-schema-validate
 name: bare-build-2204
 base: bare
 build-base: ubuntu@22.04

--- a/tests/spread/rockcraft/plugin-python/base-2004/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-python/base-2004/rockcraft.yaml
@@ -1,3 +1,4 @@
+# pragma: no-schema-validate
 name: base-2004
 base: ubuntu@20.04
 # Remaining contents will come from "parts.yaml"

--- a/tests/spread/rockcraft/plugin-python/base-2204/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-python/base-2204/rockcraft.yaml
@@ -1,3 +1,4 @@
+# pragma: no-schema-validate
 name: base-2204
 base: ubuntu@22.04
 # Remaining contents will come from "parts.yaml"

--- a/tests/spread/rockcraft/plugin-python/base-2404/rockcraft.yaml
+++ b/tests/spread/rockcraft/plugin-python/base-2404/rockcraft.yaml
@@ -1,3 +1,4 @@
+# pragma: no-schema-validate
 name: base-2404
 base: ubuntu@24.04
 # Remaining contents will come from "parts.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -490,8 +490,8 @@ toml = [
 
 [[package]]
 name = "craft-application"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
+version = "5.0.3.post3+g824a682"
+source = { git = "https://github.com/canonical/craft-application.git?rev=work%2FCRAFT-4421#824a68251d9c163c3f94091df172f58ccad3ecd0" }
 dependencies = [
     { name = "annotated-types" },
     { name = "craft-archives" },
@@ -509,10 +509,6 @@ dependencies = [
     { name = "requests" },
     { name = "snap-helpers" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/2f/ad297bdd8402d4e4932404fc08ed89f9eca3f35c0e620d09fc6e4ffbfb76/craft_application-5.0.1.tar.gz", hash = "sha256:a268ee6b70bb57320f35fe578aec52e0c4ca427b6df527b1752517911a358f6c", size = 340203 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/43/70bf3ef434b6df2c928269a8dc6f2a0f2a27e62b2785d3f5b2e09955fc1f/craft_application-5.0.1-py3-none-any.whl", hash = "sha256:b0fb49a54bd9e37f911ce0f84f1fd13f99cf702ee6350bd0706fbaccfbe3916b", size = 171976 },
 ]
 
 [[package]]
@@ -2443,7 +2439,7 @@ types = [
 
 [package.metadata]
 requires-dist = [
-    { name = "craft-application", specifier = ">=5.0.1" },
+    { name = "craft-application", git = "https://github.com/canonical/craft-application.git?rev=work%2FCRAFT-4421" },
     { name = "craft-archives" },
     { name = "craft-cli" },
     { name = "craft-parts" },


### PR DESCRIPTION
NOT YET READY TO MERGE (craft-application needs a release for it).

This uses the latest platforms schema changes in review in craft-application (https://github.com/canonical/craft-application/pull/735) to update the rockcraft schema.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
