### PR TITLE
docs: cover statsd metrics in extensions

### DIFF
--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -54,9 +54,9 @@ StatsD exporter
 ===============
 
 A StatsD exporter is installed alongside the Gunicorn server to export Gunicorn
-server metrics. The `Gunicorn-provided metrics
+server metrics. Three of the `Gunicorn-provided metrics
 <https://docs.gunicorn.org/en/stable/instrumentation.html>`_
-are mapped to the names ``django_response_code``, ``django_requests`` and
+are mapped to new names: ``django_response_code``, ``django_requests`` and
 ``django_request_duration``.
 
 The  exporter listens on localhost at port 9125. You can push your

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -53,15 +53,15 @@ application. In the following example we use it to specify ``libpq-dev``:
 StatsD exporter
 ===============
 
-A StatsD exporter is installed alongside the Gunicorn server to export Gunicorn
+A StatsD exporter is installed alongside the Gunicorn server to record
 server metrics. Three of the `Gunicorn-provided metrics
 <https://docs.gunicorn.org/en/stable/instrumentation.html>`_
 are mapped to new names: ``django_response_code``, ``django_requests`` and
 ``django_request_duration``.
 
 The  exporter listens on localhost at port 9125. You can push your
-own metrics to the statsd-exporter using any StatsD Client. For example,
-using the client ``pystatsd``:
+own metrics to the exporter using any StatsD client. This snippet from an example
+Django app uses pystatsd as a client:
 
 .. code-block:: python
 

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -60,8 +60,8 @@ are mapped to new names:
 
 .. list-table::
 
-  * - StatsD metric
-    - Gunicorn metric
+  * - Gunicorn metric
+    - StatsD metric
   * - ``gunicorn.request.status.*``
     - ``django_response_code``
   * - ``gunicorn.requests``

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -59,14 +59,15 @@ server metrics. Some of the `Gunicorn-provided metrics
 are mapped to new names:
 
 .. list-table::
-    * - StatsD metric
-       - Gunicorn metric
-    * - ``gunicorn.request.status.*``
-       - ``django_response_code``
-    * - ``gunicorn.requests``
-       - ``django_requests``
-    * - ``gunicorn.request.duration``
-       - ``django_request_duration``
+
+  * - StatsD metric
+    - Gunicorn metric
+  * - ``gunicorn.request.status.*``
+    - ``django_response_code``
+  * - ``gunicorn.requests``
+    - ``django_requests``
+  * - ``gunicorn.request.duration``
+    - ``django_request_duration``
 
 The  exporter listens on localhost at port 9125. You can push your
 own metrics to the exporter using any StatsD client. This snippet from an example

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -54,10 +54,19 @@ StatsD exporter
 ===============
 
 A StatsD exporter is installed alongside the Gunicorn server to record
-server metrics. Three of the `Gunicorn-provided metrics
+server metrics. Some of the `Gunicorn-provided metrics
 <https://docs.gunicorn.org/en/stable/instrumentation.html>`_
-are mapped to new names: ``django_response_code``, ``django_requests`` and
-``django_request_duration``.
+are mapped to new names:
+
+.. list-table::
+    * - StatsD metric
+       - Gunicorn metric
+    * - ``gunicorn.request.status.*``
+       - ``django_response_code``
+    * - ``gunicorn.requests``
+       - ``django_requests``
+    * - ``gunicorn.request.duration``
+       - ``django_request_duration``
 
 The  exporter listens on localhost at port 9125. You can push your
 own metrics to the exporter using any StatsD client. This snippet from an example

--- a/docs/reference/extensions/django-framework.rst
+++ b/docs/reference/extensions/django-framework.rst
@@ -10,9 +10,6 @@ It facilitates the installation of Django application dependencies, including
 Gunicorn, inside the rock. Additionally, it transfers your project files to
 ``/django/app`` within the rock.
 
-A statsd-exporter is installed alongside the Gunicorn server to export Gunicorn
-server metrics.
-
 .. note::
     The Django extension is compatible with the ``bare``, ``ubuntu@22.04``
     and ``ubuntu@24.04`` bases.
@@ -51,6 +48,31 @@ application. In the following example we use it to specify ``libpq-dev``:
          stage-packages:
          # list required packages or slices for your Django application below.
          - libpq-dev
+
+
+StatsD exporter
+===============
+
+A StatsD exporter is installed alongside the Gunicorn server to export Gunicorn
+server metrics. The `Gunicorn-provided metrics
+<https://docs.gunicorn.org/en/stable/instrumentation.html>`_
+are mapped to the names ``django_response_code``, ``django_requests`` and
+``django_request_duration``.
+
+The  exporter listens on localhost at port 9125. You can push your
+own metrics to the statsd-exporter using any StatsD Client. For example,
+using the client ``pystatsd``:
+
+.. code-block:: python
+
+  import statsd
+  c = statsd.StatsClient('localhost', 9125)
+  c.incr('my_counter')
+
+
+See the `StatsD exporter documentation <https://github.com/prometheus/statsd_exporter>`_
+for more information.
+
 
 .. _django-gunicorn-worker-selection:
 

--- a/docs/reference/extensions/flask-framework.rst
+++ b/docs/reference/extensions/flask-framework.rst
@@ -58,8 +58,8 @@ are mapped to new names:
 
 .. list-table::
 
-  * - StatsD metric
-    - Gunicorn metric
+  * - Gunicorn metric
+    - StatsD metric
   * - ``gunicorn.request.status.*``
     - ``flask_response_code``
   * - ``gunicorn.requests``

--- a/docs/reference/extensions/flask-framework.rst
+++ b/docs/reference/extensions/flask-framework.rst
@@ -9,9 +9,6 @@ It facilitates the installation of Flask application dependencies, including
 Gunicorn, inside the rock. Additionally, it transfers your project files to
 ``/flask/app`` within the rock.
 
-A statsd-exporter is installed alongside the Gunicorn server to export Gunicorn
-server metrics.
-
 .. note::
     The Flask extension is compatible with the ``bare``, ``ubuntu@22.04``
     and ``ubuntu@24.04`` bases.
@@ -49,6 +46,31 @@ application. In the following example we use it to specify ``libpq-dev``:
       stage-packages:
         # list required packages or slices for your flask app below.
         - libpq-dev
+
+
+StatsD exporter
+===============
+
+A StatsD exporter is installed alongside the Gunicorn server to export Gunicorn
+server metrics. The `Gunicorn-provided metrics
+<https://docs.gunicorn.org/en/stable/instrumentation.html>`_
+are mapped to the names ``flask_response_code``, ``flask_requests`` and
+``flask_request_duration``.
+
+The  exporter listens on localhost at port 9125. You can push your
+own metrics to the statsd-exporter using any StatsD Client. For example,
+using the client ``pystatsd``:
+
+.. code-block:: python
+
+  import statsd
+  c = statsd.StatsClient('localhost', 9125)
+  c.incr('my_counter')
+
+
+See the `StatsD exporter documentation <https://github.com/prometheus/statsd_exporter>`_
+for more information.
+
 
 .. _flask-gunicorn-worker-selection:
 

--- a/docs/reference/extensions/flask-framework.rst
+++ b/docs/reference/extensions/flask-framework.rst
@@ -57,14 +57,15 @@ server metrics. Some of the `Gunicorn-provided metrics
 are mapped to new names:
 
 .. list-table::
-    * - StatsD metric
-       - Gunicorn metric
-    * - ``gunicorn.request.status.*``
-       - ``flask_response_code``
-    * - ``gunicorn.requests``
-       - ``flask_requests``
-    * - ``gunicorn.request.duration``
-       - ``flask_request_duration``
+
+  * - StatsD metric
+    - Gunicorn metric
+  * - ``gunicorn.request.status.*``
+    - ``flask_response_code``
+  * - ``gunicorn.requests``
+    - ``flask_requests``
+  * - ``gunicorn.request.duration``
+    - ``flask_request_duration``
 
 The  exporter listens on localhost at port 9125. You can push your
 own metrics to the exporter using any StatsD client. This snippet from an example

--- a/docs/reference/extensions/flask-framework.rst
+++ b/docs/reference/extensions/flask-framework.rst
@@ -51,15 +51,24 @@ application. In the following example we use it to specify ``libpq-dev``:
 StatsD exporter
 ===============
 
-A StatsD exporter is installed alongside the Gunicorn server to export Gunicorn
-server metrics. The `Gunicorn-provided metrics
+A StatsD exporter is installed alongside the Gunicorn server to record
+server metrics. Some of the `Gunicorn-provided metrics
 <https://docs.gunicorn.org/en/stable/instrumentation.html>`_
-are mapped to the names ``flask_response_code``, ``flask_requests`` and
-``flask_request_duration``.
+are mapped to new names:
+
+.. list-table::
+    * - StatsD metric
+       - Gunicorn metric
+    * - ``gunicorn.request.status.*``
+       - ``flask_response_code``
+    * - ``gunicorn.requests``
+       - ``flask_requests``
+    * - ``gunicorn.request.duration``
+       - ``flask_request_duration``
 
 The  exporter listens on localhost at port 9125. You can push your
-own metrics to the statsd-exporter using any StatsD Client. For example,
-using the client ``pystatsd``:
+own metrics to the exporter using any StatsD client. This snippet from an example
+Flask app uses pystatsd as a client:
 
 .. code-block:: python
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR adds documentation about Gunicorn metrics for Django and Flask extensions. It also explains how to push app metrics to the StatsD exporter.