### PR TITLE
docs: Reorganize 12-factor how-to guides

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,7 +14,7 @@ adapt the steps to fit your specific requirements.
    :maxdepth: 1
 
    Get started - quick guide <get-started>
-   Manage a 12-factor app rock <manage-12-factor-app-rock>
+   Manage a 12-factor app rock <manage-web-app-rock/index>
    Outsource rock builds to Launchpad <outsource-rock-builds-to-launchpad>
 
 Chisel

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -14,7 +14,7 @@ adapt the steps to fit your specific requirements.
    :maxdepth: 1
 
    Get started - quick guide <get-started>
-   Build a 12-factor app rock <build-a-12-factor-app-rock>
+   Manage a 12-factor app rock <manage-12-factor-app-rock>
    Outsource rock builds to Launchpad <outsource-rock-builds-to-launchpad>
 
 Chisel

--- a/docs/how-to/manage-12-factor-app-rock.rst
+++ b/docs/how-to/manage-12-factor-app-rock.rst
@@ -1,5 +1,5 @@
-How to build a 12-Factor app rock
-*********************************
+How to manage a 12-Factor app rock
+**********************************
 
 The following how-to guide provides instructions on managing
 and configuring rocks for 12-factor applications.

--- a/docs/how-to/manage-web-app-rock/configure-web-app-rock.rst
+++ b/docs/how-to/manage-web-app-rock/configure-web-app-rock.rst
@@ -1,8 +1,8 @@
-How to manage a 12-Factor app rock
-**********************************
+How to configure a 12-Factor app rock
+*************************************
 
-The following how-to guide provides instructions on managing
-and configuring rocks for 12-factor applications.
+The following how-to guide provides instructions on
+configuring rocks for 12-factor apps.
 
 Include extra files in the OCI image
 ------------------------------------
@@ -129,91 +129,3 @@ following snippet to the project file:
 
       For the ``go-framework`` extension, a deb could be needed for example to use an external command in the migration process.
 
-Update and deploy the OCI image
--------------------------------
-
-.. tabs::
-
-   .. group-tab:: Flask
-
-      After making a change to your app:
-
-      1. Make sure that any new files will be included in the new OCI image.
-      2. Run ``rockcraft pack`` to create the new OCI image.
-      3. To upload the OCI image to the local Docker registry, run:
-
-         .. code-block:: bash
-
-            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-            oci-archive:<path to rock file> \
-            docker://localhost:32000/<rock name>:<rock version>
-
-      4. To deploy the new OCI image, run:
-
-         .. code-block:: bash
-
-            juju refresh <app name> --path=<relative path to .charm file> \
-            --resource flask-app-image=<localhost:32000/<rock name>:<rock version>>
-
-   .. group-tab:: Django
-
-      After making a change to your app:
-
-      1. Make sure that any new files will be included in the new OCI image.
-      2. Run ``rockcraft pack`` to create the new OCI image.
-      3. To upload the OCI image to the local Docker registry, run:
-
-         .. code-block:: bash
-
-            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-            oci-archive:<path to rock file> \
-            docker://localhost:32000/<rock name>:<rock version>
-
-      4. To deploy the new OCI image, run:
-
-         .. code-block:: bash
-
-            juju refresh <app name> --path=<relative path to .charm file> \
-            --resource django-app-image=<localhost:32000/<rock name>:<rock version>>
-
-   .. group-tab:: FastAPI
-
-      After making a change to your app:
-
-      1. Make sure that any new files will be included in the new OCI image.
-      2. Run ``rockcraft pack`` to create the new OCI image.
-      3. To upload the OCI image to the local Docker registry, run:
-
-         .. code-block:: bash
-
-            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-            oci-archive:<path to rock file> \
-            docker://localhost:32000/<rock name>:<rock version>
-
-      4. To deploy the new OCI image, run:
-
-         .. code-block:: bash
-
-            juju refresh <app name> --path=<relative path to .charm file> \
-            --resource app-image=<localhost:32000/<rock name>:<rock version>>
-
-   .. group-tab:: Go
-
-      After making a change to your app:
-
-      1. Make sure that any new files will be included in the new OCI image.
-      2. Run ``rockcraft pack`` to create the new OCI image.
-      3. To upload the OCI image to the local Docker registry, run:
-
-         .. code-block:: bash
-
-            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-            oci-archive:<path to rock file> \
-            docker://localhost:32000/<rock name>:<rock version>
-
-      4. To deploy the new OCI image, run:
-
-         .. code-block:: bash
-
-            juju refresh <app name> --path=<relative path to .charm file> \
-            --resource app-image=<localhost:32000/<rock name>:<rock version>>

--- a/docs/how-to/manage-web-app-rock/index.rst
+++ b/docs/how-to/manage-web-app-rock/index.rst
@@ -1,0 +1,38 @@
+How to manage a 12-Factor app rock
+**********************************
+
+These guides walk you through all the ways you can manage 12-factor app rocks,
+from initialization to usage.
+
+Initialization
+--------------
+
+Use the pre-defined Rockcraft extension to cater the initial rock files to
+your specific web app framework.
+
+.. toctree::
+    :maxdepth: 2
+
+    Initialize a 12-factor app rock <init-web-app-rock>
+
+Configuration
+-------------
+
+Once your 12-factor app rock has been set up, you can customize many aspects
+of it using Rockcraft.
+
+.. toctree::
+    :maxdepth: 2
+
+    Configure a 12-factor app rock <configure-web-app-rock>
+
+Usage
+-----
+
+Now that you’ve initialized and configured your 12-factor app rock,
+you’re ready to use it.
+
+.. toctree::
+    :maxdepth: 2
+
+    Use a 12-factor app rock <use-web-app-rock>

--- a/docs/how-to/manage-web-app-rock/init-web-app-rock.rst
+++ b/docs/how-to/manage-web-app-rock/init-web-app-rock.rst
@@ -1,0 +1,48 @@
+How to initialize a 12-factor app rock
+**************************************
+
+Use ``rockcraft init`` and specify the relevant profile:
+
+.. code-block:: bash
+
+    rockcraft init --profile <profile>
+
+Rockcraft automatically creates a ``rockcraft.yaml`` project file
+for the rock in your current directory. You will need to check the project
+file to verify that the rock's name and description are correct.
+
+.. seealso::
+
+    :ref:`ref_commands_init`
+
+.. tabs::
+
+    .. group-tab:: Django
+
+        .. code-block:: bash
+
+            rockcraft init --profile django-framework
+
+    .. group-tab:: ExpressJS
+
+        .. code-block:: bash
+
+            rockcraft init --profile expressjs-framework
+
+    .. group-tab:: FastAPI
+
+        .. code-block:: bash
+
+            rockcraft init --profile fastapi-framework
+
+    .. group-tab:: Flask
+
+        .. code-block:: bash
+
+            rockcraft init --profile flask-framework
+
+    .. group-tab:: Go
+
+        .. code-block:: bash
+
+            rockcraft init --profile go-framework

--- a/docs/how-to/manage-web-app-rock/use-web-app-rock.rst
+++ b/docs/how-to/manage-web-app-rock/use-web-app-rock.rst
@@ -1,0 +1,94 @@
+How to use a 12-factor app rock
+*******************************
+
+The following how-to guide provides instructions on
+using rocks for 12-factor apps.
+
+Update and deploy the OCI image
+-------------------------------
+
+.. tabs::
+
+   .. group-tab:: Flask
+
+      After making a change to your app:
+
+      1. Make sure that any new files will be included in the new OCI image.
+      2. Run ``rockcraft pack`` to create the new OCI image.
+      3. To upload the OCI image to the local Docker registry, run:
+
+         .. code-block:: bash
+
+            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+            oci-archive:<path to rock file> \
+            docker://localhost:32000/<rock name>:<rock version>
+
+      4. To deploy the new OCI image, run:
+
+         .. code-block:: bash
+
+            juju refresh <app name> --path=<relative path to .charm file> \
+            --resource flask-app-image=<localhost:32000/<rock name>:<rock version>>
+
+   .. group-tab:: Django
+
+      After making a change to your app:
+
+      1. Make sure that any new files will be included in the new OCI image.
+      2. Run ``rockcraft pack`` to create the new OCI image.
+      3. To upload the OCI image to the local Docker registry, run:
+
+         .. code-block:: bash
+
+            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+            oci-archive:<path to rock file> \
+            docker://localhost:32000/<rock name>:<rock version>
+
+      4. To deploy the new OCI image, run:
+
+         .. code-block:: bash
+
+            juju refresh <app name> --path=<relative path to .charm file> \
+            --resource django-app-image=<localhost:32000/<rock name>:<rock version>>
+
+   .. group-tab:: FastAPI
+
+      After making a change to your app:
+
+      1. Make sure that any new files will be included in the new OCI image.
+      2. Run ``rockcraft pack`` to create the new OCI image.
+      3. To upload the OCI image to the local Docker registry, run:
+
+         .. code-block:: bash
+
+            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+            oci-archive:<path to rock file> \
+            docker://localhost:32000/<rock name>:<rock version>
+
+      4. To deploy the new OCI image, run:
+
+         .. code-block:: bash
+
+            juju refresh <app name> --path=<relative path to .charm file> \
+            --resource app-image=<localhost:32000/<rock name>:<rock version>>
+
+   .. group-tab:: Go
+
+      After making a change to your app:
+
+      1. Make sure that any new files will be included in the new OCI image.
+      2. Run ``rockcraft pack`` to create the new OCI image.
+      3. To upload the OCI image to the local Docker registry, run:
+
+         .. code-block:: bash
+
+            rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+            oci-archive:<path to rock file> \
+            docker://localhost:32000/<rock name>:<rock version>
+
+      4. To deploy the new OCI image, run:
+
+         .. code-block:: bash
+
+            juju refresh <app name> --path=<relative path to .charm file> \
+            --resource app-image=<localhost:32000/<rock name>:<rock version>>

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -8,4 +8,4 @@
 "release-notes/rockcraft-1-9-0.rst" "release-notes/rockcraft-1-9.rst"
 "release-notes/rockcraft-1-8-0.rst" "release-notes/rockcraft-1-8.rst"
 "release-notes/rockcraft-1-7-0.rst" "release-notes/rockcraft-1-7.rst"
-"how-to/build-a-12-factor-app-rock.rst" "how-to/manage-12-factor-app-rock.rst"
+"how-to/build-a-12-factor-app-rock.rst" "how-to/manage-web-app-rock/index.rst"

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -8,3 +8,4 @@
 "release-notes/rockcraft-1-9-0.rst" "release-notes/rockcraft-1-9.rst"
 "release-notes/rockcraft-1-8-0.rst" "release-notes/rockcraft-1-8.rst"
 "release-notes/rockcraft-1-7-0.rst" "release-notes/rockcraft-1-7.rst"
+"how-to/build-a-12-factor-app-rock.rst" "how-to/manage-12-factor-app-rock.rst"


### PR DESCRIPTION
In preparation for adding more how-to guides specific to the 12-factor tooling, this PR reorganizes the current 12-factor how-to guides.

### Summary of changes
* A new folder, `how-to/manage-web-app-rock`, was added.
* The original 12-factor file, `how-to/build-a-12-factor-app-rock.rst`, was split into two under the `how-to/manage-web-app-rock` directory: `configure-web-app-rock.rst` and `use-web-app-rock.rst`. The main how-to index page was updated, and a relevant redirect was added.
* A new 12-factor file, `how-to/manage-web-app-rock/init-web-app-rock.rst`, was created. This is to complete the full story of initialization-configuration-usage.

- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
I successfully ran `make lint-docs`. I am not contributing a code change (although, for completeness, I ran `make lint && make test` and the commands failed).

