### PR TITLE
refactor: consolidate base-specific knowledge

### DIFF
--- a/rockcraft/bases.py
+++ b/rockcraft/bases.py
@@ -1,0 +1,45 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021,2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Definitions of supported bases, and per-base behaviors."""
+
+SUPPORTED = (
+    "ubuntu@20.04",
+    "ubuntu@22.04",
+    "ubuntu@24.04",
+    "ubuntu@25.10",
+)
+"""Ubuntu bases currently supported by Rockcraft."""
+
+#############################
+# Pebble-related definitions
+#############################
+
+PEBBLE_IN_BIN = ("ubuntu@20.04", "ubuntu@22.04")
+"""Bases where the Pebble binary exists as "/bin/pebble"."""
+
+PEBBLE_ORGANIZED_USR_BIN = ("ubuntu@24.04",)
+"""Bases where the Pebble binary is organized to /usr/bin/pebble."""
+
+###########################################
+# Plugin and Lifecycle-related definitions
+###########################################
+
+PRE_USRMERGED_INSTALL = ("ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04")
+"""Bases where we *don't* usrmerge a part's install dir by default."""
+
+PYTHON_PRE_BAD_LIB64 = ("ubuntu@20.04", "ubuntu@22.04")
+"""Bases where we *didn't* have to manually fix the venv-provided "lib64" symlink."""

--- a/rockcraft/services/lifecycle.py
+++ b/rockcraft/services/lifecycle.py
@@ -23,7 +23,7 @@ from craft_application import LifecycleService
 from craft_parts.infos import StepInfo
 from overrides import override  # type: ignore[reportUnknownVariableType]
 
-from rockcraft import layers
+from rockcraft import bases, layers
 from rockcraft.plugins.python_common import get_python_plugins
 
 
@@ -45,11 +45,9 @@ class RockcraftLifecycleService(LifecycleService):
         image_info = image_service.obtain_image()
 
         base = project.effective_base
-        usrmerged_by_default = True
 
-        # Bases older than 25.10 do not get usermerged install dirs by default
-        if base in ("ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"):
-            usrmerged_by_default = False
+        # Whether we usrmerge the install dirs by default is base-dependent.
+        usrmerged_by_default = base not in bases.PRE_USRMERGED_INSTALL
 
         self._manager_kwargs.update(
             base_layer_dir=image_info.base_layer_dir,
@@ -79,7 +77,7 @@ class RockcraftLifecycleService(LifecycleService):
 
 def _python_usrmerge_fix(step_info: StepInfo) -> None:
     """Fix 'lib64' symlinks created by the Python plugin on ubuntu@24.04+ projects."""
-    if step_info.project_info.build_base in ("ubuntu@20.04", "ubuntu@22.04"):
+    if step_info.project_info.build_base in bases.PYTHON_PRE_BAD_LIB64:
         # The issue only affects rocks with 24.04 and newer build bases.
         return
 

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -33,7 +33,7 @@ from rockcraft.services.project import RockcraftProjectService
     ],
 )
 @pytest.mark.parametrize(
-    "parts", [{}, {"pebble": Pebble.PEBBLE_PART_SPEC_2204_2004.copy()}]
+    "parts", [{}, {"pebble": Pebble.PEBBLE_PART_PEBBLE_IN_BIN.copy()}]
 )
 def test_add_pebble_part_project_jammy_focal(
     base,
@@ -54,7 +54,7 @@ def test_add_pebble_part_project_jammy_focal(
         platform="Unused",
     )
 
-    assert project["parts"]["pebble"] == Pebble.PEBBLE_PART_SPEC_2204_2004
+    assert project["parts"]["pebble"] == Pebble.PEBBLE_PART_PEBBLE_IN_BIN
 
 
 @pytest.mark.parametrize(
@@ -64,7 +64,9 @@ def test_add_pebble_part_project_jammy_focal(
         ("ubuntu@24.04", None),
     ],
 )
-@pytest.mark.parametrize("parts", [{}, {"pebble": Pebble.PEBBLE_PART_SPEC_2404.copy()}])
+@pytest.mark.parametrize(
+    "parts", [{}, {"pebble": Pebble.PEBBLE_PART_PEBBLE_ORGANIZED_USR_BIN.copy()}]
+)
 def test_add_pebble_part_noble(
     base,
     build_base,
@@ -84,7 +86,7 @@ def test_add_pebble_part_noble(
         platform="Unused",
     )
 
-    assert project["parts"]["pebble"] == Pebble.PEBBLE_PART_SPEC_2404
+    assert project["parts"]["pebble"] == Pebble.PEBBLE_PART_PEBBLE_ORGANIZED_USR_BIN
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Instead of having the information about which base behaves which way with regards to support, pebble, plugins, etc, have a single "bases" module that serves as an authoritative source for all base-related knowledge. The idea is that someone can look at this single module and have a full view of how Rockcraft's behavior changes depending on the project's base.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
