### PR TITLE
feat: add support for amd64v3 platform

### DIFF
--- a/rockcraft/architectures.py
+++ b/rockcraft/architectures.py
@@ -38,9 +38,7 @@ SUPPORTED_ARCHS: dict[str, ArchitectureMapping] = {
         go_arch="amd64",
     ),
     "amd64v3": ArchitectureMapping(
-        description="Intel 64",
-        go_arch="amd64",
-        go_variant="v3"
+        description="Intel 64", go_arch="amd64", go_variant="v3"
     ),
     "armhf": ArchitectureMapping(
         description="ARM 32-bit", go_arch="arm", go_variant="v7"


### PR DESCRIPTION
Introduce `amd64v3` in the list of supported archs. 

NOTE: this may require additional validation, so please use this PR as a conversation starter/feature request if further work is required across the craft components.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
