### PR TITLE
ci: clean up OSV workflows

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -15,7 +15,10 @@ jobs:
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
       packages: python-apt-dev
-      # requirements-noble.txt can't build on jammy
-      requirements-find-args: "! -name requirements-noble.txt"
-      osv-extra-args: "--config=source/osv-scanner.toml"
+      # 1. requirements-noble.txt can't build on jammy
+      # 2. Ignore requirements files in spread tests, as some of these intentionally
+      #    contain vulnerable versions.
+      # 3. Docs contain requirements.txt files that don't specify versions.
+      requirements-find-args: '! -name requirements-noble.txt ! -path "./tests/spread*" ! -path "./docs/**"'
+      trivy-extra-args: "--ignore-unfixed --skip-dirs tests/spread/"
       uv-export: false

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,4 +1,0 @@
-[[IgnoredVulns]]
-id = "CVE-2024-35195"
-ignoreUntil = "2025-01-01T00:00:00Z"
-reason = "Needed for requests-unixsocket, which we're replacing with requests-unixsocket2"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Fixes up the OSV scanner workflows moving forward by using the same arguments [Snapcraft and Charmcraft use](https://github.com/canonical/snapcraft/blob/932bd92e510f1217a23551c9dd454bebdb771c2c/.github/workflows/policy.yaml#L16-L22) and removing a now-outdated config.