### PR TITLE
fix: sh executable for bare bases

### DIFF
--- a/docs/reference/extensions/spring-boot-framework.rst
+++ b/docs/reference/extensions/spring-boot-framework.rst
@@ -104,6 +104,9 @@ The ``spring-boot-framework`` uses the following configuration:
         - ca-certificates_data
         - coreutils_bins
         - base-files_tmp
+      override-stage: |
+        craftctl default
+        ln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh
 
 .. _reference-spring-boot-framework-stage:
 

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -80,6 +80,10 @@ class ExpressJSFramework(Extension):
         snippet["parts"] = {
             "expressjs-framework/install-app": self._gen_install_app_part(),
         }
+        if self._rock_base == "bare":
+            snippet["parts"]["expressjs-framework/install-app"]["override-stage"] = (
+                "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh"
+            )
         runtime_part = self._gen_runtime_part()
         if runtime_part:
             snippet["parts"]["expressjs-framework/runtime"] = runtime_part

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -124,6 +124,7 @@ class FastAPIFramework(Extension):
                     "coreutils_bins",
                     "ca-certificates_data",
                 ],
+                "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
             }
         else:
             parts["fastapi-framework/runtime"] = {

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -82,6 +82,10 @@ class GoFramework(Extension):
             },
             "go-framework/logging": gen_logging_part(),
         }
+        if self.yaml_data["base"] == "bare":
+            snippet["parts"]["go-framework/runtime"]["override-stage"] = (
+                "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh"
+            )
 
         assets_part = self._get_install_assets_part()
         if assets_part:

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -147,6 +147,7 @@ class _GunicornBase(Extension):
                     "coreutils_bins",
                     "ca-certificates_data",
                 ],
+                "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
             }
         else:
             parts[f"{self.framework}-framework/runtime"] = {

--- a/rockcraft/extensions/springboot.py
+++ b/rockcraft/extensions/springboot.py
@@ -286,6 +286,9 @@ class SpringBootFramework(Extension):
                 "base-files_tmp",
                 "coreutils_bins",
             ]
+            runtime_part["override-stage"] = (
+                "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh"
+            )
 
         return runtime_part
 

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -210,6 +210,7 @@ def package_json_file(app_path):
                             "ca-certificates_data",
                             "coreutils_bins",
                         ],
+                        "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
                         "build-environment": [{"UV_USE_IO_URING": "0"}],
                     },
                     "expressjs-framework/runtime": {
@@ -280,6 +281,7 @@ def package_json_file(app_path):
                             "ca-certificates_data",
                             "coreutils_bins",
                         ],
+                        "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
                         "build-environment": [{"UV_USE_IO_URING": "0"}],
                     },
                     "expressjs-framework/runtime": {

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -242,6 +242,7 @@ def test_fastapi_extension_bare(tmp_path):
         "plugin": "nil",
         "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp",
         "stage-packages": ["bash_bins", "coreutils_bins", "ca-certificates_data"],
+        "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
     }
 
 

--- a/tests/unit/extensions/test_go.py
+++ b/tests/unit/extensions/test_go.py
@@ -104,6 +104,7 @@ def test_go_extension_bare(tmp_path):
     assert applied["parts"]["go-framework/runtime"] == {
         "plugin": "nil",
         "stage-packages": ["ca-certificates_data", "bash_bins", "coreutils_bins"],
+        "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
     }
 
 

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -363,6 +363,7 @@ def test_flask_extension_bare(
         "plugin": "nil",
         "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp",
         "stage-packages": ["bash_bins", "coreutils_bins", "ca-certificates_data"],
+        "override-stage": "craftctl default\nln -sf /usr/bin/bash ${CRAFT_PART_STAGE}/usr/bin/sh",
     }
     assert applied["parts"]["flask-framework/dependencies"] == {
         "plugin": "python",


### PR DESCRIPTION
<!-- Describe your changes -->
Symlink the `sh` executable to point to `bash` so that `juju ssh` works.

This is the approach [recommended by chisel](https://github.com/canonical/chisel-releases/blob/ubuntu-24.04/slices/bash.yaml#L20)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
