### PR TITLE
build(snap): include store dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,6 +142,10 @@ parts:
       # Parallel make jobs for things like python-apt
       - MAKEOPTS: -j$(nproc --all)
       - UV_COMPILE_BYTECODE: "true"
+    uv-extras:
+      # Rockcraft itself doesn't interact with the Store at the moment, but
+      # craft-application plugins might.
+      - store
     organize:
       bin/craftctl: libexec/rockcraft/craftctl
       # Extensions currently expect to find data files in share/rockcraft/


### PR DESCRIPTION
This got dropped by accident when we migrated to the 'uv' plugin. Rockcraft itself doesn't have Store-related code at the moment, but craft-application plugins do.

<!-- Describe your changes -->

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
