### PR TITLE
feat(oci): inject mediatype in manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ endif
 ifeq ($(wildcard /usr/share/doc/umoci/copyright),)
 APT_PACKAGES += umoci
 endif
+ifeq ($(wildcard /usr/share/doc/skopeo/copyright),)
+APT_PACKAGES += skopeo
+endif
 
 # Used for installing build dependencies in CI.
 .PHONY: install-build-deps

--- a/rockcraft/services/package.py
+++ b/rockcraft/services/package.py
@@ -172,6 +172,13 @@ def _pack(
     new_image.set_control_data(rock_metadata)
     emit.progress("Metadata added")
 
+    # Set the media type in the target images's manifest.
+    # This is different than calling _inject_oci_fields in oci.Image.new_oci_image,
+    # since _inject_oci_fields is called in the context of creating the base image.
+    emit.progress("Adding manifest media type")
+    new_image.set_media_type()
+    emit.progress("Manifest media type added")
+
     emit.progress("Exporting to OCI archive")
     archive_name = f"{project.name}_{project.version}_{rock_suffix}.rock"
     new_image.to_oci_archive(tag=version, filename=archive_name)

--- a/tests/integration/services/test_package.py
+++ b/tests/integration/services/test_package.py
@@ -1,0 +1,42 @@
+import json
+import subprocess
+from pathlib import Path
+from typing import cast
+
+import pytest
+from craft_application import ServiceFactory
+from craft_platforms import DebianArchitecture
+from rockcraft import oci
+from rockcraft.models.project import Project
+from rockcraft.services import package
+
+
+@pytest.mark.usefixtures("fake_project_file")
+def test_media_type_in_packed_image_manifest(fake_services: ServiceFactory):
+    base_image = oci.Image.new_oci_image(
+        image_name="bare@original",
+        image_dir=Path("images"),
+        arch=DebianArchitecture.from_host(),
+    )[0]
+
+    fake_services.get("project").configure(platform="risky", build_for="riscv64")
+    project = cast(Project, fake_services.get("project").get())
+
+    # pylint: disable=protected-access
+    archive_name = package._pack(
+        prime_dir=Path("prime"),
+        project=project,
+        project_base_image=base_image,
+        base_digest=b"deadbeef",
+        rock_suffix="risky",
+        build_for=project.platforms["risky"].build_for[0],
+        base_layer_dir=Path("base_layer"),
+    )
+
+    manifest = subprocess.check_output(
+        ["skopeo", "inspect", "--raw", f"oci-archive:{archive_name}"],
+        stderr=subprocess.STDOUT,
+    )
+    manifest_content = json.loads(manifest)
+
+    assert manifest_content["mediaType"] == "application/vnd.oci.image.manifest.v1+json"

--- a/tests/integration/test_oci.py
+++ b/tests/integration/test_oci.py
@@ -231,3 +231,16 @@ def test_stat(new_dir):
     assert len(layer2_history) == 2
     # The first layer in the ``layer2_history`` list is layer1
     assert layer2_history[0] == layer1_history[0]
+
+
+def test_image_manifest_has_media_type():
+    """Test that the image manifest has the correct media type."""
+    image = oci.Image.new_oci_image(
+        image_name="bare@original",
+        image_dir=Path("images"),
+        arch="amd64",
+    )[0]
+
+    # Check the media type of the manifest
+    manifest = image.get_manifest()
+    assert manifest["mediaType"] == "application/vnd.oci.image.manifest.v1+json"

--- a/uv.lock
+++ b/uv.lock
@@ -2559,7 +2559,7 @@ requires-dist = [
     { name = "craft-application", specifier = "~=5.1" },
     { name = "craft-archives" },
     { name = "craft-cli" },
-    { name = "craft-parts" },
+    { name = "craft-parts", specifier = ">=2.9.1" },
     { name = "craft-platforms", specifier = "~=0.8" },
     { name = "craft-providers" },
     { name = "craft-store", marker = "extra == 'store'" },


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR make `rockcraft` add the field `mediaType` in the image manifest, which is missing in the default manifest created by `umoci`.