### PR TITLE
feat(snap): add rockcraft.json to the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -244,3 +244,10 @@ parts:
       bin/spread: libexec/rockcraft/craft.spread
     stage:
       - libexec/rockcraft/
+
+  # Add the project schema to the snap
+  schema:
+    plugin: dump
+    source: ./schema
+    organize:
+      "*": schema/


### PR DESCRIPTION
This is a request from the Rocks team. With the project schema in the snap, users can do things like validate a rockcraft.yaml against the version of rockcraft they have, check which bases are supported, etc.

<!-- Describe your changes -->

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
