### PR TITLE
build(docs): update build, add sphinx sitemap, update site links

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,4 +30,7 @@ build:
     create_environment:
       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
+      - make setup-docs UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}"
+    build:
+      html:
+        - make docs UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" DOCS_OUTPUT="$READTHEDOCS_OUTPUT/html/"

--- a/common.mk
+++ b/common.mk
@@ -221,11 +221,11 @@ test-find-slow:  ##- Identify slow tests. Set cutoff time in seconds with SLOW_C
 
 .PHONY: docs
 docs:  ## Build documentation
-	uv run $(UV_DOCS_GROUPS) sphinx-build -b html -W $(DOCS) $(DOCS)/_build
+	uv run $(UV_DOCS_GROUPS) sphinx-build -b dirhtml -W $(DOCS) $(DOCS)/_build
 
 .PHONY: docs-auto
 docs-auto:  ## Build and host docs with sphinx-autobuild
-	uv run --group docs sphinx-autobuild -b html --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
+	uv run --group docs sphinx-autobuild -b dirhtml --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
 
 .PHONY: pack-pip
 pack-pip:  ##- Build packages for pip (sdist, wheel)

--- a/common.mk
+++ b/common.mk
@@ -3,6 +3,7 @@
 
 SOURCES=$(wildcard *.py) $(PROJECT) tests
 DOCS=docs
+DOCS_OUTPUT=$(DOCS)/_build
 
 ifneq ($(OS),Windows_NT)
 	OS := $(shell uname)
@@ -221,11 +222,11 @@ test-find-slow:  ##- Identify slow tests. Set cutoff time in seconds with SLOW_C
 
 .PHONY: docs
 docs:  ## Build documentation
-	uv run $(UV_DOCS_GROUPS) sphinx-build -b dirhtml -W $(DOCS) $(DOCS)/_build
+	uv run $(UV_DOCS_GROUPS) sphinx-build -b dirhtml -W $(DOCS) $(DOCS_OUTPUT)
 
 .PHONY: docs-auto
 docs-auto:  ## Build and host docs with sphinx-autobuild
-	uv run --group docs sphinx-autobuild -b dirhtml --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
+	uv run --group docs sphinx-autobuild -b dirhtml --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS_OUTPUT)
 
 .PHONY: pack-pip
 pack-pip:  ##- Build packages for pip (sdist, wheel)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ html_theme_options = {
 extensions = [
     "canonical_sphinx",
     "notfound.extension",
+    "sphinx_sitemap",
 ]
 # endregion
 extensions.extend(
@@ -120,6 +121,15 @@ rst_epilog = """
 # Client-side page redirects.
 rediraffe_redirects = "redirects.txt"
 
+# Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
+html_baseurl = "https://documentation.ubuntu.com/rockcraft/"
+
+if "READTHEDOCS_VERSION" in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = "{version}{link}"
+else:
+    sitemap_url_scheme = "latest/{link}"
+
 # Do (not) include module names.
 add_module_names = True
 
@@ -134,9 +144,6 @@ linkcheck_retries = 3
 
 # Enable support for google-style instance attributes.
 napoleon_use_ivar = True
-
-# Client-side page redirects.
-rediraffe_redirects = "redirects.txt"
 
 # TODO: this is a boilerplate copy from the sphinx-docs. It should
 # be built on top of it instead of duplicating its content

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,22 +20,18 @@ import pathlib
 import sys
 
 import craft_parts_docs
-
-project_dir = pathlib.Path("..").resolve()
-sys.path.insert(0, str(project_dir.absolute()))
-
 import rockcraft  # noqa: E402
 
 project = "Rockcraft"
 author = "Canonical Group Ltd"
 
-copyright = "2022-%s, %s" % (datetime.date.today().year, author)
-
 # The full version, including alpha/beta/rc tags
 release = rockcraft.__version__
+# The commit hash in the dev release version confuses the spellchecker
 if ".post" in release:
-    # The commit hash in the dev release version confuses the spellchecker
     release = "dev"
+
+copyright = "2022-%s, %s" % (datetime.date.today().year, author)
 
 # region Configuration for canonical-sphinx
 ogp_site_url = "https://canonical-rockcraft.readthedocs-hosted.com/"
@@ -43,10 +39,13 @@ ogp_site_name = project
 ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
 
 html_context = {
-    "product_page": "github.com/canonical/rockcraft",
-    "discourse": "https://discourse.ubuntu.com/c/rocks/117",
+    "product_page": "", # Rockcraft doesn't have a marketing page
     "github_url": "https://github.com/canonical/rockcraft",
-    "github_issues": "https://github.com/canonical/rockcraft/issues",
+    "repo_default_branch": "main",
+    "repo_folder": "/docs/",
+    "github_issues": "enabled",
+    "matrix": "https://matrix.to/#/#rockcraft:ubuntu.com",
+    "discourse": "https://discourse.ubuntu.com/c/rocks/117",
     "display_contributors": False,
 }
 
@@ -118,9 +117,8 @@ rst_epilog = """
 
 # region Options for extensions
 
-# Github config
-github_username = "canonical"
-github_repository = "rockcraft"
+# Client-side page redirects.
+rediraffe_redirects = "redirects.txt"
 
 # Do (not) include module names.
 add_module_names = True
@@ -136,8 +134,6 @@ linkcheck_retries = 3
 
 # Enable support for google-style instance attributes.
 napoleon_use_ivar = True
-
-# endregion
 
 # Client-side page redirects.
 rediraffe_redirects = "redirects.txt"
@@ -186,15 +182,17 @@ notfound_context = {
 }
 # endregion
 
+# region Autgenerate documentation
+
+project_dir = pathlib.Path("..").resolve()
+sys.path.insert(0, str(project_dir.absolute()))
 
 def generate_cli_docs(nil):
     gen_cli_docs_path = (project_dir / "tools" / "docs" / "gen_cli_docs.py").resolve()
     os.system("%s %s" % (gen_cli_docs_path, project_dir / "docs"))
 
-
 def setup(app):
     app.connect("builder-inited", generate_cli_docs)
-
 
 # Setup libraries documentation snippets for use in rockcraft docs.
 common_docs_path = pathlib.Path(__file__).parent / "common"
@@ -203,3 +201,5 @@ craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-
 (common_docs_path / "craft-parts").symlink_to(
     craft_parts_docs_path, target_is_directory=True
 )
+
+# endregion

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,11 +191,11 @@ notfound_context = {
 
 # region Autgenerate documentation
 
-project_dir = pathlib.Path("..").resolve()
+project_dir = pathlib.Path(__file__).parents[1].resolve()
 sys.path.insert(0, str(project_dir.absolute()))
 
 def generate_cli_docs(nil):
-    gen_cli_docs_path = (project_dir / "tools" / "docs" / "gen_cli_docs.py").resolve()
+    gen_cli_docs_path = (project_dir / "tools/docs/gen_cli_docs.py").resolve()
     os.system("%s %s" % (gen_cli_docs_path, project_dir / "docs"))
 
 def setup(app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,10 @@ types = [
 docs = [
     "canonical-sphinx[full]~=0.4.0",
     "sphinx-autobuild~=2024.2",
-    "sphinx-pydantic==0.1.1",
-    "sphinx-toolbox~=3.5",
     "sphinx-lint~=1.0",
+    "sphinx-pydantic==0.1.1",
+    "sphinx-sitemap>=2.6.0",
+    "sphinx-toolbox~=3.5",
     "sphinxcontrib-details-directive",
     "sphinxext-rediraffe==0.2.7",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2541,6 +2541,7 @@ docs = [
     { name = "sphinx-autobuild" },
     { name = "sphinx-lint" },
     { name = "sphinx-pydantic" },
+    { name = "sphinx-sitemap" },
     { name = "sphinx-toolbox" },
     { name = "sphinxcontrib-details-directive" },
     { name = "sphinxext-rediraffe" },
@@ -2605,6 +2606,7 @@ docs = [
     { name = "sphinx-autobuild", specifier = "~=2024.2" },
     { name = "sphinx-lint", specifier = "~=1.0" },
     { name = "sphinx-pydantic", specifier = "==0.1.1" },
+    { name = "sphinx-sitemap", specifier = ">=2.6.0" },
     { name = "sphinx-toolbox", specifier = "~=3.5" },
     { name = "sphinxcontrib-details-directive" },
     { name = "sphinxext-rediraffe", specifier = "==0.2.7" },
@@ -2973,6 +2975,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/6b/bcca2785de4071f604a722444d4d7ba8a9d40de3c14ad52fce93e6d92694/sphinx_reredirects-0.1.6.tar.gz", hash = "sha256:c491cba545f67be9697508727818d8626626366245ae64456fe29f37e9bbea64", size = 7080, upload-time = "2025-03-22T10:52:30.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/6f/0b3625be30a1a50f9e4c2cb2ec147b08f15ed0e9f8444efcf274b751300b/sphinx_reredirects-0.1.6-py3-none-any.whl", hash = "sha256:efd50c766fbc5bf40cd5148e10c00f2c00d143027de5c5e48beece93cc40eeea", size = 5675, upload-time = "2025-03-22T10:52:29.113Z" },
+]
+
+[[package]]
+name = "sphinx-sitemap"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/ed/96cc112b671e06df01c8306c25ce3331ccfece0d30235e32eb039afc8094/sphinx_sitemap-2.6.0.tar.gz", hash = "sha256:5e0c66b9f2e371ede80c659866a9eaad337d46ab02802f9c7e5f7bc5893c28d2", size = 6042, upload-time = "2024-04-29T00:18:13.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d4/dffb4da380be24fd390d284634735d6fba560980014050e52569c04d215b/sphinx_sitemap-2.6.0-py3-none-any.whl", hash = "sha256:7478e417d141f99c9af27ccd635f44c03a471a08b20e778a0f9daef7ace1d30b", size = 5632, upload-time = "2024-04-29T00:18:12.147Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
ROCKCRAFT-237

- Update site links.
- Also, do some small housekeeping in docs config file.

For ROCKCRAFT-238:

- Configure sitemap.
- Switch Sphinx builder to `dirhtml`, as it's required for sitemap
  generation.

Other:

Make local and builds use the same consistent tooling.
---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
