### PR TITLE
chore: set min version of Django in tutorial

### DIFF
--- a/docs/tutorial/code/django/requirements.txt
+++ b/docs/tutorial/code/django/requirements.txt
@@ -1,1 +1,1 @@
-Django
+Django>=5.2.1


### PR DESCRIPTION
The lack of a minimum version makes osv-scanner complain about basically every CVE ever published for Django. Version 5.2.1 is quite new (from May 7), but this patch release itself addresses a CVE, so we might as well set it as a baseline.

0: https://docs.djangoproject.com/en/5.2/releases/5.2.1/

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
