### PR TITLE
ci: run tests on amd64

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,4 +16,6 @@ jobs:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
       lowest-python-version: ""
+      fast-test-platforms: '[["jammy", "amd64"], ["noble", "amd64"]]'
       fast-test-python-versions: '["3.10", "3.12"]'
+      slow-test-platforms: '[["jammy", "amd64"], ["noble", "amd64"]]'


### PR DESCRIPTION
The jobs fail on the new s390x self-hosted runners because some wheels are missing (cryptography specifically). Ideally we would also be able to run on arm64, but there's no language to say "run on either amd64 or arm64".

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
