### PR TITLE
docs: fix a missing link

### DIFF
--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -30,3 +30,4 @@ process. Rockcraft only uses the internal, pre-packaged copy of skopeo for this 
 .. _Craft Application: https://canonical-craft-application.readthedocs-hosted.com/en/latest/
 .. _Cryptographic technology in Craft Application: https://canonical-craft-application.readthedocs-hosted.com/en/latest/explanation/cryptography/
 .. _umoci: https://umo.ci/
+.. _skopeo: https://github.com/containers/skopeo


### PR DESCRIPTION
Places a missing hyperlink. I'm surprised sphinx linting didn't catch this...

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
