### PR TITLE
docs: Update README.md contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Conduct](https://ubuntu.com/community/docs/ethos/code-of-conduct).
 
 Rockcraft is open source and part of the Canonical family. We would love your help.
 
-If you're interested, start with the [contribution guide](HACKING.md).
+If you're interested, start with the [contribution guide](CONTRIBUTING.md).
 
 We welcome any suggestions and help with the docs. The [Canonical Open Documentation
 Academy](https://github.com/canonical/open-documentation-academy) is the hub for doc


### PR DESCRIPTION
The contributing link in README.md was not working anymore, I fixed it and linked it to CONTRIBUTING.md.

- [x ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ x] I've successfully run `make lint && make test`.
- [ x] I've added or updated any relevant documentation.
