### PR TITLE
build(deps): update craft-application to 6.2.1

### DIFF
--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -71,6 +71,7 @@ def test_lifecycle_args(
         base_layer_hash=b"deadbeef",
         cache_dir=project_path / "cache",
         ignore_local_sources=[".craft", "*.rock"],
+        ignore_outdated=[".craft", "*.rock"],
         parallel_build_count=4,
         partitions=None,
         project_name="test-rock",

--- a/uv.lock
+++ b/uv.lock
@@ -570,7 +570,7 @@ toml = [
 
 [[package]]
 name = "craft-application"
-version = "6.1.1"
+version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -589,11 +589,12 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "snap-helpers" },
+    { name = "snap-http" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/22/2b357189ad52133e4841afae1091691e873828d2cb0732e65ca058c479fb/craft_application-6.1.1.tar.gz", hash = "sha256:2223ac6b9c8db7567eda5f3ba839f85ff7a170cc198fce4f08a19d720d3205b9", size = 587699, upload-time = "2026-01-28T21:32:25.201Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/df/72c6e7265bcc312bc9156387bb15293ee8572cbf0e20f463502bdf132f7e/craft_application-6.2.1.tar.gz", hash = "sha256:ae08c2f879757372841b0be49b669f3b24fd7b69374bf0516c462c92a4058f4d", size = 595995, upload-time = "2026-03-06T16:18:22.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/b7/8f8ccaf3ce8b86d87c0341f3ad19613309123625d1ce063fe214e3e534d9/craft_application-6.1.1-py3-none-any.whl", hash = "sha256:8c8d15deb3064eda421b696ec0e7ae25457ad2853ffb7a1e0fb243f366a75d83", size = 195068, upload-time = "2026-01-28T21:32:24.017Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/30412ff58410b8ebabb4a6d1e431057beff85320ff1b774e7f403faf800b/craft_application-6.2.1-py3-none-any.whl", hash = "sha256:084fc51abbe38fea4bf8fbca826d6889c614cd4caaf10ea68af97cbbc3aee6ec", size = 197267, upload-time = "2026-03-06T16:18:20.281Z" },
 ]
 
 [[package]]
@@ -3298,6 +3299,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/2a/221ab0a9c0200065bdd8a5d2b131997e3e19ce81832fdf8138a7f5247216/snap-helpers-0.4.2.tar.gz", hash = "sha256:ef3b8621e331bb71afe27e54ef742a7dd2edd9e8026afac285beb42109c8b9a9", size = 20100, upload-time = "2023-08-06T09:38:53.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2c/c1304eb8787bbed23cfc0b07cee6b21e1310ceb6a6f7a4193dab02525c91/snap_helpers-0.4.2-py3-none-any.whl", hash = "sha256:04d0ebd167c943849c99ec68b87829fef4a915cbe9b02d8afc3891d889327327", size = 22805, upload-time = "2023-08-06T09:38:52.06Z" },
+]
+
+[[package]]
+name = "snap-http"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/0b/97fa751d236936dbb4cfc227e04c677fee110e824ce623ed382b7e66caea/snap_http-1.11.0.tar.gz", hash = "sha256:ee9afbe38e53c242cd7970ebda6f79fcad517998d79bae50ad24ff6b357f4965", size = 15993, upload-time = "2026-01-30T21:28:58.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/8a/e17a649f9d75514877b641c9ddb8414d1dcd9cfffc6bdb8ce361a810c733/snap_http-1.11.0-py3-none-any.whl", hash = "sha256:856afe2de663673104e4a431ea175c84fb342deb88003157541f3f4d4a336645", size = 17055, upload-time = "2026-01-30T21:28:57.753Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This should address the problem of incorrect plugin groups at project-validation-time.

<!-- Describe your changes -->

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
