### PR TITLE
fix: ubuntu@26.04 is not a valid build-base yet

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -73,7 +73,6 @@ BuildBaseT = typing.Annotated[
         "ubuntu@22.04",
         "ubuntu@24.04",
         "ubuntu@25.10",
-        "ubuntu@26.04",
         "devel",
     ]
     | None,

--- a/schema/rockcraft.json
+++ b/schema/rockcraft.json
@@ -11048,7 +11048,6 @@
             "ubuntu@22.04",
             "ubuntu@24.04",
             "ubuntu@25.10",
-            "ubuntu@26.04",
             "devel"
           ],
           "type": "string"


### PR DESCRIPTION
There is no way to define a valid project with `build-base:ubuntu@26.04` at the moment, and there won't be until we stabilize the base. The only way to build 26.04 rocks at this stage of development is to use `build-base: devel`.

So in this sense, the valid options for 'build-base' are the bases that Rockcraft considers stable, plus of course 'devel'.

Fixes #1069

<!-- Describe your changes -->

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
