### PR TITLE
docs(node tutorial): fix docker run command to display app logs

### DIFF
--- a/docs/tutorial/code/node-app/task.yaml
+++ b/docs/tutorial/code/node-app/task.yaml
@@ -28,7 +28,7 @@ execute: |
   # to the documentation that uses it.
   cat <<EOF > run-container.sh
   # [docs:run-container]
-  docker run --name my-node-app -p 8000:8080 my-node-app:1.0
+  docker run --name my-node-app -p 8000:8000 my-node-app:1.0 -v
   # [docs:run-container-end]
   EOF
 


### PR DESCRIPTION
Update the docker run command in the Node.js tutorial so that application logs are displayed instead of only Pebble logs.

Fixes #1134.