### PR TITLE
fix: remove base.digest for bare-based rocks

### DIFF
--- a/docs/how-to/crafting/migrate-to-chiselled-rock.rst
+++ b/docs/how-to/crafting/migrate-to-chiselled-rock.rst
@@ -214,7 +214,7 @@ The output should be similar to:
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.767 Entrypoint set to ['/bin/pebble', 'enter']
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.767 Adding metadata
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.767 Configuring labels and annotations...
-    2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.785 Labels and annotations set to ['org.opencontainers.image.version=chiselled', 'org.opencontainers.image.title=dotnet-runtime', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2023-04-19T13:55:59.767870+00:00', 'org.opencontainers.image.base.digest=13155b5ad26816d4107ee499de072069a701c9fe183f7e347e8d88fee16e69c2']
+    2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.785 Labels and annotations set to ['org.opencontainers.image.version=chiselled', 'org.opencontainers.image.title=dotnet-runtime', 'org.opencontainers.image.licenses=Apache-2.0', 'org.opencontainers.image.created=2023-04-19T13:55:59.767870+00:00']
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.792 Setting the ROCK's Control Data
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.797 Adding to layer: /tmp/tmpdqjmducj/.rock as '.rock'
     2023-04-19 15:56:00.567 :: 2023-04-19 13:55:59.797 Adding to layer: /tmp/tmpdqjmducj/.rock/metadata.yaml as '.rock/metadata.yaml'

--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -406,7 +406,6 @@ class Project(BaseProject):
             "version": self.version,
             "created": generation_time,
             "base": self.base,
-            "base-digest": base_digest.hex(),
             # `architecture` "looks like" a string since it inherits from it, but serialization
             # represents it as a DebianArchitecture, which comes out wrong (see rockcraft#992)
             # instead, explicitly cast it to just be an actual string
@@ -421,7 +420,6 @@ class Project(BaseProject):
             "org.opencontainers.image.version": self.version,
             "org.opencontainers.image.title": self.title,
             "org.opencontainers.image.created": generation_time,
-            "org.opencontainers.image.base.digest": base_digest.hex(),
             "org.opencontainers.image.description": re.sub(
                 r"\n{2,}", "\n", self.summary
             )
@@ -429,6 +427,12 @@ class Project(BaseProject):
         }
         if self.license:
             annotations["org.opencontainers.image.licenses"] = self.license
+
+        # The base digest is only valid for non-bare bases, since there isn't an image
+        # sharing the zero-indexed layers with the target image for a bare-based image.
+        if self.base != "bare":
+            metadata["base-digest"] = base_digest.hex()
+            annotations["org.opencontainers.image.base.digest"] = base_digest.hex()
 
         return (annotations, metadata)
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -765,6 +765,25 @@ def test_metadata_base_devel(yaml_loaded_data):
     assert rock_metadata["grade"] == "devel"
 
 
+def test_metadata_base_bare(yaml_loaded_data):
+    yaml_loaded_data["base"] = "bare"
+    yaml_loaded_data["build-base"] = "ubuntu@24.04"
+    yaml_loaded_data["parts"]["foo"] = {
+        "plugin": "nil",
+        "stage-packages": ["hello"],
+    }  # Avoid validation error for no overlay with bare base
+    project = Project.unmarshal(yaml_loaded_data)
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    digest = "a1b2c3"  # mock digest
+
+    oci_annotations, rock_metadata = project.generate_metadata(
+        now, bytes.fromhex(digest), DebianArchitecture.from_host()
+    )
+    assert "base-digest" not in rock_metadata
+    assert "org.opencontainers.image.base.digest" not in oci_annotations
+
+
 EXPECTED_DUMPED_YAML = f"""\
 name: mytest
 title: My Test


### PR DESCRIPTION
According to the [OCI spec](https://github.com/opencontainers/image-spec/blob/v1.1.1/annotations.md#pre-defined-annotation-keys), the key `org.opencontainers.image.base.digest` shouldn't be added to the annotations of a `bare`-based rock, as `bare`-based rocks don't have a valid "base" image. This annotation key is removed from the generated metadata for the `bare`-based rocks.

Similarly, the key `base-digest` shouldn't be added to the rock's metadata for `bare`-based rocks either, and is removed in this PR.

This PR targets at removing one of the hard blockers from [the PR in Docker official images](https://github.com/docker-library/official-images/pull/20937)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
