### PR TITLE
docs: add completion time to tutorials

### DIFF
--- a/docs/tutorial/chisel.rst
+++ b/docs/tutorial/chisel.rst
@@ -7,6 +7,8 @@ In this tutorial, you will create a lean hello-world rock that uses chisel
 slices, and then compare the resulting rock with the one created without slices
 in :doc:`/tutorial/hello-world`.
 
+It should take around 10 minutes to complete.
+
 Setup your environment
 ----------------------
 

--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -7,6 +7,8 @@ In this tutorial, we'll create a simple Django app and learn how to
 containerise it in a rock, using Rockcraft's ``django-framework``
 :ref:`extension <reference-django-framework>`.
 
+It should take 25 minutes for you to complete.
+
 Setup
 =====
 

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -7,6 +7,8 @@ In this tutorial, we'll create a simple FastAPI app and learn how to
 containerise it in a rock with Rockcraft's
 :ref:`fastapi-framework <reference-fastapi-framework>` extension.
 
+It should take 25 minutes for you to complete.
+
 Setup
 =====
 

--- a/docs/tutorial/flask.rst
+++ b/docs/tutorial/flask.rst
@@ -7,6 +7,8 @@ In this tutorial, we'll create a simple Flask app and learn how to
 containerise it in a rock, using Rockcraft's ``flask-framework``
 :ref:`extension <reference-flask-framework>`.
 
+It should take 25 minutes for you to complete.
+
 Setup
 =====
 

--- a/docs/tutorial/hello-world.rst
+++ b/docs/tutorial/hello-world.rst
@@ -3,6 +3,10 @@
 Create a "Hello World" rock
 ===========================
 
+This tutorial guides you through the process of packaging a rock with Rockcraft.
+
+It should take around 10 minutes to complete.
+
 Setup your environment
 ----------------------
 

--- a/docs/tutorial/node-app.rst
+++ b/docs/tutorial/node-app.rst
@@ -6,6 +6,8 @@ Bundle a Node.js app into a rock
 This tutorial describes the steps needed to bundle a typical Node.js application
 into a rock.
 
+It should take around 10 minutes to complete.
+
 Setup your environment
 ----------------------
 

--- a/docs/tutorial/pypi-package.rst
+++ b/docs/tutorial/pypi-package.rst
@@ -14,6 +14,7 @@ By the end of this tutorial you will be able to run pyfiglet via docker:
     | | | |  __/ | | (_) |
     |_| |_|\___|_|_|\___/
 
+It should take around 10 minutes to complete.
 
 Setup your environment
 ----------------------


### PR DESCRIPTION
Through UR, we have been asked to add completion times to the rest of the tutorials. The tutorials have been tested and timed. The resulting time has been added. 

For the "Hello World rock" tutorial, I have also added an introductory sentence, as this was missing.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
