### PR TITLE
Rocks 2419/allow single char names

### DIFF
--- a/rockcraft/application.py
+++ b/rockcraft/application.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from craft_application import Application, AppMetadata
+from craft_application.models import constraints
 from overrides import override  # type: ignore[reportUnknownVariableType]
 
 from rockcraft import plugins
@@ -50,8 +51,8 @@ class Rockcraft(Application):
         self.services.update_kwargs(
             "init",
             default_name="my-rock-name",
-            name_regex=project.PROJECT_NAME_COMPILED_REGEX,
-            invalid_name_message=project.MESSAGE_INVALID_NAME,
+            name_regex=constraints.PROJECT_NAME_COMPILED_REGEX,
+            invalid_name_message=constraints.MESSAGE_INVALID_NAME,
         )
         super()._configure_services(provider_name)
 

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -19,14 +19,13 @@
 import re
 import typing
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import craft_cli
 import pydantic
 import spdx_lookup  # type: ignore[import-untyped]
 from craft_application.models import (
     Platform,
-    get_validator_by_regex,
 )
 from craft_application.models import Project as BaseProject
 from craft_application.models.base import alias_generator
@@ -47,22 +46,6 @@ else:
     _RunUser = Literal[tuple(SUPPORTED_GLOBAL_USERNAMES)] | None
 
 
-PROJECT_NAME_REGEX = r"^([a-z](?:-?[a-z0-9]){2,})$"
-_PROJECT_NAME_DESCRIPTION = """\
-Valid names for rocks. It matches the accepted values for pebble layer files:
-
-- must start with a lowercase letter [a-z]
-- must contain only lowercase letters [a-z], numbers [0-9] or hyphens
-- must not end with a hyphen, and must not contain two or more consecutive hyphens
-"""
-PROJECT_NAME_COMPILED_REGEX = re.compile(PROJECT_NAME_REGEX)
-
-MESSAGE_INVALID_NAME = (
-    "invalid name for rock: Names can only use ASCII lowercase letters, numbers, and hyphens. "
-    "They must start with a lowercase letter, may not end with a hyphen, "
-    "and may not have two hyphens in a row."
-)
-
 MESSAGE_ENTRYPOINT_CHANGED = (
     "This operation will result in a rock with an "
     "atypical OCI Entrypoint. While that might be acceptable for testing and "
@@ -72,20 +55,6 @@ MESSAGE_ENTRYPOINT_CHANGED = (
 
 DEPRECATED_COLON_BASES = ["ubuntu:20.04", "ubuntu:22.04"]
 
-
-ProjectName = Annotated[
-    str,
-    pydantic.BeforeValidator(
-        get_validator_by_regex(PROJECT_NAME_COMPILED_REGEX, MESSAGE_INVALID_NAME)
-    ),
-    pydantic.Field(
-        min_length=1,
-        strict=True,
-        pattern=PROJECT_NAME_REGEX,
-        description=_PROJECT_NAME_DESCRIPTION,
-        title="Project Name",
-    ),
-]
 
 BaseT = Literal[
     "bare",
@@ -110,7 +79,6 @@ BuildBaseT = typing.Annotated[
 class Project(BaseProject):
     """Rockcraft project definition."""
 
-    name: ProjectName  # type: ignore[reportIncompatibleVariableOverride]
     # Type of summary is Optional[str] in BaseProject
     summary: str  # type: ignore[reportIncompatibleVariableOverride]
     description: str  # type: ignore[reportIncompatibleVariableOverride]
@@ -364,20 +332,6 @@ class Project(BaseProject):
             annotations["org.opencontainers.image.licenses"] = self.license
 
         return (annotations, metadata)
-
-    @override
-    @classmethod
-    def transform_pydantic_error(cls, error: pydantic.ValidationError) -> None:
-        BaseProject.transform_pydantic_error(error)
-
-        for error_dict in error.errors():
-            loc = str(error_dict["loc"][0]) if error_dict["loc"] else ""
-            loc_and_type = (loc, error_dict["type"])
-            if loc_and_type == ("name", "value_error.str.regex"):
-                # Note: The base Project class already changes the error message
-                # for the "name" regex, but we re-change it here because
-                # Rockcraft's name regex is slightly stricter.
-                error_dict["msg"] = MESSAGE_INVALID_NAME
 
     @override
     @classmethod

--- a/rockcraft/pebble.py
+++ b/rockcraft/pebble.py
@@ -185,7 +185,7 @@ class Pebble:
         )
 
         new_layer_prefix = f"{(int(prefixes[-1]) + 1):03}" if prefixes else "001"
-        new_layer_name = f"{new_layer_prefix}-{rock_name}.yaml"
+        new_layer_name = f"{new_layer_prefix}-rockcraft-{rock_name}.yaml"
 
         emit.progress(f"Preparing new Pebble layer file {new_layer_name}")
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -121,14 +121,14 @@ def test_run_init_with_name(mocker):
 
 @pytest.mark.usefixtures("valid_dir")
 def test_run_init_with_invalid_name(mocker):
-    mocker.patch.object(sys, "argv", ["rockcraft", "init", "--name=f"])
+    mocker.patch.object(sys, "argv", ["rockcraft", "init", "--name=-f"])
     return_code = cli.run()
     assert return_code == 1
 
 
 def test_run_init_fallback_name(mocker, new_dir, monkeypatch):
     mocker.patch.object(sys, "argv", ["rockcraft", "init"])
-    invalid_dir = pathlib.Path(new_dir) / "f"
+    invalid_dir = pathlib.Path(new_dir) / "-f"
     invalid_dir.mkdir()
     monkeypatch.chdir(invalid_dir)
 

--- a/tests/unit/test_pebble.py
+++ b/tests/unit/test_pebble.py
@@ -66,7 +66,7 @@ class TestPebble:
             # Without any previous layers, the default layer prefix is 001.
             (
                 [],
-                "001",
+                "001-rockcraft",
                 {
                     "summary": "mock summary",
                     "description": "mock description",
@@ -100,7 +100,7 @@ class TestPebble:
             # Also make sure it works with multiple services.
             (
                 ["001-existing-layer1.yml", "003-existing-layer3.yaml"],
-                "004",
+                "004-rockcraft",
                 {
                     "summary": "mock summary",
                     "description": "mock description",
@@ -134,7 +134,7 @@ class TestPebble:
             # If there are more files that are not layers, they are ignored.
             (
                 ["2-bad-layer.yaml", "001-good-layer.yml", "not-a-layer"],
-                "002",
+                "002-rockcraft",
                 {
                     "summary": "mock summary",
                     "description": "mock description",

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -24,9 +24,10 @@ import pydantic
 import pytest
 import yaml
 from craft_application.errors import CraftValidationError
+from craft_application.models.constraints import MESSAGE_INVALID_NAME
 from craft_providers.bases import ubuntu
 from rockcraft.models import Project
-from rockcraft.models.project import MESSAGE_INVALID_NAME, Platform
+from rockcraft.models.project import Platform
 from rockcraft.pebble import Service
 from rockcraft.services.project import RockcraftProjectService
 
@@ -276,7 +277,7 @@ def test_project_title_empty_invalid_name(yaml_loaded_data):
 
     expected = (
         "Bad rockcraft.yaml content:\n"
-        "- invalid name for rock: Names can only use .* "
+        "- invalid name: Names can only use ASCII lowercase letters, numbers, and hyphens. They must have at least one letter, may not start or end with a hyphen, and may not have two hyphens in a row. "
         r"\(in field 'name'\)"
     )
     assert err.match(expected)
@@ -508,7 +509,9 @@ def test_project_all_platforms_invalid(yaml_loaded_data):
     )
 
 
-@pytest.mark.parametrize("valid_name", ["aaa", "a00", "a-00", "a-a-a", "a-000-bbb"])
+@pytest.mark.parametrize(
+    "valid_name", ["aaa", "a00", "0aaa", "a", "a-00", "a-a-a", "a-000-bbb"]
+)
 def test_project_name_valid(yaml_loaded_data, valid_name):
     yaml_loaded_data["name"] = valid_name
 
@@ -517,7 +520,7 @@ def test_project_name_valid(yaml_loaded_data, valid_name):
 
 
 @pytest.mark.parametrize(
-    "invalid_name", ["AAA", "0aaa", "a", "a--a", "aa-", "a:a", "a/a", "a@a", "a_a"]
+    "invalid_name", ["", "AAA", "a--a", "aa-", "a:a", "a/a", "a@a", "a_a"]
 )
 def test_project_name_invalid(yaml_loaded_data, invalid_name):
     yaml_loaded_data["name"] = invalid_name


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR allows rockcraft to produce Rocks with less than three characters in the name by removing such restriction in `rockcraft` and using the one from parent class in `craft-application`. To prevent the resulting pebble layer to fail the validation, a `-rockcraft-` prefix is automatically added to the layer name.

### Related PR

https://github.com/canonical/craft-application/pull/894

Context: Although rockcraft itself will allow names with a single character, it will fail the validation for `title`. This is because when `title` is not set, Rockcraft will set the `title` value to be equal to the `name`. However, `title` has a `min_length` of `2` while `name` has a min length of `1`. The PR above aims to fix this situation.