### PR TITLE
docs: clarify time endpoint timezone in tutorials

### DIFF
--- a/docs/tutorial/django.rst
+++ b/docs/tutorial/django.rst
@@ -424,7 +424,7 @@ Update the Django app
 =====================
 
 As a final step, let's update our app. For example,
-we want to add a new ``/time/`` endpoint which returns the current time in the container's timezone.
+we want to add a new ``/time/`` endpoint which returns the current time in UTC.
 
 .. literalinclude:: code/django/task.yaml
     :language: bash
@@ -507,7 +507,7 @@ Finally, use ``curl`` to send a request to the ``/time/`` endpoint:
     :end-before: [docs:curl-time-end]
     :dedent: 2
 
-The updated app should respond with the current date and time in the container's timezone (e.g.
+The updated app should respond with the current date and time in UTC (e.g.
 ``2024-08-20 07:28:19``).
 
 .. note::

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -413,7 +413,7 @@ Update the FastAPI app
 ======================
 
 As a final step, let's update our app. For example,
-we want to add a new ``/time`` endpoint which returns the current time in the container's timezone.
+we want to add a new ``/time`` endpoint which returns the current time in UTC.
 
 Start by opening the ``app.py`` file in a text editor and update the code to
 look like the following:
@@ -477,7 +477,7 @@ Finally, use ``curl`` to send a request to the ``/time`` endpoint:
     :end-before: [docs:curl-time-end]
     :dedent: 2
 
-The updated app should respond with the current date and time in the container's timezone (e.g.
+The updated app should respond with the current date and time in UTC (e.g.
 ``{"value":"2024-10-01 06:53:54\n"}``).
 
 .. note::

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -328,7 +328,7 @@ Update the Go app
 =================
 
 As a final step, let's update our app. For example,
-we want to add a new ``/time`` endpoint which returns the current time in the container's timezone.
+we want to add a new ``/time`` endpoint which returns the current time in UTC.
 
 Start by opening the ``main.go`` file in a text editor and update the code to
 look like the following:
@@ -392,7 +392,7 @@ Finally, use ``curl`` to send a request to the ``/time`` endpoint:
     :end-before: [docs:curl-time-end]
     :dedent: 2
 
-The updated app will respond with the current date and time in the container's timezone.
+The updated app will respond with the current date and time in UTC.
 
 .. note::
 

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -335,7 +335,7 @@ Update the Spring Boot app
 ==========================
 
 As a final step, let's update our app. For example,
-we want to add a new ``/time`` endpoint which returns the current time in the container's timezone.
+we want to add a new ``/time`` endpoint which returns the current time in UTC.
 
 Start by creating the ``src/main/java/com/example/demo/TimeController.java``
 file in a text editor and paste in the code to look like the following:
@@ -400,7 +400,7 @@ Finally, use ``curl`` to send a request to the ``/time`` endpoint:
     :end-before: [docs:curl-time-end]
     :dedent: 2
 
-The updated app will respond with the current date and time in the container's timezone.
+The updated app will respond with the current date and time in UTC.
 
 .. note::
 


### PR DESCRIPTION
## Summary
- clarify that the `/time` endpoint returns the current time in the container timezone
- update the Django, FastAPI, Go, and Spring Boot tutorials
- keep the change minimal and documentation-only

Closes #1142

## Testing
- make lint-docs