### PR TITLE
docs: Update CONTRIBUTING.md for PR titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,8 +306,8 @@ git push -u origin <branch-name>
 
 Finally, [open a PR](https://github.com/canonical/rockcraft/compare) for it on GitHub.
 If your branch has one commit, GitHub will title the PR after it. If your branch has
-more than one commit, name the PR after the most significant. Please ensure the title
-of the PR follows the Conventional Commits style. Once open, reviewers are
+more than one commit, name the PR after the most significant and ensure it
+follows the Conventional Commits style. Once open, reviewers are
 assigned automatically to your work.
 
 ### Follow up for the review


### PR DESCRIPTION
Currently, following the Conventional Commits style is only used when explaining how to label commits. This style is also used for PR titles, so this change explicitly mentions this. This will ensure users title their PRs correctly.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
