### PR TITLE
test: don't leave behind test files

### DIFF
--- a/tests/integration/test_oci.py
+++ b/tests/integration/test_oci.py
@@ -233,6 +233,7 @@ def test_stat(new_dir):
     assert layer2_history[0] == layer1_history[0]
 
 
+@pytest.mark.usefixtures("new_dir")
 def test_image_manifest_has_media_type():
     """Test that the image manifest has the correct media type."""
     image = oci.Image.new_oci_image(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

One of the OCI tests was leaving behind test files in the main project directory after running. This PR just makes those test files live in a temp directory instead.