### PR TITLE
build(deps): update craft-parts and craft-platforms

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -13,6 +13,7 @@ Rockcraft.
    /common/craft-parts/reference/plugins/dotnet_plugin
    plugins/ant_plugin
    /common/craft-parts/reference/plugins/autotools_plugin
+   /common/craft-parts/reference/plugins/cargo_use_plugin
    /common/craft-parts/reference/plugins/cmake_plugin
    /common/craft-parts/reference/plugins/dump_plugin
    /common/craft-parts/reference/plugins/go_plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "craft-archives",
     "craft-cli",
     "craft-parts",
-    "craft-platforms~=0.7.1",
+    "craft-platforms~=0.8",
     "craft-providers",
     "overrides",
     "spdx-lookup",

--- a/rockcraft/extensions/_utils.py
+++ b/rockcraft/extensions/_utils.py
@@ -64,7 +64,7 @@ def _apply_extension(
     if "parts" not in yaml_data:
         yaml_data["parts"] = {}
 
-    parts = cast(dict[str, Any], yaml_data["parts"])
+    parts = cast("dict[str, Any]", yaml_data["parts"])
     for part_definition in parts.values():
         for property_name, property_value in part_extension.items():
             part_definition[property_name] = _apply_extension_property(

--- a/rockcraft/extensions/_utils.py
+++ b/rockcraft/extensions/_utils.py
@@ -64,7 +64,7 @@ def _apply_extension(
     if "parts" not in yaml_data:
         yaml_data["parts"] = {}
 
-    parts: dict[str, Any] = yaml_data["parts"]
+    parts = cast(dict[str, Any], yaml_data["parts"])
     for part_definition in parts.values():
         for property_name, property_value in part_extension.items():
             part_definition[property_name] = _apply_extension_property(

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -608,6 +608,7 @@
           "enum": [
             "ant",
             "autotools",
+            "cargo-use",
             "cmake",
             "dotnet",
             "dump",
@@ -902,6 +903,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -1224,6 +1226,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -1513,6 +1516,301 @@
           "if": {
             "properties": {
               "plugin": {
+                "const": "cargo-use"
+              }
+            }
+          },
+          "then": {
+            "$comment": "common properties had to be repeated here or they would be considered invalid by the schema validator otherwise",
+            "properties": {
+              "plugin": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Plugin",
+                "enum": [
+                  "ant",
+                  "autotools",
+                  "cargo-use",
+                  "cmake",
+                  "dotnet",
+                  "dump",
+                  "go",
+                  "go-use",
+                  "jlink",
+                  "make",
+                  "maven",
+                  "meson",
+                  "nil",
+                  "npm",
+                  "poetry",
+                  "python",
+                  "qmake",
+                  "rust",
+                  "scons",
+                  "uv"
+                ]
+              },
+              "source": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Source"
+              },
+              "source-checksum": {
+                "default": "",
+                "title": "Source-Checksum",
+                "type": "string"
+              },
+              "source-channel": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Source-Channel"
+              },
+              "source-branch": {
+                "default": "",
+                "title": "Source-Branch",
+                "type": "string"
+              },
+              "source-commit": {
+                "default": "",
+                "title": "Source-Commit",
+                "type": "string"
+              },
+              "source-depth": {
+                "default": 0,
+                "title": "Source-Depth",
+                "type": "integer"
+              },
+              "source-subdir": {
+                "default": "",
+                "title": "Source-Subdir",
+                "type": "string"
+              },
+              "source-submodules": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Source-Submodules"
+              },
+              "source-tag": {
+                "default": "",
+                "title": "Source-Tag",
+                "type": "string"
+              },
+              "source-type": {
+                "default": "",
+                "title": "Source-Type",
+                "type": "string"
+              },
+              "disable-parallel": {
+                "default": false,
+                "title": "Disable-Parallel",
+                "type": "boolean"
+              },
+              "after": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "After",
+                "type": "array"
+              },
+              "overlay-packages": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "Overlay-Packages",
+                "type": "array"
+              },
+              "stage-snaps": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "Stage-Snaps",
+                "type": "array"
+              },
+              "stage-packages": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "Stage-Packages",
+                "type": "array"
+              },
+              "build-snaps": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "Build-Snaps",
+                "type": "array"
+              },
+              "build-packages": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "Build-Packages",
+                "type": "array"
+              },
+              "build-environment": {
+                "default": [],
+                "items": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "title": "Build-Environment",
+                "type": "array"
+              },
+              "build-attributes": {
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "title": "Build-Attributes",
+                "type": "array"
+              },
+              "organize": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "title": "Organize",
+                "type": "object"
+              },
+              "overlay": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Overlay",
+                "type": "array"
+              },
+              "stage": {
+                "items": {
+                  "description": "relative path",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "title": "Stage",
+                "type": "array"
+              },
+              "prime": {
+                "items": {
+                  "description": "relative path",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "title": "Prime",
+                "type": "array"
+              },
+              "override-pull": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Override-Pull"
+              },
+              "overlay-script": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Overlay-Script"
+              },
+              "override-build": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Override-Build"
+              },
+              "override-stage": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Override-Stage"
+              },
+              "override-prime": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Override-Prime"
+              },
+              "permissions": {
+                "default": [],
+                "items": {
+                  "$ref": "#/$defs/Permissions"
+                },
+                "title": "Permissions",
+                "type": "array"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "plugin": {
                 "const": "cmake"
               }
             }
@@ -1534,6 +1832,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -1841,6 +2140,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -2152,6 +2452,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -2446,6 +2747,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -2756,6 +3058,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -3050,6 +3353,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -3352,6 +3656,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -3654,6 +3959,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -3956,6 +4262,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -4258,6 +4565,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -4552,6 +4860,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -4863,6 +5172,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -5182,6 +5492,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -5504,6 +5815,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -5816,6 +6128,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -6168,6 +6481,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",
@@ -6470,6 +6784,7 @@
                 "enum": [
                   "ant",
                   "autotools",
+                  "cargo-use",
                   "cmake",
                   "dotnet",
                   "dump",

--- a/tests/spread/foreign/big/rockcraft.yaml
+++ b/tests/spread/foreign/big/rockcraft.yaml
@@ -6,7 +6,7 @@ description: |
   and "teardown" price once. Feel free to add to this file and to "task.yaml",
   adding references to issues/PRs where appropriate.
 license: Apache-2.0
-base: ubuntu@22.04 # FIXME: this should be 'ubuntu:22.04'
+base: ubuntu:22.04
 platforms:
   amd64:
 

--- a/tests/spread/rockcraft/destructive/rockcraft.yaml
+++ b/tests/spread/rockcraft/destructive/rockcraft.yaml
@@ -3,7 +3,7 @@ version: latest
 summary: A destructively-built rock
 description: Building a rock in destructive mode
 license: Apache-2.0
-build-base: ubuntu@22.04 # FIXME: this should be 'ubuntu:22.04'
+build-base: ubuntu:22.04
 base: bare
 platforms:
   amd64:

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "craft-parts"
-version = "2.7.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "overrides" },
@@ -573,24 +573,25 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-unixsocket2" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-9-rockcraft-dev-jammy' and extra == 'group-9-rockcraft-dev-noble') or (extra == 'group-9-rockcraft-dev-jammy' and extra == 'group-9-rockcraft-dev-oracular') or (extra == 'group-9-rockcraft-dev-jammy' and extra == 'group-9-rockcraft-dev-plucky') or (extra == 'group-9-rockcraft-dev-noble' and extra == 'group-9-rockcraft-dev-oracular') or (extra == 'group-9-rockcraft-dev-noble' and extra == 'group-9-rockcraft-dev-plucky') or (extra == 'group-9-rockcraft-dev-oracular' and extra == 'group-9-rockcraft-dev-plucky')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/d8/9ba8f33084e5c39744dd0e4b6db85937d118f65ebbf149b4990176883e8e/craft_parts-2.7.0.tar.gz", hash = "sha256:aa9e9e88ad893e12046c86a484fd7acf064d03039b6ce9907597dc093835baa4", size = 648642 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/af/3a36df71dd40f0267e5f7c5d2b0dbe92886a5170475e3a9876dbf88b2eb4/craft_parts-2.8.0.tar.gz", hash = "sha256:689c0baf4465eed5366bd02580867973cb3285ae3dc43dc9842c87ec37fbd7bc", size = 653143 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/7d/24aeba828d96431eb1d1813747c65c8ebc00a58de4c55cd66d19c0469432/craft_parts-2.7.0-py3-none-any.whl", hash = "sha256:c230386314fb8d50e410372df1edec3d0d87a1ea53b2d5c92357f7755828b84b", size = 456889 },
+    { url = "https://files.pythonhosted.org/packages/06/0e/c6f4a2b148e35fe80a3bfbbd4f58d501a3d65b9a974fd4263f4144505e4f/craft_parts-2.8.0-py3-none-any.whl", hash = "sha256:e0a9d97d673859a7b67eed2df4a7e2202191b4aa87366c9a6831b82ee50dacf9", size = 460069 },
 ]
 
 [[package]]
 name = "craft-platforms"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "distro" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/8a/9717ef8b6534a58a8920c4277b218a4798bd2e32ca0520009fd440914648/craft_platforms-0.7.1.tar.gz", hash = "sha256:e72f6b6029aa060f75089bd6120e3eee0b103e5a0c7c8912c17fa32e4f99854d", size = 182466 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/3b/96f9c7aaf9eca6f677b880029e7c1c160b927d3409f8dc1954d4ccd2a22b/craft_platforms-0.8.0.tar.gz", hash = "sha256:0c18f39aef7caadc7b101aa5123e76b4e32396d3217af7bad1184a5014f29369", size = 183988 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/10/dff0e782c95b152a1b988a4d31990d43a722fbbb4ac0fc7bef24af4116ce/craft_platforms-0.7.1-py3-none-any.whl", hash = "sha256:2fc1cb066be3348d77119e880ff268ab8c83e46af41934bdacd761dfdbf41a14", size = 28438 },
+    { url = "https://files.pythonhosted.org/packages/c3/b9/ded298fa675957c86ed5785a424a5706377882ebacc3c0f99df89e53652b/craft_platforms-0.8.0-py3-none-any.whl", hash = "sha256:b7574e6886fbfa6c1c2ca74b013851297782d20e6bf3be5fc30a75bb586c5b5a", size = 29365 },
 ]
 
 [[package]]
@@ -2447,7 +2448,7 @@ requires-dist = [
     { name = "craft-archives" },
     { name = "craft-cli" },
     { name = "craft-parts" },
-    { name = "craft-platforms", specifier = "~=0.7.1" },
+    { name = "craft-platforms", specifier = "~=0.8" },
     { name = "craft-providers" },
     { name = "craft-store", marker = "extra == 'store'" },
     { name = "overrides" },


### PR DESCRIPTION
The craft-parts update brings in the 'cargo-use' plugin, and the craft-platforms
update allows us to use "ubuntu:22.04" deprecated notation again.