### PR TITLE
feat: don't emit url for `--profile=test`

### DIFF
--- a/rockcraft/services/init.py
+++ b/rockcraft/services/init.py
@@ -42,7 +42,7 @@ class RockcraftInitService(InitService):
         )
 
         init_profile = template_dir.name
-        if init_profile != "simple":
+        if init_profile not in ("simple", "test"):
             versioned_docs = self._app.versioned_docs_url
             reference_docs = f"{versioned_docs}/reference/extensions/{init_profile}"
             emit.message(


### PR DESCRIPTION
`rockcraft init --profile=test` prints

```
Go to https://documentation.ubuntu.com/rockcraft/en/latest/reference/extensions/test to read more about the 'test' profile.
Successfully initialised project.
```

https://documentation.ubuntu.com/rockcraft/en/latest/reference/extensions/test

^ this page does not exist.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
