### PR TITLE
fix: remove ref.name from annotation

### DIFF
--- a/docs/how-to/crafting/migrate-to-chiselled-rock.rst
+++ b/docs/how-to/crafting/migrate-to-chiselled-rock.rst
@@ -214,7 +214,7 @@ The output should be similar to:
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.767 Entrypoint set to ['/bin/pebble', 'enter']
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.767 Adding metadata
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.767 Configuring labels and annotations...
-    2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.785 Labels and annotations set to ['org.opencontainers.image.version=chiselled', 'org.opencontainers.image.title=dotnet-runtime', 'org.opencontainers.image.ref.name=dotnet-runtime', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2023-04-19T13:55:59.767870+00:00', 'org.opencontainers.image.base.digest=13155b5ad26816d4107ee499de072069a701c9fe183f7e347e8d88fee16e69c2']
+    2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.785 Labels and annotations set to ['org.opencontainers.image.version=chiselled', 'org.opencontainers.image.title=dotnet-runtime', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2023-04-19T13:55:59.767870+00:00', 'org.opencontainers.image.base.digest=13155b5ad26816d4107ee499de072069a701c9fe183f7e347e8d88fee16e69c2']
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.792 Setting the ROCK's Control Data
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.797 Adding to layer: /tmp/tmpdqjmducj/.rock as '.rock'
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.797 Adding to layer: /tmp/tmpdqjmducj/.rock/metadata.yaml as '.rock/metadata.yaml'

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -420,7 +420,6 @@ class Project(BaseProject):
         annotations = {
             "org.opencontainers.image.version": self.version,
             "org.opencontainers.image.title": self.title,
-            "org.opencontainers.image.ref.name": self.name,
             "org.opencontainers.image.created": generation_time,
             "org.opencontainers.image.base.digest": base_digest.hex(),
             "org.opencontainers.image.description": re.sub(

--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -600,6 +600,10 @@ def _inject_oci_fields(image_path: Path, arch_variant: str | None = None) -> Non
     # The manifest of the image being built contains both the base image
     # and the target image. We need to find the manifest that matches the
     # tag of the target image, and ensure the tag is not ambiguous.
+    # The annotation "org.opencontainers.image.ref.name" here is set by umoci
+    # when calling the method `add_layer` to distinguish images with different
+    # tags within the same OCI directory. This annotation is irrelevant to the
+    # annotation field with the same name in the manifest of the target image.
     manifest_digests: list[tuple[str, int]] = [
         (manifest["digest"].split(":")[-1], i)
         for i, manifest in enumerate(tl_index["manifests"])

--- a/tests/unit/test_oci.py
+++ b/tests/unit/test_oci.py
@@ -832,7 +832,13 @@ class TestImage:
                     "annotations": {
                         "org.opencontainers.image.ref.name": "latest",
                     },
-                }
+                },
+                {
+                    "digest": "sha256:basemanifest",
+                    "annotations": {
+                        "org.opencontainers.image.ref.name": "origin",
+                    },
+                },
             ]
         }
         test_manifest = {"config": {"digest": "sha256:fooconfig"}}
@@ -871,7 +877,13 @@ class TestImage:
                             "org.opencontainers.image.ref.name": "latest",
                         },
                         "size": len(new_test_manifest_bytes),
-                    }
+                    },
+                    {
+                        "digest": "sha256:basemanifest",
+                        "annotations": {
+                            "org.opencontainers.image.ref.name": "origin",
+                        },
+                    },
                 ]
             },
         }

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -717,7 +717,6 @@ def test_project_generate_metadata(yaml_loaded_data):
     assert oci_annotations == {
         "org.opencontainers.image.version": yaml_loaded_data["version"],
         "org.opencontainers.image.title": yaml_loaded_data["title"],
-        "org.opencontainers.image.ref.name": yaml_loaded_data["name"],
         "org.opencontainers.image.licenses": yaml_loaded_data["license"],
         "org.opencontainers.image.created": now,
         "org.opencontainers.image.base.digest": digest,


### PR DESCRIPTION
This PR removes the field `ref.name` from the image annotation to remove the blockers as concerned by https://github.com/docker-library/official-images/pull/20937

Rationale behind this: The annotation key `org.opencontainers.image.ref.name` should only be considered as valid if it's used in an image manifest index (i.e., the `index.json`) according to the [OCI spec](https://github.com/opencontainers/image-spec/blob/v1.1.1/annotations.md#pre-defined-annotation-keys). 

As a result, our adding the key `org.opencontainers.image.ref.name` to the image's manifest (instead of the manifest index) is considered invalid, and this behavior should be deprecated.

Contrarily, in the code, we are using this annotation key added implicitly by `umoci`  in the `_inject_oci_fields` function to distinguish the base image and the target image (see [comments](https://github.com/canonical/rockcraft/pull/1129/changes#diff-2ea5c49f4e82d2d8e882d4697ce07f60dbf804425f59e4f22d25259dd336452eR603)), which is deemed to be a valid use case, since this key is scoped inside the `index.json` file.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
