### PR TITLE
docs: remove bounty instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,22 +43,6 @@ add your voice to the issue.
 If the bug or feature doesn't have an issue, we invite you to [open
 one](https://github.com/canonical/rockcraft/issues/new/choose).
 
-## Apply for a bounty
-
-Rockcraft has a parallel stream of materially-rewarding work in the form of bounties. At
-the Starcraft team's discretion, high-value GitHub issues are allocated monetary
-bounties. A bounty is paid when the solution is merged into the codebase and its
-implementation meets all business and technical specifications outlined in the issue. To
-keep things fair, you can work on only one bounty at a time.
-
-If you're interested in bounties, enroll in the [GitHub Sponsors
-program](https://docs.github.com/en/sponsors/getting-started-with-github-sponsors/about-github-sponsors).
-
-To show interest in a bounty, provide a rough solution plan for it in a comment on its
-GitHub issue. The Rockcraft maintainers review all proposals for technical soundness. If
-your proposal is accepted, they will assign you the bounty, after which you can begin
-work.
-
 ## Set up for development
 
 Rockcraft uses a forking, feature-based workflow. Most work on Rockcraft occurs on
@@ -140,9 +124,6 @@ the issue's thread. In your proposal, describe a plan for the change, its tests,
 documentation. If the feature warrants a new page in the documentation, propose a
 [Diátaxis](https://diataxis.fr) category for the page. The Starcraft team will review
 your proposal and, if everything looks complete, assign the issue to you.
-
-Certain high-value issues are allocated monetary bounties. If you're interested in
-taking one on, we welcome you to apply.
 
 ### Create a feature branch
 


### PR DESCRIPTION
Removes information about bounties, as part of decommissioning the bounty program.

CRAFT-5020.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
