### PR TITLE
docs: Incorporate UX feedback into 12-factor tutorials

### DIFF
--- a/docs/tutorial/code/django/task.yaml
+++ b/docs/tutorial/code/django/task.yaml
@@ -46,8 +46,9 @@ execute: |
   # [docs:ls-rock-end]
 
   # [docs:skopeo-copy]
-  sudo rockcraft.skopeo --insecure-policy \
-    copy oci-archive:django-hello-world_0.1_amd64.rock \
+  sudo rockcraft.skopeo copy \
+    --insecure-policy \
+    oci-archive:django-hello-world_0.1_amd64.rock \
     docker-daemon:django-hello-world:0.1
   # [docs:skopeo-copy-end]
 

--- a/docs/tutorial/code/expressjs/task.yaml
+++ b/docs/tutorial/code/expressjs/task.yaml
@@ -55,8 +55,9 @@ execute: |
   # [docs:ls-rock-end]
 
   # [docs:skopeo-copy]
-  sudo rockcraft.skopeo --insecure-policy \
-    copy oci-archive:expressjs-hello-world_0.1_amd64.rock \
+  sudo rockcraft.skopeo copy \
+    --insecure-policy \
+    oci-archive:expressjs-hello-world_0.1_amd64.rock \
     docker-daemon:expressjs-hello-world:0.1
   # [docs:skopeo-copy-end]
 

--- a/docs/tutorial/code/fastapi/task.yaml
+++ b/docs/tutorial/code/fastapi/task.yaml
@@ -40,8 +40,9 @@ execute: |
   # [docs:ls-rock-end]
 
   # [docs:skopeo-copy]
-  sudo rockcraft.skopeo --insecure-policy \
-    copy oci-archive:fastapi-hello-world_0.1_amd64.rock \
+  sudo rockcraft.skopeo copy \
+    --insecure-policy \
+    oci-archive:fastapi-hello-world_0.1_amd64.rock \
     docker-daemon:fastapi-hello-world:0.1
   # [docs:skopeo-copy-end]
 

--- a/docs/tutorial/code/flask/task.yaml
+++ b/docs/tutorial/code/flask/task.yaml
@@ -40,8 +40,9 @@ execute: |
   # [docs:ls-rock-end]
 
   # [docs:skopeo-copy]
-  sudo rockcraft.skopeo --insecure-policy \
-    copy oci-archive:flask-hello-world_0.1_amd64.rock \
+  sudo rockcraft.skopeo copy \
+    --insecure-policy \
+    oci-archive:flask-hello-world_0.1_amd64.rock \
     docker-daemon:flask-hello-world:0.1
   # [docs:skopeo-copy-end]
 

--- a/docs/tutorial/code/go/task.yaml
+++ b/docs/tutorial/code/go/task.yaml
@@ -50,8 +50,9 @@ execute: |
   # [docs:ls-rock-end]
 
   # [docs:skopeo-copy]
-  rockcraft.skopeo --insecure-policy \
-    copy oci-archive:go-hello-world_0.1_amd64.rock \
+  rockcraft.skopeo copy \
+    --insecure-policy \
+    oci-archive:go-hello-world_0.1_amd64.rock \
     docker-daemon:go-hello-world:0.1
   # [docs:skopeo-copy-end]
 

--- a/docs/tutorial/code/spring-boot/task.yaml
+++ b/docs/tutorial/code/spring-boot/task.yaml
@@ -65,9 +65,9 @@ execute: |
   # [docs:ls-rock-end]
 
   # [docs:skopeo-copy]
-  rockcraft.skopeo \
+  rockcraft.skopeo copy \
     --insecure-policy \
-    copy oci-archive:spring-boot-hello-world_0.1_amd64.rock \
+    oci-archive:spring-boot-hello-world_0.1_amd64.rock \
     docker-daemon:spring-boot-hello-world:0.1
   # [docs:skopeo-copy-end]
 

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -272,7 +272,7 @@ the ``rockcraft.yaml`` file should look similar to the following:
     # for more information about bases and using 'bare' bases for chiselled rocks
     base: bare
     build-base: ubuntu@22.04
-    version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
+    version: '0.1-chiselled'
     summary: A summary of your Django app # 79 char long summary
     description: |
         This is django-hello-world's description. You have a paragraph or two to tell the

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -29,6 +29,7 @@ Create a ``requirements.txt`` file, copy the following text into it and then
 save it:
 
 .. literalinclude:: code/django/requirements.txt
+    :caption: ~/django-hello-world/requirements.txt
 
 In order to test the Django application locally (before packing it into a rock),
 install ``python3-venv`` and create a virtual environment:
@@ -343,17 +344,20 @@ we want to add a new ``/time/`` endpoint which returns the current time.
 Open the file ``time_app/views.py`` and replace its contents with the following:
 
 .. literalinclude:: code/django/time_app_views.py
+    :caption: ~/django-hello-world/django_hello_world/time_app/views.py
     :language: python
 
 Create the file ``time_app/urls.py`` with the following contents:
 
 .. literalinclude:: code/django/time_app_urls.py
+    :caption: ~/django-hello-world/django_hello_world/time_app/urls.py
     :language: python
 
 Open the file ``django_hello_world/urls.py`` and replace its contents with
 the following:
 
 .. literalinclude:: code/django/urls.py
+    :caption: ~/django-hello-world/django_hello_world/django_hello_world/urls.py
     :language: python
 
 Since we are creating a new version of the application, go back to the

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -144,6 +144,13 @@ need to load it into Docker:
     :end-before: [docs:skopeo-copy-end]
     :dedent: 2
 
+This command contains the following pieces:
+
+- ``--insecure-policy``: adopts a permissive policy that
+  removes the need for a dedicated policy file.
+- ``oci-archive``: specifies the rock we created for our Django app.
+- ``docker-daemon``: specifies the name of the image in the Docker registry.
+
 Check that the image was successfully loaded into Docker:
 
 .. literalinclude:: code/django/task.yaml

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -136,7 +136,10 @@ Run the Django rock with Docker
 ===============================
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we'll
-need to load it into Docker:
+need to load it into Docker. Docker requires rocks to be imported into the
+daemon since they cannot be executed directly like an executable.
+
+Copy the rock:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -267,7 +267,8 @@ the ``rockcraft.yaml`` file should look similar to the following:
     name: django-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/
     # for more information about bases and using 'bare' bases for chiselled rocks
-    base: ubuntu@22.04 # the base environment for this Django app
+    base: bare
+    build-base: ubuntu@22.04
     version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
     summary: A summary of your Django app # 79 char long summary
     description: |

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -262,7 +262,7 @@ the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml
     :caption: ~/django-hello-world/rockcraft.yaml
-    :emphasize-lines: 5
+    :emphasize-lines: 6
 
     name: django-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -249,8 +249,33 @@ In the project file, change the ``base`` to ``bare`` and add
     :dedent: 2
 
 So that we can compare the size after chiselling, open the project
-file and change the ``version`` (e.g. to ``0.1-chiselled``). Pack the rock with
-the new ``bare`` :ref:`base <bases_explanation>`:
+file and change the ``version`` (e.g. to ``0.1-chiselled``). The top of
+the ``rockcraft.yaml`` file should look similar to the following:
+
+.. code-block:: yaml
+    :caption: ~/django-hello-world/rockcraft.yaml
+    :emphasize-lines: 5
+
+    name: django-hello-world
+    # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/
+    # for more information about bases and using 'bare' bases for chiselled rocks
+    base: ubuntu@22.04 # the base environment for this Django app
+    version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
+    summary: A summary of your Django app # 79 char long summary
+    description: |
+        This is django-hello-world's description. You have a paragraph or two to tell the
+        most important story about it. Keep it under 100 words though,
+        we live in tweetspace and your description wants to look good in the
+        container registries out there.
+    # the platforms this rock should be built on and run on.
+    # you can check your architecture with `dpkg --print-architecture`
+    platforms:
+        amd64:
+        # arm64:
+        # ppc64el:
+        # s390x:
+
+Pack the rock with the new ``bare`` :ref:`base <bases_explanation>`:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -12,7 +12,7 @@ Setup
 
 .. include:: /reuse/tutorial/setup_stable.rst
 
-Finally, create a new directory for this tutorial and go inside it:
+Finally, create an empty project directory:
 
 .. code-block:: bash
 
@@ -137,7 +137,7 @@ Run the Django rock with Docker
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we'll
 need to load it into Docker. Docker requires rocks to be imported into the
-daemon since they cannot be executed directly like an executable.
+daemon since they can't be run directly like an executable.
 
 Copy the rock:
 
@@ -287,7 +287,7 @@ the ``rockcraft.yaml`` file should look similar to the following:
         # ppc64el:
         # s390x:
 
-Pack the rock with the new ``bare`` :ref:`base <bases_explanation>`:
+Pack the rock with the new ``bare`` base:
 
 .. literalinclude:: code/django/task.yaml
     :language: bash

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -223,7 +223,7 @@ Start by creating the ``app/routes/time.js`` file in a text editor and paste the
 code from the snippet below:
 
 .. literalinclude:: code/expressjs/time.js
-    :caption: time.js
+    :caption: ~/app/routes/time.js
     :language: javascript
 
 Place the code snippet below in ``app/app.js`` under routes registration section
@@ -231,7 +231,7 @@ along with other ``app.use(...)`` lines.
 It will register the new ``/time`` endpoint:
 
 .. literalinclude:: code/expressjs/time_app.js
-    :caption: app.js
+    :caption: ~/app/app.js
     :language: javascript
     :start-after: [docs:append-lines]
     :end-before: [docs:append-lines-end]

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -135,6 +135,12 @@ We already have the rock as an OCI image. Load the image into Docker:
     :end-before: [docs:skopeo-copy-end]
     :dedent: 2
 
+This command contains the following pieces:
+
+- ``--insecure-policy``: adopts a permissive policy that
+  removes the need for a dedicated policy file.
+- ``oci-archive``: specifies the rock we created for our Express app.
+- ``docker-daemon``: specifies the name of the image in the Docker registry.
 
 Check that the image was successfully loaded into Docker:
 
@@ -243,6 +249,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
 .. code-block:: yaml
     :caption: ~/rockcraft.yaml
     :emphasize-lines: 6
+
     name: expressjs-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
     # for more information about bases and using 'bare' bases for chiselled rocks

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -137,7 +137,11 @@ extension:
 Run the ExpressJS rock with Docker
 ==================================
 
-We already have the rock as an OCI image. Load the image into Docker:
+We already have the rock as an OCI image. Now we
+need to load it into Docker. Docker requires rocks to be imported into the
+daemon since they cannot be executed directly like an executable.
+
+Copy the rock:
 
 .. literalinclude:: code/expressjs/task.yaml
     :language: bash

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -40,7 +40,17 @@ rock, install ``npm`` and initialize the starter app.
 Create the ExpressJS application
 ================================
 
-Start by generating the ExpressJS starter template using the express-generator.
+Start by creating the "Hello, world" Express application that will be used for
+this tutorial.
+
+Create a new directory for this tutorial and enter it:
+
+.. code-block:: bash
+
+   mkdir expressjs-hello-world
+   cd expressjs-hello-world
+
+Generate the ExpressJS starter template using the express-generator.
 
 .. literalinclude:: code/expressjs/task.yaml
     :language: bash
@@ -229,7 +239,7 @@ Start by creating the ``app/routes/time.js`` file in a text editor and paste the
 code from the snippet below:
 
 .. literalinclude:: code/expressjs/time.js
-    :caption: ~/app/routes/time.js
+    :caption: ~/expressjs-hello-world/app/routes/time.js
     :language: javascript
 
 Place the code snippet below in ``app/app.js`` under routes registration section
@@ -237,7 +247,7 @@ along with other ``app.use(...)`` lines.
 It will register the new ``/time`` endpoint:
 
 .. literalinclude:: code/expressjs/time_app.js
-    :caption: ~/app/app.js
+    :caption: ~/expressjs-hello-world/app/app.js
     :language: javascript
     :start-after: [docs:append-lines]
     :end-before: [docs:append-lines-end]
@@ -247,7 +257,7 @@ Since we are creating a new version of the application, set
 The top of the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml
-    :caption: ~/rockcraft.yaml
+    :caption: ~/expressjs-hello-world/rockcraft.yaml
     :emphasize-lines: 6
 
     name: expressjs-hello-world

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -1,9 +1,9 @@
 .. _build-a-rock-for-an-expressjs-application:
 
-Build a rock for an ExpressJS application
------------------------------------------
+Build a rock for an Express application
+---------------------------------------
 
-In this tutorial, we'll containerise a simple ExpressJS application into a rock
+In this tutorial, we'll containerise a simple Express application into a rock
 using Rockcraft's ``expressjs-framework`` :ref:`extension
 <expressjs-framework-reference>`.
 
@@ -11,12 +11,12 @@ It should take 25 minutes for you to complete.
 
 You won’t need to come prepared with intricate knowledge of software
 packaging, but familiarity with Linux paradigms, terminal operations,
-and ExpressJS is required.
+and Express is required.
 
-Once you complete this tutorial, you’ll have a working rock for an ExpressJS
+Once you complete this tutorial, you’ll have a working rock for an Express
 application. You’ll gain familiarity with Rockcraft and the
 ``expressjs-framework`` extension, and have the experience to create
-rocks for ExpressJS applications.
+rocks for Express applications.
 
 Setup
 =====
@@ -27,7 +27,7 @@ This tutorial requires the ``latest/edge`` channel of Rockcraft. Run
 ``sudo snap refresh rockcraft --channel latest/edge`` to get the latest
 edge version.
 
-In order to test the ExpressJS application locally, before packing it into a
+In order to test the Express application locally, before packing it into a
 rock, install ``npm`` and initialize the starter app.
 
 .. literalinclude:: code/expressjs/task.yaml
@@ -37,8 +37,8 @@ rock, install ``npm`` and initialize the starter app.
     :dedent: 2
 
 
-Create the ExpressJS application
-================================
+Create the Express application
+==============================
 
 Start by creating the "Hello, world" Express application that we'll pack in
 this tutorial.
@@ -75,14 +75,14 @@ endpoint. We may need a new terminal for this -- if using Multipass, run
     :end-before: [docs:curl-expressjs-end]
     :dedent: 2
 
-The ExpressJS application should respond with *Welcome to Express* web page.
+The Express application should respond with *Welcome to Express* web page.
 
 .. note::
-    The response from the ExpressJS application includes HTML and CSS which
+    The response from the Express application includes HTML and CSS which
     makes it difficult to read on a terminal. Visit ``http://localhost:3000``
     using a browser to see the fully rendered page.
 
-The ExpressJS application looks good, so let's stop it for now
+The Express application looks good, so let's stop it for now
 with :kbd:`Ctrl` + :kbd:`C`, then move out of the application directory
 ``cd ..``.
 
@@ -90,7 +90,7 @@ Pack the Express application into a rock
 ========================================
 
 First, we'll need a ``rockcraft.yaml`` project file. Rockcraft will automate its
-creation and tailor it for a ExpressJS application when we tell it to use the
+creation and tailor it for a Express application when we tell it to use the
 ``expressjs-framework`` profile:
 
 .. literalinclude:: code/expressjs/task.yaml
@@ -123,7 +123,7 @@ Pack the rock:
 
 Depending on the network, this step can take a couple of minutes to finish.
 
-Once Rockcraft has finished packing the ExpressJS rock, we'll find a new file in
+Once Rockcraft has finished packing the Express rock, we'll find a new file in
 the working directory (an `OCI <OCI_image_spec_>`_ image) with the ``.rock``
 extension:
 
@@ -134,8 +134,8 @@ extension:
     :dedent: 2
 
 
-Run the ExpressJS rock with Docker
-==================================
+Run the Express rock with Docker
+================================
 
 We already have the rock as an OCI image. Now we
 need to load it into Docker. Docker requires rocks to be imported into the
@@ -164,7 +164,7 @@ Check that the image was successfully loaded into Docker:
     :end-before: [docs:docker-images-end]
     :dedent: 2
 
-The output should list the ExpressJS image, along with its tag, ID and
+The output should list the Express image, along with its tag, ID and
 size:
 
 .. terminal::
@@ -172,7 +172,7 @@ size:
     REPOSITORY              TAG       IMAGE ID       CREATED       SIZE
     expressjs-hello-world   0.1       30c7e5aed202   2 weeks ago   304MB
 
-Now we're finally ready to run the rock and test the containerised ExpressJS
+Now we're finally ready to run the rock and test the containerised Express
 application:
 
 .. literalinclude:: code/expressjs/task.yaml
@@ -181,7 +181,7 @@ application:
     :end-before: [docs:docker-run-end]
     :dedent: 2
 
-Use the same curl command as before to send a request to the ExpressJS
+Use the same curl command as before to send a request to the Express
 application's root endpoint which is running inside the container:
 
 .. literalinclude:: code/expressjs/task.yaml
@@ -190,12 +190,12 @@ application's root endpoint which is running inside the container:
     :end-before: [docs:curl-expressjs-rock-end]
     :dedent: 2
 
-The ExpressJS application again responds with *Welcome to Express* page.
+The Express application again responds with *Welcome to Express* page.
 
 View the application logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When deploying the ExpressJS rock, we can always get the application logs with
+When deploying the Express rock, we can always get the application logs with
 :ref:`pebble_explanation_page`:
 
 .. literalinclude:: code/expressjs/task.yaml
@@ -222,7 +222,7 @@ We can also choose to follow the logs by using the ``-f`` option with the
 Stop the application
 ~~~~~~~~~~~~~~~~~~~~
 
-Now we have a fully functional rock for a ExpressJS application! This concludes
+Now we have a fully functional rock for a Express application! This concludes
 the first part of this tutorial, so we'll stop the container and remove the
 respective image for now:
 
@@ -233,8 +233,8 @@ respective image for now:
     :dedent: 2
 
 
-Update the ExpressJS application
-================================
+Update the Express application
+==============================
 
 For our final task, let's update our application. As an example,
 let's add a new ``/time`` endpoint that returns the current time.
@@ -371,7 +371,7 @@ Troubleshooting
 
 **Application updates not taking effect?**
 
-Upon changing the ExpressJS application and re-packing the rock, if
+Upon changing the Express application and re-packing the rock, if
 the changes are not taking effect, try running ``rockcraft clean`` and pack
 the rock again with ``rockcraft pack``.
 

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -40,17 +40,17 @@ rock, install ``npm`` and initialize the starter app.
 Create the ExpressJS application
 ================================
 
-Start by creating the "Hello, world" Express application that will be used for
+Start by creating the "Hello, world" Express application that we'll pack in
 this tutorial.
 
-Create a new directory for this tutorial and enter it:
+Create an empty project directory:
 
 .. code-block:: bash
 
    mkdir expressjs-hello-world
    cd expressjs-hello-world
 
-Generate the ExpressJS starter template using the express-generator.
+Next, create a skeleton for the project with the Express application generator:
 
 .. literalinclude:: code/expressjs/task.yaml
     :language: bash
@@ -139,7 +139,7 @@ Run the ExpressJS rock with Docker
 
 We already have the rock as an OCI image. Now we
 need to load it into Docker. Docker requires rocks to be imported into the
-daemon since they cannot be executed directly like an executable.
+daemon since they can't be run directly like an executable.
 
 Copy the rock:
 

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -238,6 +238,30 @@ It will register the new ``/time`` endpoint:
 
 Since we are creating a new version of the application, set
 ``version: '0.2'`` in the project file.
+The top of the ``rockcraft.yaml`` file should look similar to the following:
+
+.. code-block:: yaml
+    :caption: ~/rockcraft.yaml
+    :emphasize-lines: 6
+    name: expressjs-hello-world
+    # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
+    # for more information about bases and using 'bare' bases for chiselled rocks
+    base: bare # as an alternative, a ubuntu base can be used
+    build-base: ubuntu@24.04 # build-base is required when the base is bare
+    version: '0.2' # just for humans. Semantic versioning is recommended
+    summary: A summary of your ExpressJS app # 79 char long summary
+    description: |
+        This is expressjs-hello-world's description. You have a paragraph or two to tell the
+        most important story about it. Keep it under 100 words though,
+        we live in tweetspace and your description wants to look good in the
+        container registries out there.
+    # the platforms this rock should be built on and run on.
+    # you can check your architecture with `dpkg --print-architecture`
+    platforms:
+        amd64:
+        # arm64:
+        # ppc64el:
+        # s390x:
 
 Pack and run the rock using similar commands as before:
 

--- a/docs/tutorial/expressjs.rst
+++ b/docs/tutorial/expressjs.rst
@@ -269,7 +269,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
     # for more information about bases and using 'bare' bases for chiselled rocks
     base: bare # as an alternative, a ubuntu base can be used
     build-base: ubuntu@24.04 # build-base is required when the base is bare
-    version: '0.2' # just for humans. Semantic versioning is recommended
+    version: '0.2'
     summary: A summary of your ExpressJS app # 79 char long summary
     description: |
         This is expressjs-hello-world's description. You have a paragraph or two to tell the

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -29,6 +29,7 @@ Create a ``requirements.txt`` file, copy the following text into it, and then
 save it:
 
 .. literalinclude:: code/fastapi/requirements.txt
+    :caption: ~/fastapi-hello-world/requirements.txt
 
 It's fastest to test the FastAPI application locally, before we pack it into a
 rock, so let's install ``python3-venv`` and create a virtual environment we
@@ -44,6 +45,7 @@ In the same directory, put the following code into a new file,
 ``app.py``:
 
 .. literalinclude:: code/fastapi/app.py
+    :caption: ~/fastapi-hello-world/app.py
     :language: python
 
 Run the FastAPI application using ``fastapi dev app.py --port 8000`` to verify
@@ -340,6 +342,7 @@ Start by opening the ``app.py`` file in a text editor and update the code to
 look like the following:
 
 .. literalinclude:: code/fastapi/time_app.py
+    :caption: ~/fastapi-hello-world/app.py
     :language: python
 
 Since we are creating a new version of the application, open the

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -251,8 +251,33 @@ In the project file, change the ``base`` to ``bare`` and add
     when using the ``bare`` base.
 
 So that we can compare the size after chiselling, open the project
-file and change the ``version`` (e.g. to ``0.1-chiselled``). Pack the rock with
-the new ``bare`` :ref:`base <bases_explanation>`:
+file and change the ``version`` (e.g. to ``0.1-chiselled``).
+The top of the ``rockcraft.yaml`` file should look similar to the following:
+
+.. code-block:: yaml
+    :caption: ~/fastapi-hello-world/rockcraft.yaml
+    :emphasize-lines: 5
+
+    name: fastapi-hello-world
+    # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
+    # for more information about bases and using 'bare' bases for chiselled rocks
+    base: ubuntu@24.04 # the base environment for this FastAPI app
+    version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
+    summary: A summary of your FastAPI app # 79 char long summary
+    description: |
+        This is fastapi project's description. You have a paragraph or two to tell the
+        most important story about it. Keep it under 100 words though,
+        we live in tweetspace and your description wants to look good in the
+        container registries out there.
+    # the platforms this rock should be built on and run on.
+    # you can check your architecture with `dpkg --print-architecture`
+    platforms:
+        amd64:
+        # arm64:
+        # ppc64el:
+        # s390x:
+
+Pack the rock with the new ``bare`` :ref:`base <bases_explanation>`:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -12,7 +12,7 @@ Setup
 
 .. include:: /reuse/tutorial/setup_edge.rst
 
-Finally, create a new directory for this tutorial and go inside it:
+Finally, create an empty project directory:
 
 .. code-block:: bash
 
@@ -134,7 +134,7 @@ Run the FastAPI rock with Docker
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
 need to load it into Docker. Docker requires rocks to be imported into the
-daemon since they cannot be executed directly like an executable.
+daemon since they can't be run directly like an executable.
 
 Copy the rock:
 
@@ -290,7 +290,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
         # ppc64el:
         # s390x:
 
-Pack the rock with the new ``bare`` :ref:`base <bases_explanation>`:
+Pack the rock with the new ``bare`` base:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -270,7 +270,8 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
     name: fastapi-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
     # for more information about bases and using 'bare' bases for chiselled rocks
-    base: ubuntu@24.04 # the base environment for this FastAPI app
+    base: bare
+    build-base: ubuntu@24.04
     version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
     summary: A summary of your FastAPI app # 79 char long summary
     description: |

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -133,7 +133,10 @@ Run the FastAPI rock with Docker
 ================================
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
-need to load it into Docker:
+need to load it into Docker. Docker requires rocks to be imported into the
+daemon since they cannot be executed directly like an executable.
+
+Copy the rock:
 
 .. literalinclude:: code/fastapi/task.yaml
     :language: bash

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -265,7 +265,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml
     :caption: ~/fastapi-hello-world/rockcraft.yaml
-    :emphasize-lines: 5
+    :emphasize-lines: 6
 
     name: fastapi-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -275,7 +275,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
     # for more information about bases and using 'bare' bases for chiselled rocks
     base: bare
     build-base: ubuntu@24.04
-    version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
+    version: '0.1-chiselled'
     summary: A summary of your FastAPI app # 79 char long summary
     description: |
         This is fastapi project's description. You have a paragraph or two to tell the

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -141,6 +141,13 @@ need to load it into Docker:
     :end-before: [docs:skopeo-copy-end]
     :dedent: 2
 
+This command contains the following pieces:
+
+- ``--insecure-policy``: adopts a permissive policy that
+  removes the need for a dedicated policy file.
+- ``oci-archive``: specifies the rock we created for our FastAPI app.
+- ``docker-daemon``: specifies the name of the image in the Docker registry.
+
 Check that the image was successfully loaded into Docker:
 
 .. literalinclude:: code/fastapi/task.yaml

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -12,7 +12,7 @@ Setup
 
 .. include:: /reuse/tutorial/setup_stable.rst
 
-Finally, create a new directory for this tutorial and go inside it:
+Finally, create an empty project directory:
 
 .. code-block:: bash
 
@@ -128,7 +128,7 @@ Run the Flask rock with Docker
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
 need to load it into Docker. Docker requires rocks to be imported into the
-daemon since they cannot be executed directly like an executable.
+daemon since they can't be run directly like an executable.
 
 Copy the rock:
 
@@ -283,7 +283,7 @@ top of the ``rockcraft.yaml`` file looks similar to the following:
         # ppc64el:
         # s390x:
 
-Pack the rock with the new ``bare`` :ref:`base <bases_explanation>`:
+Pack the rock with the new ``bare`` base:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -258,12 +258,13 @@ top of the ``rockcraft.yaml`` file looks similar to the following:
 
 .. code-block:: yaml
     :caption: ~/flask-hello-world/rockcraft.yaml
-    :emphasize-lines: 5
+    :emphasize-lines: 6
 
     name: flask-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/
     # for more information about bases and using 'bare' bases for chiselled rocks
-    base: ubuntu@22.04 # the base environment for this Flask app
+    base: bare
+    build-base: ubuntu@22.04
     version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
     summary: A summary of your Flask app # 79 char long summary
     description: |

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -244,8 +244,33 @@ In the project file, change the ``base`` to ``bare`` and add
     when using the ``bare`` base.
 
 So that we can compare the size after chiselling, open the project
-file and change the ``version`` (e.g. to ``0.1-chiselled``). Pack the rock with
-the new ``bare`` :ref:`base <bases_explanation>`:
+file and change the ``version`` (e.g. to ``0.1-chiselled``). The
+top of the ``rockcraft.yaml`` file looks similar to the following:
+
+.. code-block:: yaml
+    :caption: ~/flask-hello-world/rockcraft.yaml
+    :emphasize-lines: 5
+
+    name: flask-hello-world
+    # see https://documentation.ubuntu.com/rockcraft/en/1.6.0/explanation/bases/
+    # for more information about bases and using 'bare' bases for chiselled rocks
+    base: ubuntu@22.04 # the base environment for this Flask app
+    version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
+    summary: A summary of your Flask app # 79 char long summary
+    description: |
+        This is flask-hello-world's description. You have a paragraph or two to tell the
+        most important story about it. Keep it under 100 words though,
+        we live in tweetspace and your description wants to look good in the
+        container registries out there.
+    # the platforms this rock should be built on and run on.
+    # you can check your architecture with `dpkg --print-architecture`
+    platforms:
+        amd64:
+        # arm64:
+        # ppc64el:
+        # s390x:
+
+Pack the rock with the new ``bare`` :ref:`base <bases_explanation>`:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -268,7 +268,7 @@ top of the ``rockcraft.yaml`` file looks similar to the following:
     # for more information about bases and using 'bare' bases for chiselled rocks
     base: bare
     build-base: ubuntu@22.04
-    version: '0.1-chiselled' # just for humans. Semantic versioning is recommended
+    version: '0.1-chiselled'
     summary: A summary of your Flask app # 79 char long summary
     description: |
         This is flask-hello-world's description. You have a paragraph or two to tell the

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -29,6 +29,7 @@ Create a ``requirements.txt`` file, copy the following text into it and then
 save it:
 
 .. literalinclude:: code/flask/requirements.txt
+    :caption: ~/flask-hello-world/requirements.txt
 
 In order to test the Flask application locally (before packing it into a rock),
 install ``python3-venv`` and create a virtual environment:
@@ -43,6 +44,7 @@ In the same directory, copy and save the following into a text file called
 ``app.py``:
 
 .. literalinclude:: code/flask/app.py
+    :caption: ~/flask-hello-world/app.py
     :language: python
 
 Run the Flask application using ``flask run -p 8000`` to verify that it works.
@@ -333,6 +335,7 @@ Start by opening the ``app.py`` file in a text editor and update the code to
 look like the following:
 
 .. literalinclude:: code/flask/time_app.py
+    :caption: ~/flask-hello-world/app.py
     :language: python
 
 Since we are creating a new version of the application, open the

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -135,6 +135,13 @@ need to load it into Docker:
     :end-before: [docs:skopeo-copy-end]
     :dedent: 2
 
+This command contains the following pieces:
+
+- ``--insecure-policy``: adopts a permissive policy that
+  removes the need for a dedicated policy file.
+- ``oci-archive``: specifies the rock we created for our Flask app.
+- ``docker-daemon``: specifies the name of the image in the Docker registry.
+
 Check that the image was successfully loaded into Docker:
 
 .. literalinclude:: code/flask/task.yaml

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -127,7 +127,10 @@ Run the Flask rock with Docker
 ==============================
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
-need to load it into Docker:
+need to load it into Docker. Docker requires rocks to be imported into the
+daemon since they cannot be executed directly like an executable.
+
+Copy the rock:
 
 .. literalinclude:: code/flask/task.yaml
     :language: bash

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -38,7 +38,7 @@ Create the Go application
 Start by creating the "Hello, world" Go application that will be used for
 this tutorial.
 
-Create a new directory for this tutorial and enter it:
+Create an empty project directory:
 
 .. code-block:: bash
 
@@ -158,7 +158,7 @@ Run the Go rock with Docker
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
 need to load it into Docker. Docker requires rocks to be imported into the
-daemon since they cannot be executed directly like an executable.
+daemon since they can't be run directly like an executable.
 
 Copy the rock:
 

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -57,6 +57,7 @@ Create a ``main.go`` file, copy the following text into it and then
 save it:
 
 .. literalinclude:: code/go/main.go
+    :caption: ~/go-hello-world/main.go
     :language: go
 
 Build the Go application so it can be run:
@@ -251,6 +252,7 @@ Start by opening the ``main.go`` file in a text editor and update the code to
 look like the following:
 
 .. literalinclude:: code/go/main.go.time
+    :caption: ~/go-hello-world/main.go
     :language: go
 
 Since we are creating a new version of the application, open the project

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -156,8 +156,11 @@ Run the Go rock with Docker
 ===========================
 
 
-We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Load the
-image into Docker:
+We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
+need to load it into Docker. Docker requires rocks to be imported into the
+daemon since they cannot be executed directly like an executable.
+
+Copy the rock:
 
 .. literalinclude:: code/go/task.yaml
     :language: bash

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -277,7 +277,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
     # for more information about bases and using 'bare' bases for chiselled rocks
     base: bare # as an alternative, a ubuntu base can be used
     build-base: ubuntu@24.04 # build-base is required when the base is bare
-    version: '0.2' # just for humans. Semantic versioning is recommended
+    version: '0.2'
     summary: A summary of your Go app # 79 char long summary
     description: |
         This is go-hello-world's description. You have a paragraph or two to tell the

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -262,7 +262,7 @@ look like the following:
     :language: go
 
 Since we are creating a new version of the application, open the project
-file and set ``version: "0.2"``.
+file and set ``version: '0.2'``.
 The top of the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -165,6 +165,12 @@ image into Docker:
     :end-before: [docs:skopeo-copy-end]
     :dedent: 2
 
+This command contains the following pieces:
+
+- ``--insecure-policy``: adopts a permissive policy that
+  removes the need for a dedicated policy file.
+- ``oci-archive``: specifies the rock we created for our Go app.
+- ``docker-daemon``: specifies the name of the image in the Docker registry.
 
 Check that the image was successfully loaded into Docker:
 

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -242,7 +242,7 @@ respective image for now:
 
 
 Update the Go application
-========================================
+=========================
 
 As a final step, let's update our application. For example,
 we want to add a new ``/time`` endpoint which returns the current time.
@@ -255,6 +255,31 @@ look like the following:
 
 Since we are creating a new version of the application, open the project
 file and set ``version: "0.2"``.
+The top of the ``rockcraft.yaml`` file should look similar to the following:
+
+.. code-block:: yaml
+    :caption: ~/go-hello-world/rockcraft.yaml
+    :emphasize-lines: 6
+
+    name: go-hello-world
+    # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
+    # for more information about bases and using 'bare' bases for chiselled rocks
+    base: bare # as an alternative, a ubuntu base can be used
+    build-base: ubuntu@24.04 # build-base is required when the base is bare
+    version: '0.2' # just for humans. Semantic versioning is recommended
+    summary: A summary of your Go app # 79 char long summary
+    description: |
+        This is go-hello-world's description. You have a paragraph or two to tell the
+        most important story about it. Keep it under 100 words though,
+        we live in tweetspace and your description wants to look good in the
+        container registries out there.
+    # the platforms this rock should be built on and run on.
+    # you can check your architecture with `dpkg --print-architecture`
+    platforms:
+        amd64:
+        # arm64:
+        # ppc64el:
+        # s390x:
 
 .. note::
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -28,5 +28,5 @@ code into container applications:
    6. Build a rock for a Django application <django.rst>
    7. Build a rock for a FastAPI application <fastapi.rst>
    8. Build a rock for a Go application <go.rst>
-   9. Build a rock for an ExpressJS application <expressjs.rst>
+   9. Build a rock for an Express application <expressjs.rst>
    9. Build a rock for a SpringBoot application <springboot.rst>

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -36,7 +36,17 @@ install ``devpack-for-spring`` and Java.
 Create the Spring Boot application
 ==================================
 
-Start by creating the Demo Spring Boot application that will be used for
+Start by creating the "Hello, world" Spring Boot application that will be used
+for this tutorial.
+
+Create a new directory for this tutorial and enter it:
+
+.. code-block:: bash
+
+   mkdir spring-boot-hello-world
+   cd spring-boot-hello-world
+
+Create the Demo Spring Boot application that will be used for
 this tutorial.
 
 .. literalinclude:: code/spring-boot/task.yaml
@@ -64,7 +74,7 @@ Let's Run the Spring Boot application to verify that it works:
 
   java -jar target/demo-0.0.1.jar
 
-The application starts an HTTP server listening on port 8000
+The application starts an HTTP server listening on port 8080
 that we can test by using ``curl`` to send a request to the root
 endpoint. We may need a new terminal for this -- if using Multipass, run
 ``multipass shell rock-dev`` to get another terminal:
@@ -255,7 +265,7 @@ Start by creating the ``src/main/java/com/example/demo/TimeController.java``
 file in a text editor and paste in the code to look like the following:
 
 .. literalinclude:: code/spring-boot/TimeController.java
-    :caption: ~/src/main/java/com/example/demo/TimeController.java
+    :caption: ~/spring-boot-hello-world/src/main/java/com/example/demo/TimeController.java
     :language: java
 
 Since we are creating a new version of the application, open the project
@@ -263,7 +273,7 @@ file and set ``version: '0.2'``.
 The top of the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml
-    :caption: ~/rockcraft.yaml
+    :caption: ~/spring-boot-hello-world/rockcraft.yaml
     :emphasize-lines: 6
 
     name: spring-boot-hello-world

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -153,8 +153,11 @@ Run the Spring Boot rock with Docker
 ====================================
 
 
-We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Load the
-image into Docker:
+We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
+need to load it into Docker. Docker requires rocks to be imported into the
+daemon since they cannot be executed directly like an executable.
+
+Copy the rock:
 
 .. literalinclude:: code/spring-boot/task.yaml
     :language: bash

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -152,6 +152,12 @@ image into Docker:
     :end-before: [docs:skopeo-copy-end]
     :dedent: 2
 
+This command contains the following pieces:
+
+- ``--insecure-policy``: adopts a permissive policy that
+  removes the need for a dedicated policy file.
+- ``oci-archive``: specifies the rock we created for our Spring Boot app.
+- ``docker-daemon``: specifies the name of the image in the Docker registry.
 
 Check that the image was successfully loaded into Docker:
 
@@ -253,12 +259,13 @@ file in a text editor and paste in the code to look like the following:
     :language: java
 
 Since we are creating a new version of the application, open the project
-file and set ``version: "0.2"``.
+file and set ``version: '0.2'``.
 The top of the ``rockcraft.yaml`` file should look similar to the following:
 
 .. code-block:: yaml
     :caption: ~/rockcraft.yaml
     :emphasize-lines: 6
+
     name: spring-boot-hello-world
     # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
     # for more information about bases and using 'bare' bases for chiselled rocks

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -249,6 +249,7 @@ Start by creating the ``src/main/java/com/example/demo/TimeController.java``
 file in a text editor and paste in the code to look like the following:
 
 .. literalinclude:: code/spring-boot/TimeController.java
+    :caption: ~/src/main/java/com/example/demo/TimeController.java
     :language: java
 
 Since we are creating a new version of the application, open the project

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -39,7 +39,7 @@ Create the Spring Boot application
 Start by creating the "Hello, world" Spring Boot application that will be used
 for this tutorial.
 
-Create a new directory for this tutorial and enter it:
+Create an empty project directory:
 
 .. code-block:: bash
 
@@ -155,7 +155,7 @@ Run the Spring Boot rock with Docker
 
 We already have the rock as an `OCI <OCI_image_spec_>`_ archive. Now we
 need to load it into Docker. Docker requires rocks to be imported into the
-daemon since they cannot be executed directly like an executable.
+daemon since they can't be run directly like an executable.
 
 Copy the rock:
 

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -253,6 +253,30 @@ file in a text editor and paste in the code to look like the following:
 
 Since we are creating a new version of the application, open the project
 file and set ``version: "0.2"``.
+The top of the ``rockcraft.yaml`` file should look similar to the following:
+
+.. code-block:: yaml
+    :caption: ~/rockcraft.yaml
+    :emphasize-lines: 6
+    name: spring-boot-hello-world
+    # see https://documentation.ubuntu.com/rockcraft/en/latest/explanation/bases/
+    # for more information about bases and using 'bare' bases for chiselled rocks
+    base: bare # as an alternative, a ubuntu base can be used
+    build-base: ubuntu@24.04 # build-base is required when the base is bare
+    version: '0.2' # just for humans. Semantic versioning is recommended
+    summary: A summary of your Go application # 79 char long summary
+    description: |
+        This is spring-boot-hello-world's description. You have a paragraph or two to tell the
+        most important story about it. Keep it under 100 words though,
+        we live in tweetspace and your description wants to look good in the
+        container registries out there.
+    # the platforms this rock should be built on and run on.
+    # you can check your architecture with `dpkg --print-architecture`
+    platforms:
+        amd64:
+        # arm64:
+        # ppc64el:
+        # s390x:
 
 .. note::
 

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -285,7 +285,7 @@ The top of the ``rockcraft.yaml`` file should look similar to the following:
     # for more information about bases and using 'bare' bases for chiselled rocks
     base: bare # as an alternative, a ubuntu base can be used
     build-base: ubuntu@24.04 # build-base is required when the base is bare
-    version: '0.2' # just for humans. Semantic versioning is recommended
+    version: '0.2'
     summary: A summary of your Go application # 79 char long summary
     description: |
         This is spring-boot-hello-world's description. You have a paragraph or two to tell the

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -265,7 +265,8 @@ Start by creating the ``src/main/java/com/example/demo/TimeController.java``
 file in a text editor and paste in the code to look like the following:
 
 .. literalinclude:: code/spring-boot/TimeController.java
-    :caption: ~/spring-boot-hello-world/src/main/java/com/example/demo/TimeController.java
+    :caption: ~/spring-boot-hello-world/src/main/java/com/example/demo/
+     TimeController.java
     :language: java
 
 Since we are creating a new version of the application, open the project


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

I ran `make lint` and received errors on files this PR doesn't touch.

---

Updates to the tutorials based on feedback in UX sessions:
1. When copying the skopeo command for the chiseled hello world rock. The user missed the hint to change the name in the project file to `0.1-chisel`, resulting in a error.
2. File headers could be added to file excerpts (app.py) [External example](https://www.digitalocean.com/community/tutorials/how-to-make-a-web-application-using-flask-in-python-3)
3. Clarification may be needed on what the skopeo command is doing. Maybe we could also mention about how Docker requires rocks (or images in general) to be imported into the daemon since they cannot be executed directly like an executable.

In addition, two corrections to the Express and Spring Boot tutorials:
1. Add `mkdir <app rock name>` and `cd <app rock name>` to the beginning of the tutorial so that the rock will have the correct name from the start.
2. Update the port to the correct value.
