### PR TITLE
docs: update multipass link in tutorials, set min RAM

### DIFF
--- a/docs/reuse/tutorial/setup_edge.rst
+++ b/docs/reuse/tutorial/setup_edge.rst
@@ -95,4 +95,4 @@ Note that we'll also need a text editor. We can either install one of our
 choice or simply use one of the already existing editors in the Ubuntu
 environment (like ``vi``).
 
-.. _`install-multipass`: https://multipass.run/docs/install-multipass
+.. _`install-multipass`: https://documentation.ubuntu.com/multipass/stable/how-to-guides/install-multipass/

--- a/docs/reuse/tutorial/setup_stable.rst
+++ b/docs/reuse/tutorial/setup_stable.rst
@@ -34,7 +34,7 @@ Then we can create the VM with the following command:
 
 .. code-block:: text
 
-    multipass launch --disk 10G --name rock-dev 24.04
+    multipass launch --memory 2G --disk 10G --name rock-dev 24.04
 
 Finally, once the VM is up, open a shell into it:
 

--- a/docs/tutorial/express.rst
+++ b/docs/tutorial/express.rst
@@ -484,4 +484,3 @@ the changes are not taking effect, try running ``rockcraft clean`` and pack
 the rock again with ``rockcraft pack``.
 
 .. _`lxd-docker-connectivity-issue`: https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-.. _`install-multipass`: https://multipass.run/docs/install-multipass

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -570,4 +570,3 @@ your changes are not taking effect (e.g. the ``/time``
 ``rockcraft pack``.
 
 .. _`lxd-docker-connectivity-issue`: https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-.. _`install-multipass`: https://multipass.run/docs/install-multipass

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -486,4 +486,3 @@ the changes are not taking effect, try running ``rockcraft clean`` and pack
 the rock again with ``rockcraft pack``.
 
 .. _`lxd-docker-connectivity-issue`: https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-.. _`install-multipass`: https://multipass.run/docs/install-multipass

--- a/docs/tutorial/springboot.rst
+++ b/docs/tutorial/springboot.rst
@@ -484,4 +484,3 @@ the changes are not taking effect, try running ``rockcraft clean`` and pack
 the rock again with ``rockcraft pack``.
 
 .. _`lxd-docker-connectivity-issue`: https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-.. _`install-multipass`: https://multipass.run/docs/install-multipass


### PR DESCRIPTION
Update multipass environment setup instructions to match the latest system requirements. Use the same URL for all multipass documentation links.

Closes #1192 

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
