### PR TITLE
docs: add platform naming rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -324,7 +324,7 @@ def link_common_docs(library_name: str) -> None:
 
     docs_module_name = f"{library_name.replace('-', '_')}_docs"
     docs_module = importlib.import_module(docs_module_name)
-    docs_path = pathlib.Path(docs_module.__file__).parent / library_name
+    docs_path = pathlib.Path(docs_module.__file__).parent / library_name  # pyright: ignore[reportArgumentType]
 
     if common_lib_path.is_symlink() and common_lib_path.readlink() == docs_path:
         return

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+import importlib
 import datetime
 import os
 import pathlib
@@ -230,6 +231,11 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/python_v2_plugin.rst",
     "common/craft-parts/reference/plugins/uv_plugin.rst",
     "common/craft-parts/reference/plugins/ruby_plugin.rst",
+    "common/craft-application/how-to-guides/build-remotely.rst",
+    "common/craft-application/how-to-guides/reuse-packages-between-builds.rst",
+    "common/craft-application/reference/fetch-service.rst",
+    "common/craft-application/reference/remote-builds.rst",
+    "common/craft-application/reference/strict-platform-names.rst",
     # Extra non-craft-parts exclusions can be added after this comment
     "reuse/*",
     "README.md",
@@ -312,11 +318,22 @@ def setup(app):
 
 # Setup libraries documentation snippets for use in rockcraft docs.
 common_docs_path = pathlib.Path(__file__).parent / "common"
-craft_parts_docs_path = pathlib.Path(craft_parts_docs.__file__).parent / "craft-parts"
-(common_docs_path / "craft-parts").unlink(missing_ok=True)
-(common_docs_path / "craft-parts").symlink_to(
-    craft_parts_docs_path, target_is_directory=True
-)
+def link_common_docs(library_name: str) -> None:
+    """Create a link to the appropriate common documentation directory."""
+    common_lib_path = common_docs_path / library_name
+
+    docs_module_name = f"{library_name.replace('-', '_')}_docs"
+    docs_module = importlib.import_module(docs_module_name)
+    docs_path = pathlib.Path(docs_module.__file__).parent / library_name
+
+    if common_lib_path.is_symlink() and common_lib_path.readlink() == docs_path:
+        return
+
+    common_lib_path.unlink(missing_ok=True)
+    common_lib_path.symlink_to(docs_path, target_is_directory=True)
+
+link_common_docs("craft-parts")
+link_common_docs("craft-application")
 
 # Do (not) include module names.
 add_module_names = True

--- a/docs/reference/rockcraft-yaml.rst
+++ b/docs/reference/rockcraft-yaml.rst
@@ -86,8 +86,16 @@ boilerplate keys from the listed extensions will be added to the project file.
 Platform keys
 -------------
 
+.. |star| replace:: rock
+.. |Starcraft| replace:: Rockcraft
+
 .. kitbash-field:: rockcraft.models.Project platforms
     :override-type: dict[str, Platform]
+
+    **Naming rules**
+
+    .. include:: ../common/craft-application/reference/strict-platform-names.rst
+        :start-after: ------------
 
 .. kitbash-field:: craft_application.models.Platform build_on
     :prepend-name: platforms.<platform-name>
@@ -98,14 +106,6 @@ Platform keys
     :override-type: str | list[str]
 
 
-.. |star| replace:: rock
-.. |Starcraft| replace:: Rockcraft
-
-Naming rules
-~~~~~~~~~~~~
-
-.. include:: ../common/craft-application/reference/strict-platform-names.rst
-    :start-after: ------------
 
 .. _rockcraft-yaml-part-keys:
 

--- a/docs/reference/rockcraft-yaml.rst
+++ b/docs/reference/rockcraft-yaml.rst
@@ -98,6 +98,15 @@ Platform keys
     :override-type: str | list[str]
 
 
+.. |star| replace:: rock
+.. |Starcraft| replace:: Rockcraft
+
+Naming rules
+~~~~~~~~~~~~
+
+.. include:: ../common/craft-application/reference/strict-platform-names.rst
+    :start-after: ------------
+
 .. _rockcraft-yaml-part-keys:
 
 Part keys


### PR DESCRIPTION
Describes the rules for naming platforms, bringing in the document from Craft Application.

<!-- Describe your changes -->

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
