### PR TITLE
docs: fix canonical URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,12 +142,16 @@ intersphinx_disabled_reftypes = ["*"]
 rediraffe_redirects = "redirects.txt"
 
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
-html_baseurl = "https://documentation.ubuntu.com/rockcraft/"
-if "READTHEDOCS_VERSION" in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = "{version}{link}"
-else:
-    sitemap_url_scheme = "latest/{link}"
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+# Builds URLs as {html_baseurl}/<page-location>
+sitemap_url_scheme = "{link}"
+
+# Exclude generated pages from the sitemap:
+sitemap_excludes = [
+    '404/',
+    'genindex/',
+    'search/',
+]
 
 # Do (not) include module names.
 add_module_names = True


### PR DESCRIPTION
The canonical URLs in this documentation currently don't specify a version.

This can confuse search engines and impair SEO. I have updated the conf.py file to:

- pull the correct canonical URL from RTD
- append only the page's path, as the canonical URL will include the correct version
- exclude certain generated pages from the sitemap

This change has already been implemented in the [snapcraft](https://github.com/canonical/snapcraft/pull/5901) docs.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
