### PR TITLE
build(deps): update craft-application to 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 dependencies = [
     # To use a dev version of a craft library:
     # craft-lib @ git+https://github.com/canonical/craft-lib@ref
-    "craft-application>=5.11.0",
+    "craft-application>=6.0.0",
     "craft-archives>=2.2.0",
     "craft-cli>=3.1.2",
     "craft-parts>=2.26.0",

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -11099,6 +11099,19 @@
           ]
         }
       },
+      "propertyNames": {
+        "description": "The name of this platform. May not contain '/'",
+        "examples": [
+          "riscv64",
+          "my-special-platform"
+        ],
+        "not": {
+          "enum": [
+            "any",
+            "*"
+          ]
+        }
+      },
       "title": "Platforms",
       "type": "object"
     },

--- a/tests/unit/commands/test_expand_extensions.py
+++ b/tests/unit/commands/test_expand_extensions.py
@@ -99,8 +99,9 @@ def test_expand_extensions_error(fake_app_config):
 
     expected_message = re.escape(
         "Bad rockcraft.yaml content:\n"
-        "- plugin not registered: 'nonexistent' (in field 'parts.foo')\n"
-        "- input should be 'merge' or 'replace' (in field 'services.my-service.override')"
+        "- plugin not registered: 'nonexistent' (in field 'parts.foo', "
+        "input: {'plugin': 'nonexistent', 'stage-packages': ['new-package-1', 'old-package']})\n"
+        "- input should be 'merge' or 'replace' (in field 'services.my-service.override', input: 'invalid')"
     )
 
     cmd = ExpandExtensionsCommand(fake_app_config)

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -75,7 +75,13 @@ def test_lifecycle_args(
         partitions=None,
         project_name="test-rock",
         project_vars=ProjectVarInfo(
-            root={"version": ProjectVar(value="0.1", updated=False, part_name=None)}
+            root={
+                "version": ProjectVar(value="0.1", updated=False, part_name=None),
+                "summary": ProjectVar(value="Rock on!", updated=False, part_name=None),
+                "description": ProjectVar(
+                    value="Ramble off!", updated=False, part_name=None
+                ),
+            }
         ),
         work_dir=project_path,
         rootfs_dir=Path(),

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ toml = [
 
 [[package]]
 name = "craft-application"
-version = "5.11.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -599,9 +599,9 @@ dependencies = [
     { name = "snap-helpers" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/6b/ad381b017a0715432791ddea24245cc6b3a5eba0c472890a794ac7918321/craft_application-5.11.0.tar.gz", hash = "sha256:4435f5db3e4313acd3c0d03f029f13ce73f4ae2eff0e2f94e0d4301742372479", size = 534825, upload-time = "2025-10-01T20:38:22.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/fd/0e3f9f1a4e4eeaf6126c4b0ddc446c7fb52b5db6dd8c86e4ef786b900eea/craft_application-6.0.0.tar.gz", hash = "sha256:3d827d5f204258b93d2b6438d4d336361603823d49039b8b59b1a8f007e9a5f9", size = 580802, upload-time = "2025-11-17T21:39:44.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/7f/024752ae33b6140f5229c0a7129d1e0dc1dea63fe0b6fd34664bfdb4165b/craft_application-5.11.0-py3-none-any.whl", hash = "sha256:7af835f106db5e20be8d533204f837b3d69457cc6192d2b89838cb26959a0309", size = 193166, upload-time = "2025-10-01T20:38:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e7/2fbbeb4a3aa49d0e54759b1bf94d7ff777838a8e7eec2a901bd5199feb92/craft_application-6.0.0-py3-none-any.whl", hash = "sha256:17cb33e55a7e8f5a36b90c3c7a36ca75c006a6b48fa996a1ccd30a1c356c0ec6", size = 193941, upload-time = "2025-11-17T21:39:41.924Z" },
 ]
 
 [[package]]
@@ -2934,7 +2934,7 @@ types = [
 
 [package.metadata]
 requires-dist = [
-    { name = "craft-application", specifier = ">=5.11.0" },
+    { name = "craft-application", specifier = ">=6.0.0" },
     { name = "craft-archives", specifier = ">=2.2.0" },
     { name = "craft-cli", specifier = ">=3.1.2" },
     { name = "craft-parts", specifier = ">=2.26.0" },
@@ -3060,6 +3060,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/150fdb96b8fab27fe08d8a59fe67554568727981806e6bc2677a16081ec7/ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539", size = 102394, upload-time = "2025-11-14T21:57:36.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e6/a3fa40084558c7e1dc9546385f22a93949c890a8b2e445b2ba43935f51da/ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008", size = 122673, upload-time = "2025-11-14T21:57:38.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This new version lets us use 26.04 as the 'devel' base.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
