### PR TITLE
docs: Add meta description guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,7 +296,7 @@ Check for problems in the documentation with:
 make lint-docs
 ```
 
-All **new** pages must include a meta description. The meta description provides 
+All **new** pages must include a meta description. The meta description provides
 a summary of the page. Search engines often reuse this for the search result’s snippet.
 
 To set custom HTML meta descriptions, add this structure at the top of a page:
@@ -314,7 +314,7 @@ Please observe the following guidelines:
 - Keep the language simple, avoid unnecessary adverbs or adjectives.
 - Use an informative tone, frame sentences in terms of actions and facts.
 - Use the tool name and page-specific terminology that users are likely to
-  use when searching for information. 
+  use when searching for information.
 - Place key terms near the start.
 - Don’t include key terms that aren’t on the page.
 


### PR DESCRIPTION
All new pages in the documentation must now include metadata descriptions. 

This pull request updates the `CONTRIBUTING.md` to add documentation guidelines for setting custom meta descriptions on new pages. It introduces instructions and best practices for writing effective meta descriptions.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
