### PR TITLE
feat(template): use images command to poll docker daemon readiness

### DIFF
--- a/rockcraft/templates/test/spread.yaml.j2
+++ b/rockcraft/templates/test/spread.yaml.j2
@@ -19,7 +19,7 @@ suites:
 
       # Wait for docker daemon to come online
       sudo apt install --yes retry
-      retry --times=10 --delay 2 -- docker run hello-world
+      retry --times=10 --delay 2 -- docker images
       sudo apt remove --yes retry
 
       # Load the rock into docker


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This PR changes the polling command for the readiness of the Docker daemon from `docker run hello-world` to `docker images` to prevent rate limit exceeds when running `rockcraft test` in CI.