### PR TITLE
fix(templates): typo in spread .extension

### DIFF
--- a/rockcraft/templates/test/spread/.extension.j2
+++ b/rockcraft/templates/test/spread/.extension.j2
@@ -37,7 +37,7 @@ prepare() {
     snap wait system seed.loaded
     snap refresh --hold
 
-    if systemctl is-enabled unattended-upgades.service; then
+    if systemctl is-enabled unattended-upgrades.service; then
         systemctl stop unattended-upgrades.service
         systemctl mask unattended-upgrades.service
     fi


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [] Have you successfully run `make lint && make test`?

---

As reported by @taurus-forever in https://github.com/canonical/rocks-template/issues/13.

NOTE: other crafts may have a similar typo.