### PR TITLE
fix: remove snapcraft.yaml reference from expand-extensions

### DIFF
--- a/rockcraft/commands/extensions.py
+++ b/rockcraft/commands/extensions.py
@@ -82,13 +82,13 @@ class ExtensionsCommand(ListExtensionsCommand, abc.ABC):
 
 
 class ExpandExtensionsCommand(AppCommand, abc.ABC):
-    """Expand the extensions in the snapcraft.yaml file."""
+    """Expand the extensions in the rockcraft.yaml file."""
 
     name = "expand-extensions"
-    help_msg = "Expand extensions in snapcraft.yaml"
+    help_msg = "Expand extensions in rockcraft.yaml"
     overview = textwrap.dedent(
         """
-        Extensions listed rockcraft.yaml will be
+        Extensions listed in rockcraft.yaml will be
         expanded and shown as output.
         """
     )


### PR DESCRIPTION
Remove remaining references to snapcraft.yaml in the expand-extensions command help and docstring.

Fixes #885.