### PR TITLE
docs: clarify hello-world tutorial validated on ubuntu@22.04

### DIFF
--- a/docs/tutorial/hello-world.rst
+++ b/docs/tutorial/hello-world.rst
@@ -24,6 +24,13 @@ This file instructs Rockcraft to build a rock that **only** has the ``hello`` pa
 help define and describe the rock. For more information about all available keys, check
 :ref:`reference-rockcraft-yaml`.
 
+.. note::
+
+   This tutorial is validated with ``build-base: ubuntu@22.04`` as shown in
+   the example above. Behaviour may differ when using other Ubuntu series
+   (for example ``ubuntu@24.04``), as the contents of ``stage-packages``
+   can vary between releases.
+
 Pack the rock with Rockcraft
 ----------------------------
 

--- a/docs/tutorial/hello-world.rst
+++ b/docs/tutorial/hello-world.rst
@@ -24,11 +24,11 @@ This file instructs Rockcraft to build a rock that **only** has the ``hello`` pa
 help define and describe the rock. For more information about all available keys, check
 :ref:`reference-rockcraft-yaml`.
 
-.. note::
+.. admonition:: About the build base
 
-   This tutorial is validated with ``build-base: ubuntu@22.04`` as shown in
-   the example above. Behaviour may differ when using other Ubuntu series
-   (for example ``ubuntu@24.04``), as the contents of ``stage-packages``
+   The rock in this tutorial depends on ``build-base: ubuntu@22.04``.
+   It may not build if you use a different Ubuntu base, such as
+   ``ubuntu@24.04``, because the contents of ``stage-packages``
    can vary between releases.
 
 Pack the rock with Rockcraft


### PR DESCRIPTION
Fixes #898

Add a note in the Hello World tutorial clarifying that the example is validated with `build-base: ubuntu@22.04` and that behaviour may differ on other Ubuntu series.