### PR TITLE
fix: export deps with hashes

### DIFF
--- a/requirements-noble.txt
+++ b/requirements-noble.txt
@@ -1,1 +1,2 @@
-python-apt @  https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.7.7ubuntu5/python-apt_2.7.7ubuntu5.tar.xz ; sys_platform == 'linux'
+python-apt @  https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.7.7ubuntu5/python-apt_2.7.7ubuntu5.tar.xz ; sys_platform == 'linux' \
+  --hash=sha256:39e71274c35d628bd73f50af386043388c5359719bed0ad61b9405500a16f158

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,7 @@ parts:
       # Extensions currently expect to find data files in share/rockcraft/
       "**/site-packages/extensions": share/rockcraft/extensions
     override-build: |
-      uv export --no-hashes --no-dev --extra store --no-emit-workspace --no-emit-package pywin32 --output-file uv-requirements.txt
+      uv export --no-dev --extra store --no-emit-workspace --no-emit-package pywin32 --output-file uv-requirements.txt
       ${SNAP}/libexec/snapcraft/craftctl default
 
       version="$("${CRAFT_STAGE}/usr/bin/python3" -c "import rockcraft;print(rockcraft.__version__)")"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Export hashes with uv, correcting a small oversight of https://github.com/canonical/rockcraft/pull/977.