### PR TITLE
spread: check that UBUNTU_PRO_TOKEN is set

### DIFF
--- a/tests/spread/pro/packages/task.yaml
+++ b/tests/spread/pro/packages/task.yaml
@@ -19,7 +19,12 @@ environment:
   PACK_ARGS/managed_standard_stage_full: ""
 
 prepare: |
-  sudo pro attach --no-auto-enable $UBUNTU_PRO_TOKEN 
+  if [ -z "$UBUNTU_PRO_TOKEN" ]; then
+    echo "Error: Pro tests require UBUNTU_PRO_TOKEN to be set."
+    exit 1
+  fi
+
+  sudo pro attach --no-auto-enable $UBUNTU_PRO_TOKEN
   sudo pro enable --assume-yes $ENV_PRO_ARG
 
 execute: |


### PR DESCRIPTION
<!-- Describe your changes -->

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
