### PR TITLE
docs: generate 'rockcraft.yaml' with kitbash

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ import os
 import pathlib
 import sys
 
-import craft_parts
 import craft_parts_docs
 import rockcraft
 
@@ -111,6 +110,7 @@ exclude_patterns = [
     "common/craft-parts/reference/parts_steps.rst",
     "common/craft-parts/reference/step_execution_environment.rst",
     "common/craft-parts/reference/step_output_directories.rst",
+    "common/craft-parts/reference/part_properties.rst",
     "common/craft-parts/reference/plugins/poetry_plugin.rst",
     "common/craft-parts/reference/plugins/python_plugin.rst",
     "common/craft-parts/reference/plugins/python_v2_plugin.rst",
@@ -241,9 +241,6 @@ notfound_context = {
 
 project_dir = pathlib.Path(__file__).parents[1].resolve()
 sys.path.insert(0, str(project_dir.absolute()))
-
-model_dir = pathlib.Path(craft_parts.__file__).parent.resolve()
-sys.path.append(str(model_dir.absolute()))
 
 
 def generate_cli_docs(nil):

--- a/docs/explanation/bases.rst
+++ b/docs/explanation/bases.rst
@@ -9,8 +9,7 @@ Every rock is built from a *base*, which defines the baseline system that the ro
 contents are layered on. The systems are Ubuntu releases. An empty, or *bare* base, is
 also available for lean images.
 
-The base is declared in the project file by the :literalref:`base <rockcraft_yaml_base>`
-key.
+The base is declared in the project file by the :ref:`base <rockcraft-yaml-base>` key.
 
 
 Ubuntu bases
@@ -58,8 +57,8 @@ deployment efficiency and reduced attack surface. The combination of the bare ba
 that meets the production environment's criteria while retaining its functionality.
 
 Even with a bare base, when Rockcraft assembles a rock, it needs Ubuntu as the operating
-system for its build environment. The project's :literalref:`build-base
-<rockcraft_yaml_build_base>` key determines which Ubuntu release is provided for the
+system for its build environment. The project's :ref:`build-base
+<rockcraft-yaml-build-base>` key determines which Ubuntu release is provided for the
 build environment.
 
 For example, if the goal is to have a tiny chiselled rock with software

--- a/docs/explanation/overlay-step.rst
+++ b/docs/explanation/overlay-step.rst
@@ -3,17 +3,15 @@
 Overlay step
 ============
 
-The component parts of a rock are built in a sequence of
+The parts of a rock are built in a sequence of
 five separate steps: pull, overlay, build, stage and prime.
 
 The overlay step is specific to rocks and is configured with overlay parameters.
-To learn more about pull, build, stage and prime see
-:doc:`/common/craft-parts/reference/part_properties`
 
 The overlay step provides the means to modify the base filesystem before the
 build step is applied. If ``overlay-packages`` is used, those packages will be
 installed first. ``overlay-script`` will run the provided script in this step.
-The location of the overlay is made available in the ${CRAFT_OVERLAY}
+The location of the overlay is made available in the ``${CRAFT_OVERLAY}``
 environment variable. ``overlay`` can be used to specify which files will be
 migrated to the next steps, and when omitted its default value will be ``"*"``.
 

--- a/docs/how-to/chiselling/chisel-existing-rock.rst
+++ b/docs/how-to/chiselling/chisel-existing-rock.rst
@@ -8,9 +8,8 @@ testing purposes. However, when moving to production, you want to make your
 rock as lean and secure as possible, getting rid of all the unnecessary bits
 and thus reducing its attack surface, while retaining its functionality.
 
-For this, you'll want to ensure that your rock has a ``bare``
-:ref:`base <rockcraft_yaml_base>` and that its contents are
-:ref:`chiselled <explanation-chisel>`.
+For this, you'll want to ensure that your rock has a bare :ref:`base
+<rockcraft-yaml-base>` and that its contents are :ref:`chiselled <explanation-chisel>`.
 
 For this guide, let's take the example of a Python runtime rock.
 

--- a/docs/how-to/crafting/add-internal-user-to-a-rock.rst
+++ b/docs/how-to/crafting/add-internal-user-to-a-rock.rst
@@ -3,7 +3,7 @@
 Add an internal user
 ====================
 
-You can declare :ref:`run-user <rockcraft_yaml_run_user>` in a rock's project
+You can declare :ref:`run-user <rockcraft-yaml-run-user>` in a rock's project
 file to specify which user you want to run a its services with. If you don't
 specify a user, the services run as root by default. The ``run-user`` key only
 accepts a limited number of users, which could be a constraint for certain

--- a/docs/how-to/crafting/convert-to-pebble-layer.rst
+++ b/docs/how-to/crafting/convert-to-pebble-layer.rst
@@ -29,7 +29,7 @@ Design the Pebble services
 
 A :external+pebble:doc:`Pebble layer <reference/layer-specification>`
 is composed of metadata, checks and services. The latter is present in
-the project file as a :ref:`top-level key <rockcraft-yaml-format-specification>`
+the project file as a :ref:`top-level key <rockcraft-yaml-top-level-keys>`
 and it represents the services which are loaded by the Pebble entrypoint when
 deploying a rock.
 

--- a/docs/how-to/crafting/outsource-rock-builds-to-launchpad.rst
+++ b/docs/how-to/crafting/outsource-rock-builds-to-launchpad.rst
@@ -39,11 +39,11 @@ If you don't already have an account, you can sign up `here
 Define desired architectures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once you :ref:`start your remote build <start-a-remote-build>`, all
-architectures defined in the :ref:`platforms` key of your project file will be
-built. Rockcraft currently supports AMD64, ARM64, ARM hard float, IA-32,
-little-endian PowerPC 64-bit, RISC-V 64-bit and S390x. Your project file can
-contain any subset of these architectures.
+Once you :ref:`start your remote build <start-a-remote-build>`, all architectures
+defined in the :ref:`rockcraft-yaml-platforms` key of your project file will be built.
+Rockcraft currently supports AMD64, ARM64, ARM hard float, IA-32, little-endian PowerPC
+64-bit, RISC-V 64-bit and S390x. Your project file can contain any subset of these
+architectures.
 
 For example, if you need to build rocks for AMD64, ARM64 and RISC-V 64-bit
 architectures, your project file would declare:

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -4,12 +4,16 @@
 # The old path must be a file that _doesn't exist_ in the source. The current path
 # must be a file that _does exist_ in the source.
 
+"tutorial/expressjs.rst" "tutorial/express.rst"
+
+"how-to/build-a-12-factor-app-rock.rst" "how-to/web-app-rocks/index.rst"
+"about-this-documentation.rst" "contribute-to-this-documentation.rst"
+"how-to/web-app-rocks/configure-the-build-base-for-an-expressjs-app.rst" "how-to/web-app-rocks/configure-the-build-base-for-an-express-app.rst"
+
+"reference/extensions/expressjs-framework.rst" "reference/extensions/express-framework.rst"
+"reference/part_properties.rst" "reference/rockcraft-yaml.rst"
+
 "release-notes/changelog.rst" "reference/changelog.rst"
 "release-notes/rockcraft-1-9-0.rst" "release-notes/rockcraft-1-9.rst"
 "release-notes/rockcraft-1-8-0.rst" "release-notes/rockcraft-1-8.rst"
 "release-notes/rockcraft-1-7-0.rst" "release-notes/rockcraft-1-7.rst"
-"how-to/build-a-12-factor-app-rock.rst" "how-to/web-app-rocks/index.rst"
-"about-this-documentation.rst" "contribute-to-this-documentation.rst"
-"tutorial/expressjs.rst" "tutorial/express.rst"
-"reference/extensions/expressjs-framework.rst" "reference/extensions/express-framework.rst"
-"how-to/web-app-rocks/configure-the-build-base-for-an-expressjs-app.rst" "how-to/web-app-rocks/configure-the-build-base-for-an-express-app.rst"

--- a/docs/reference/plugins/ant_plugin.rst
+++ b/docs/reference/plugins/ant_plugin.rst
@@ -15,12 +15,10 @@ After a successful build, this plugin will:
   ``$CRAFT_PART_INSTALL/usr/bin/java`` if ``/usr/bin`` exists.
 
 
-Keywords
---------
+Keys
+----
 
-In addition to the common :ref:`plugin <reference-part-properties-plugin>` and
-:ref:`sources <reference-part-properties-source>` keywords, this plugin provides
-the following plugin-specific keywords:
+This plugin provides the following unique keys.
 
 ant-build-targets
 ~~~~~~~~~~~~~~~~~

--- a/docs/reference/plugins/maven_plugin.rst
+++ b/docs/reference/plugins/maven_plugin.rst
@@ -14,12 +14,10 @@ After a successful build, this plugin will:
   ``$CRAFT_PART_INSTALL/usr/bin/java`` if ``/usr/bin`` exists.
 
 
-Keywords
---------
+Keys
+----
 
-In addition to the common :ref:`plugin <reference-part-properties-plugin>` and
-:ref:`sources <reference-part-properties-source>` keywords, this plugin
-provides the following plugin-specific keywords:
+This plugin provides the following unique keys.
 
 maven-parameters
 ~~~~~~~~~~~~~~~~

--- a/docs/reference/rock_parts/toc.rst
+++ b/docs/reference/rock_parts/toc.rst
@@ -1,4 +1,0 @@
-.. toctree::
-   :hidden:
-
-   /common/craft-parts/reference/part_properties

--- a/docs/reference/rockcraft-yaml.rst
+++ b/docs/reference/rockcraft-yaml.rst
@@ -46,17 +46,7 @@ Top-level keys
 
 .. kitbash-field:: rockcraft.models.Project entrypoint_service
 
-.. caution::
-
-    Only set this key when the targeted deployment environment has a container image
-    entrypoint that is guaranteed to be static.
-
 .. kitbash-field:: rockcraft.models.Project entrypoint_command
-
-.. important::
-
-    You should only set this key for certain categories of general-purpose rocks where
-    Pebble services aren't appropriate, such as the Ubuntu OS and base images.
 
 .. kitbash-field:: rockcraft.models.Project checks
     :override-type: dict[str, str]
@@ -126,6 +116,9 @@ Part keys
     :prepend-name: parts.<part-name>
 
 .. Overlay step keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec overlay_files
+    :prepend-name: parts.<part-name>
 
 .. kitbash-field:: craft_parts.parts.PartSpec overlay_packages
     :prepend-name: parts.<part-name>

--- a/docs/reference/rockcraft-yaml.rst
+++ b/docs/reference/rockcraft-yaml.rst
@@ -58,6 +58,28 @@ Top-level keys
     :override-type: dict[str, str]
 
 
+.. _rockcraft-yaml-extensions:
+
+extensions
+~~~~~~~~~~
+
+**Type**
+
+``list[str]``
+
+**Description**
+
+The :ref:`extensions <reference-extensions>` to use in this project. During packing, the
+boilerplate keys from the listed extensions will be added to the project file.
+
+**Examples**
+
+.. code-block:: yaml
+
+    extensions:
+      - expressjs-framework
+
+
 .. _rockcraft-yaml-platform-keys:
 
 Platform keys

--- a/docs/reference/rockcraft-yaml.rst
+++ b/docs/reference/rockcraft-yaml.rst
@@ -22,6 +22,12 @@ Top-level keys
 
 .. kitbash-field:: craft_application.models.Project version
 
+.. kitbash-field:: rockcraft.models.Project base
+    :override-type: Literal['ubuntu@20.04', 'ubuntu@22.04', 'ubuntu@24.04', 'ubuntu@25.10', 'ubuntu@26.04']
+
+.. kitbash-field:: rockcraft.models.Project build_base
+    :override-type: Literal['ubuntu@20.04', 'ubuntu@22.04', 'ubuntu@24.04', 'ubuntu@25.10', 'ubuntu@26.04', 'devel']
+
 .. kitbash-field:: craft_application.models.Project source_code
     :override-type: str
 
@@ -51,10 +57,11 @@ Top-level keys
 .. kitbash-field:: rockcraft.models.Project checks
     :override-type: dict[str, str]
 
-.. kitbash-field:: rockcraft.models.Project base
 
-.. kitbash-field:: rockcraft.models.Project build_base
-    :override-type: Literal['ubuntu@20.04', 'ubuntu@22.04', 'ubuntu@24.04', 'ubuntu@25.10', 'ubuntu@26.04', 'devel']
+.. _rockcraft-yaml-platform-keys:
+
+Platform keys
+-------------
 
 .. kitbash-field:: craft_application.models.Project platforms
 

--- a/docs/reference/rockcraft-yaml.rst
+++ b/docs/reference/rockcraft-yaml.rst
@@ -1,307 +1,195 @@
 .. _reference-rockcraft-yaml:
 
-**************
 rockcraft.yaml
-**************
+==============
 
-.. include:: rock_parts/toc.rst
+This reference describes the purpose, usage, and examples of all available keys in a
+rock's project file, ``rockcraft.yaml``.
 
-A Rockcraft project is defined in a YAML file named ``rockcraft.yaml`` at the
-root of the project tree in the filesystem. This file is commonly known as the
-*project file*.
 
-This reference describes the configuration keys available in this file.
+.. _rockcraft-yaml-top-level-keys:
 
-.. _rockcraft-yaml-format-specification:
-
-Format specification
-====================
-
-``name``
---------
-
-**Type**: string
-
-**Required**: Yes
-
-The name of the rock. This value must conform with Pebble's format for layer
-files, meaning that the ``name``:
-
-- must start with a lowercase letter [a-z];
-- must contain only lowercase letters [a-z], numbers [0-9] or hyphens;
-- must not end with a hyphen, and must not contain two or more consecutive
-  hyphens.
-
-``title``
----------
-
-**Type**: string
-
-**Required**: No
-
-The human-readable title of the rock. If omitted, defaults to ``name``.
-
-``summary``
------------
-
-**Type**: string
-
-**Required**: Yes
-
-A short summary describing the rock.
-
-``description``
----------------
-
-**Type**: string
-
-**Required**: Yes
-
-A longer, possibly multi-line description of the rock.
-
-``version``
------------
-
-**Type**: string
-
-**Required**: Yes
-
-The rock version, used to tag the OCI image and name the rock file.
-
-.. _rockcraft_yaml_base:
-
-``base``
---------
-
-**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | ubuntu@24.04 | ubuntu@25.10 | bare``
-
-**Required**: Yes
-
-The base system image that the rock's contents will be layered on. This is also
-the system that will be mounted and made available when using Overlays. The
-special value ``bare`` means that the rock will have no base system at all,
-which is typically used with static binaries or
-:ref:`Chisel slices <explanation-chisel>`.
-
-.. note::
-   The notation "ubuntu:<channel>" is also supported for some channels, but this
-   format is deprecated and should be avoided.
-
-.. _rockcraft_yaml_build_base:
-
-``build-base``
+Top-level keys
 --------------
 
-**Type**: One of ``ubuntu@20.04 | ubuntu@22.04 | ubuntu@24.04 | ubuntu@25.10 | devel``
+.. kitbash-field:: craft_application.models.Project name
 
-**Required**: Yes, if ``base`` is ``bare``
+.. kitbash-field:: craft_application.models.Project title
 
-The system and version that will be used during the rock's build, but not
-included in the final rock itself. It comprises the set of tools and libraries
-that Rockcraft will use when building the rock's contents. This key is
-mandatory if ``base`` is ``bare``, but otherwise it is optional and defaults to
-the value of ``base``.
+.. kitbash-field:: rockcraft.models.Project summary
 
-.. note::
-   The notation "ubuntu:<channel>" is also supported for some channels, but this
-   format is deprecated and should be avoided.
+.. kitbash-field:: rockcraft.models.Project description
 
-.. note::
-   ``devel`` is a "special" value that means "the next Ubuntu version, currently
-   in development". This means that the contents of this system changes
-   frequently and should not be relied on for production rocks.
+.. kitbash-field:: craft_application.models.Project version
 
-``license``
------------
+.. kitbash-field:: craft_application.models.Project source_code
+    :override-type: str
 
-**Type**: string, in `SPDX format <https://spdx.org/licenses/>`_
+.. kitbash-field:: craft_application.models.Project license
 
-**Required**: No
+.. kitbash-field:: craft_application.models.Project contact
+    :override-type: list[str]
 
-The license of the software packaged inside the rock. This must either be
-"proprietary" or match the SPDX format. It is case insensitive (e.g. both
-``MIT`` and ``mit`` are valid).
+.. kitbash-field:: craft_application.models.Project issues
+    :override-type: list[str]
 
-.. _rockcraft_yaml_run_user:
+.. kitbash-field:: craft_application.models.Project adopt_info
 
-``run-user``
-------------
+.. kitbash-field:: rockcraft.models.Project environment
 
-**Type**: string
+.. kitbash-field:: craft_application.models.Project package_repositories
+    :override-type: list[repository]
 
-**Required**: No
+.. kitbash-field:: rockcraft.models.Project run_user
 
-The default OCI user. It must be a supported shared user. Currently, the only
-supported shared user is "_daemon_" (with UID/GID 584792). It defaults to
-"root" (with UID 0).
+.. kitbash-field:: rockcraft.models.Project services
 
-``environment``
----------------
-
-**Type**: dict
-
-**Required**: No
-
-A set of key-value pairs specifying the environment variables to be added
-to the base image's OCI environment.
-
-.. note::
-   String interpolation is not yet supported so any attempts to dynamically
-   define environment variables with ``$`` will end in a project
-   validation error.
-
-``services``
-------------
-
-**Type**: dict, following the `Pebble Layer Specification format`_
-
-**Required**: No
-
-A list of services for the Pebble entrypoint. It uses Pebble's layer
-specification syntax exactly, with each entry defining a Pebble service. For
-each service, the ``override`` and ``command`` keys are mandatory, but all
-others are optional.
-
-``entrypoint-service``
-------------------------
-
-**Type**: string
-
-**Required**: No
-
-The optional name of the Pebble service to serve as the `OCI entrypoint`_. If set,
-this makes Rockcraft extend ``["/bin/pebble", "enter"]`` with
-``["--args", "<serviceName>"]``. The command of the Pebble service must
-contain an optional argument that will become the `OCI CMD`_.
-
-.. warning::
-   This option must only be used in cases where the targeted deployment
-   environment has unalterable assumptions about the container image's
-   entrypoint.
-
-.. _rockcraft-yaml-entrypoint-command:
-
-``entrypoint-command``
-------------------------
-
-**Type**: string
-
-**Required**: No
-
-Replaces the rock's default Pebble `OCI entrypoint`_ and `OCI CMD`_ properties.
-The value can be suffixed with default entrypoint arguments,
-using the same square bracket list delimiters ([]) as the Pebble service command.
-If provided, these default entrypoint arguments become the rock's OCI CMD. For example:
-
-.. code-block::
-
-   echo [ Hello ]
-
-This key and the ``entrypoint-service`` are mutually incompatible and can't both be set.
+.. kitbash-field:: rockcraft.models.Project entrypoint_service
 
 .. caution::
+
+    Only set this key when the targeted deployment environment has a container image
+    entrypoint that is guaranteed to be static.
+
+.. kitbash-field:: rockcraft.models.Project entrypoint_command
+
+.. important::
+
     You should only set this key for certain categories of general-purpose rocks where
     Pebble services aren't appropriate, such as the Ubuntu OS and base images.
 
-``checks``
-------------
+.. kitbash-field:: rockcraft.models.Project checks
+    :override-type: dict[str, str]
 
-**Type**: dict, following the `Pebble Layer Specification format`_
+.. kitbash-field:: rockcraft.models.Project base
 
-**Required**: No
+.. kitbash-field:: rockcraft.models.Project build_base
+    :override-type: Literal['ubuntu@20.04', 'ubuntu@22.04', 'ubuntu@24.04', 'ubuntu@25.10', 'ubuntu@26.04', 'devel']
 
-A list of health checks that can be configured to restart Pebble services
-when they fail. It uses Pebble's layer specification syntax, with each
-entry corresponding to a check. Each check can be one of three types:
-``http``, ``tcp`` or ``exec``.
+.. kitbash-field:: craft_application.models.Project platforms
+
+.. kitbash-field:: craft_application.models.Platform build_on
+    :prepend-name: platforms.<platform-name>
+
+.. kitbash-field:: craft_application.models.Platform build_for
+    :prepend-name: platforms.<platform-name>
 
 
-.. _platforms:
+.. _rockcraft-yaml-part-keys:
 
-``platforms``
--------------
-
-**Type**: dict
-
-**Required**: Yes
-
-The set of architecture-specific rocks to be built. Supported architectures are:
-``amd64``, ``arm64``, ``armhf``, ``i386``, ``ppc64el``, ``riscv64`` and ``s390x``.
-
-Entries in the ``platforms`` dict can be free-form strings, or the name of a
-supported architecture (in Debian format).
-
-.. warning::
-   **All** target architectures must be compatible with the architecture of
-   the host where Rockcraft is being executed (i.e. emulation is not supported
-   at the moment).
-
-``platforms.<entry>.build-on``
-------------------------------
-
-**Type**: list[string]
-
-**Required**: Yes, if ``build-for`` is specified *or* if ``<entry>`` is not a
-supported architecture name.
-
-Host architectures where the rock can be built. Defaults to ``<entry>`` if that
-is a valid, supported architecture name.
-
-``platforms.<entry>.build-for``
--------------------------------
-
-**Type**: string | list[string]
-
-**Required**: Yes, if ``<entry>`` is not a supported architecture name.
-
-Target architecture the rock will be built for. Defaults to ``<entry>`` that
-is a valid, supported architecture name.
-
-.. note::
-   At the moment Rockcraft will only build for a single architecture, so
-   if provided ``build-for`` must be a single string or a list with exactly one
-   element.
-
-``parts``
+Part keys
 ---------
 
-**Type**: dict
+.. Main keys
 
-**Required**: Yes
+.. kitbash-field:: craft_parts.parts.PartSpec plugin
+    :prepend-name: parts.<part-name>
 
-The set of parts that compose the rock's contents
-(see :ref:`Parts <reference-part-properties>`).
+.. kitbash-field:: craft_parts.parts.PartSpec after
+    :prepend-name: parts.<part-name>
 
+.. kitbash-field:: craft_parts.parts.PartSpec disable_parallel
+    :prepend-name: parts.<part-name>
 
-.. note::
-   The keys ``entrypoint``, ``cmd`` and ``env`` are not supported in
-   Rockcraft. All rocks have Pebble as their entrypoint, and thus you must use
-   ``services`` to define your container application.
+.. Source keys
 
-``extensions``
---------------
+.. kitbash-field:: craft_parts.parts.PartSpec source
+    :prepend-name: parts.<part-name>
 
-**Type**: list[string]
+.. kitbash-field:: craft_parts.parts.PartSpec source_type
+    :prepend-name: parts.<part-name>
 
-**Required**: No
+.. kitbash-field:: craft_parts.parts.PartSpec source_checksum
+    :prepend-name: parts.<part-name>
 
-Extensions to enable when building the ROCK.
+.. kitbash-field:: craft_parts.parts.PartSpec source_branch
+    :prepend-name: parts.<part-name>
 
-Currently supported extensions:
+.. kitbash-field:: craft_parts.parts.PartSpec source_tag
+    :prepend-name: parts.<part-name>
 
-- ``flask-framework``
-- ``django-framework``
-- ``go-framework``
-- ``fastapi-framework``
-- ``expressjs-framework``
-- ``spring-boot-framework``
+.. kitbash-field:: craft_parts.parts.PartSpec source_commit
+    :prepend-name: parts.<part-name>
 
-Example
-=======
+.. kitbash-field:: craft_parts.parts.PartSpec source_depth
+    :prepend-name: parts.<part-name>
 
-.. literalinclude:: code/example/rockcraft.yaml
-    :caption: rockcraft.yaml
-    :language: yaml
+.. kitbash-field:: craft_parts.parts.PartSpec source_submodules
+    :prepend-name: parts.<part-name>
 
+.. kitbash-field:: craft_parts.parts.PartSpec source_subdir
+    :prepend-name: parts.<part-name>
 
-.. _`Pebble Layer Specification format`:  https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/
+.. Pull step keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec override_pull
+    :prepend-name: parts.<part-name>
+
+.. Overlay step keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec overlay_packages
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec overlay_script
+    :prepend-name: parts.<part-name>
+
+.. Build step keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec build_environment
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec build_attributes
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec override_build
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec build_packages
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec build_snaps
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec organize_files
+    :prepend-name: parts.<part-name>
+
+.. Stage step keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec stage_files
+    :prepend-name: parts.<part-name>
+    :override-type: list[str]
+
+.. kitbash-field:: craft_parts.parts.PartSpec stage_packages
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec stage_snaps
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.parts.PartSpec override_stage
+    :prepend-name: parts.<part-name>
+
+.. Prime step keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec prime_files
+    :prepend-name: parts.<part-name>
+    :override-type: list[str]
+
+.. kitbash-field:: craft_parts.parts.PartSpec override_prime
+    :prepend-name: parts.<part-name>
+
+.. Permission keys
+
+.. kitbash-field:: craft_parts.parts.PartSpec permissions
+    :prepend-name: parts.<part-name>
+
+.. kitbash-field:: craft_parts.permissions.Permissions path
+    :prepend-name: parts.<part-name>.permissions.<permission>
+
+.. kitbash-field:: craft_parts.permissions.Permissions owner
+    :prepend-name: parts.<part-name>.permissions.<permission>
+
+.. kitbash-field:: craft_parts.permissions.Permissions group
+    :prepend-name: parts.<part-name>.permissions.<permission>
+
+.. kitbash-field:: craft_parts.permissions.Permissions mode
+    :prepend-name: parts.<part-name>.permissions.<permission>

--- a/docs/release-notes/rockcraft-1-10.rst
+++ b/docs/release-notes/rockcraft-1-10.rst
@@ -70,7 +70,7 @@ Rockcraft 1.10 brings the following minor changes.
 Part sources
 ~~~~~~~~~~~~
 
-The ``source-commit`` :ref:`key <reference-part-properties-source-commit>` now accepts
+The ``source-commit`` :ref:`key <rockcraft-yaml-source-commit>` now accepts
 short hashes in addition to the full hash of a Git commit.
 
 OCI Annotations

--- a/docs/release-notes/rockcraft-1-12.rst
+++ b/docs/release-notes/rockcraft-1-12.rst
@@ -68,7 +68,7 @@ Rockcraft 1.12 brings the following minor changes.
 Support for non-root rocks in 12-factor extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can now use the non-root :ref:`_daemon_ user <rockcraft_yaml_run_user>` with
+You can now set :ref:`run-user <rockcraft-yaml-run-user>` to ``_daemon_`` with
 extensions that support the :ref:`12-factor web app <set-up-web-app-rock>` methodology.
 
 12-factor web app documentation

--- a/docs/release-notes/rockcraft-1-15.rst
+++ b/docs/release-notes/rockcraft-1-15.rst
@@ -123,8 +123,8 @@ Autotools plugin
 ~~~~~~~~~~~~~~~~
 
 The :ref:`craft_parts_autotools_plugin` now supports the
-:ref:`reference-part-properties-disable-parallel` key to force builds using the plugin
-to run using a single job.
+:ref:`rockcraft-yaml-disable-parallel` key to force builds using the plugin to run using
+a single job.
 
 Documentation for bases
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorial/hello-world.rst
+++ b/docs/tutorial/hello-world.rst
@@ -18,11 +18,11 @@ save it as ``rockcraft.yaml``:
     :caption: rockcraft.yaml
     :language: yaml
 
-This file instructs Rockcraft to build a rock that **only** has the ``hello``
-package (and its dependencies) inside. For more information about the ``parts``
-section, check :ref:`reference-part-properties`. The remaining YAML keys correspond to
-metadata that help define and describe the rock. For more information about all
-available keys, check :ref:`reference-rockcraft-yaml`.
+This file instructs Rockcraft to build a rock that **only** has the ``hello`` package
+(and its dependencies) inside. For more information about the ``parts`` section, check
+:ref:`rockcraft-yaml-part-keys`. The remaining YAML keys correspond to metadata that
+help define and describe the rock. For more information about all available keys, check
+:ref:`reference-rockcraft-yaml`.
 
 Pack the rock with Rockcraft
 ----------------------------

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -129,12 +129,18 @@ class Project(BaseProject):
     )
     """The optional name of the Pebble service to serve as the `OCI entrypoint
     <https://specs.opencontainers.org/image-spec/config/?v=v1.0.1#properties>`_.
+
+    .. caution::
+
+        Only set this key when the deployment environment has a container image
+        entrypoint that is guaranteed to be static.
+
     If set, this makes Rockcraft extend ``["/bin/pebble", "enter"]`` with
     ``["--args", "<serviceName>"]``. The command of the Pebble service must
     contain an optional argument that will become the `OCI CMD
     <https://specs.opencontainers.org/image-spec/config/?v=v1.0.1#properties>`_.
 
-    Mutually exclusive with ``entrypoint-command``.
+    This key is mutually incompatible with the ``entrypoint-command`` key.
     """
     entrypoint_command: str | None = pydantic.Field(
         default=None,
@@ -145,10 +151,15 @@ class Project(BaseProject):
     )
     """Overrides the rock's default Pebble OCI ``entrypoint`` and ``CMD`` properties.
 
+    .. important::
+
+        Only set this key for certain categories of general-purpose rocks where
+        Pebble services aren't appropriate, such as the Ubuntu OS and base images.
+
     The value can be suffixed with default entrypoint arguments using square
     brackets (``[]``). These entrypoint arguments become the rock's OCI CMD.
 
-    This key is mutually incompatible with ``entrypoint-service``.
+    This key is mutually incompatible with the ``entrypoint-service`` key.
     """
     base: BaseT = pydantic.Field(  # type: ignore[reportIncompatibleVariableOverride]
         description="The base system image for the rock.",

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -113,8 +113,8 @@ class Project(BaseProject):
     )
     """Services to run in the rock.
 
-    This field is added to the Pebble :external+pebble:ref:`layer specification
-    <layer-specification>`.
+    This map of services is added to the Pebble configuration layer conforming to the
+    :external+pebble:ref:`layer specification <layer-specification>`.
     """
     checks: dict[str, Check] | None = pydantic.Field(
         default=None,
@@ -156,7 +156,7 @@ class Project(BaseProject):
     """
     The base system image that the rock's contents will be layered on.
 
-    :ref:`This system <bases_explanation>` is mounted and made available when using
+    :ref:`This system <explanation-bases>` is mounted and made available when using
     overlays. The special value ``bare`` means that the rock will have no base system,
     which is typically used with static binaries or
     :ref:`Chisel slices <explanation-chisel>`.
@@ -167,7 +167,7 @@ class Project(BaseProject):
     """The system and version that will be used during the rock's build, but not
     included in the final rock itself.
 
-    The :ref:`build base <bases_explanation>` comprises the set of tools and libraries
+    The :ref:`build base <explanation-bases>` comprises the set of tools and libraries
     that Rockcraft uses when building the rock's contents.
 
     This key is mandatory if ``base`` is ``bare``. Otherwise, it is optional and


### PR DESCRIPTION
@tigarmo This took longer than expected due to the number of links that broke and the different ways we import these models.

Please have a critical look at the **order** of the top-level keys. I included more keys than Snapcraft has, and once these are in I'd like to share those changes with the other crafts.

Closes canonical/open-documentation-academy#304.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
