### PR TITLE
chore: Update documentation owners in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 *       @tigarmo
 
 # Documentation owners
-/docs/  @canonical/starcraft-authors @tigarmo
+/docs/  @canonical/starcraft-authors @asanvaq @tigarmo
 
 # Finally, all CODEOWNERS changes need to be approved by The Man, Himself.
 /.github/CODEOWNERS     @steinbro


### PR DESCRIPTION
This update reflects the transfer of the Rockcraft documentation ownership, ensuring CODEOWNERS remains accurate.
---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
