### PR TITLE
style: adjust linting rules for ruff 0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,6 +357,9 @@ ignore = [
 
     # Ignored due to common usage in current code
     "TRY003", # Avoid specifying long messages outside the exception class
+
+    # Rockcraft-specific rule ignores
+    "PLC0415",# Rockcraft in particular uses non top-level imports frequently.
 ]
 
 [tool.ruff.lint.flake8-annotations]


### PR DESCRIPTION
Rockcraft uses PLC0415 frequently enough that it doesn't make sense to noqa it.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
