### PR TITLE
fix: fix minimum version of Flask used in tutorial

### DIFF
--- a/docs/tutorial/code/flask/requirements.txt
+++ b/docs/tutorial/code/flask/requirements.txt
@@ -1,1 +1,1 @@
-Flask
+Flask>=2.3.2


### PR DESCRIPTION
Versions <2.3.2 are subject to https://osv.dev/vulnerability/GHSA-m2qf-hxjv-5gpq and other CVEs.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
