### PR TITLE
FastAPI, Go and Express extensions are no longer experimental

### DIFF
--- a/docs/tutorial/code/expressjs/task.yaml
+++ b/docs/tutorial/code/expressjs/task.yaml
@@ -42,10 +42,6 @@ execute: |
 
   sed -i "s/name: .*/name: expressjs-hello-world/g" rockcraft.yaml
 
-  # [docs:experimental]
-  export ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=true
-  # [docs:experimental-end]
-
   # [docs:pack]
   rockcraft pack
   # [docs:pack-end]

--- a/docs/tutorial/code/fastapi/task.yaml
+++ b/docs/tutorial/code/fastapi/task.yaml
@@ -31,10 +31,6 @@ execute: |
   # [docs:create-rockcraft-yaml-end]
   sed -i "s/name: .*/name: fastapi-hello-world/g" rockcraft.yaml
 
-  # [docs:experimental]
-  export ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=true
-  # [docs:experimental-end]
-
   # [docs:pack]
   rockcraft pack
   # [docs:pack-end]

--- a/docs/tutorial/code/go/task.yaml
+++ b/docs/tutorial/code/go/task.yaml
@@ -37,10 +37,6 @@ execute: |
   # [docs:create-rockcraft-yaml-end]
   sed -i "s/name: .*/name: go-hello-world/g" rockcraft.yaml
 
-  # [docs:experimental]
-  export ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=true
-  # [docs:experimental-end]
-
   # [docs:pack]
   rockcraft pack
   # [docs:pack-end]

--- a/docs/tutorial/express.rst
+++ b/docs/tutorial/express.rst
@@ -160,15 +160,6 @@ the architecture of your system:
 
 Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
 
-As the ``expressjs-framework`` extension is still experimental, export the
-environment variable ``ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS``:
-
-.. literalinclude:: code/expressjs/task.yaml
-    :language: bash
-    :start-after: [docs:experimental]
-    :end-before: [docs:experimental-end]
-    :dedent: 2
-
 Pack the rock:
 
 .. literalinclude:: code/expressjs/task.yaml

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -140,15 +140,6 @@ Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
     The ``name``, ``version`` and ``platform`` all influence the name of the
     generated ``.rock`` file.
 
-As the ``fastapi-framework`` extension is still experimental, export the
-environment variable ``ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS``:
-
-.. literalinclude:: code/fastapi/task.yaml
-    :language: bash
-    :start-after: [docs:experimental]
-    :end-before: [docs:experimental-end]
-    :dedent: 2
-
 Pack the rock:
 
 .. literalinclude:: code/fastapi/task.yaml
@@ -184,8 +175,6 @@ Pack the rock:
          --ctstate RELATED,ESTABLISHED -j ACCEPT
 
 Depending on the network, this step can take a couple of minutes to finish.
-Since FastAPI is an experimental extension,
-``ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS`` must be enabled.
 
 Once Rockcraft has finished packing the FastAPI rock, we'll find a new file in
 the project's working directory (an `OCI <OCI_image_spec_>`_ archive) with

--- a/docs/tutorial/go.rst
+++ b/docs/tutorial/go.rst
@@ -20,7 +20,7 @@ rocks for Go apps.
 Setup
 =====
 
-.. include:: /reuse/tutorial/setup_edge.rst
+.. include:: /reuse/tutorial/setup_stable.rst
 
 In order to test the Go app locally, before packing it into a rock,
 install Go.
@@ -167,16 +167,6 @@ Edit the ``platforms`` key in ``rockcraft.yaml`` if required.
 
     The ``name``, ``version`` and ``platform`` all influence the name of the
     generated ``.rock`` file.
-
-
-As the ``go-framework`` extension is still experimental, export the
-environment variable ``ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS``:
-
-.. literalinclude:: code/go/task.yaml
-    :language: bash
-    :start-after: [docs:experimental]
-    :end-before: [docs:experimental-end]
-    :dedent: 2
 
 Pack the rock:
 

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -45,7 +45,7 @@ class ExpressJSFramework(Extension):
     @override
     def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
         """Check if the extension is in an experimental state."""
-        return True
+        return False
 
     @override
     def get_root_snippet(self) -> dict[str, Any]:

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -51,7 +51,7 @@ class FastAPIFramework(Extension):
     @override
     def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
         """Check if the extension is in an experimental state."""
-        return True
+        return False
 
     @override
     def get_root_snippet(self) -> dict[str, Any]:

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -44,7 +44,7 @@ class GoFramework(Extension):
     @override
     def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
         """Check if the extension is in an experimental state."""
-        return True
+        return False
 
     @override
     def get_root_snippet(self) -> dict[str, Any]:

--- a/tests/spread/rockcraft/extension-expressjs/task.yaml
+++ b/tests/spread/rockcraft/extension-expressjs/task.yaml
@@ -4,7 +4,6 @@ kill-timeout: 45m
 environment:
   SCENARIO/bare: bare
   SCENARIO/base_2404: ubuntu-24.04
-  ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
   UV_USE_IO_URING: "0"
 
 execute: |
@@ -33,7 +32,7 @@ execute: |
         - findutils
   EOL
   fi
-   
+
   function run_test() {
     # rockcraft clean is required here because the cached layer writes to npmrc
     # multiple times, causing the app to crash on first run.

--- a/tests/spread/rockcraft/extension-fastapi/task.yaml
+++ b/tests/spread/rockcraft/extension-fastapi/task.yaml
@@ -2,7 +2,6 @@ summary: fastapi extension test
 environment:
   SCENARIO/bare: bare
   SCENARIO/base_2404: ubuntu-24.04
-  ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
 
 execute: |
   NAME="fastapi-${SCENARIO//./-}"

--- a/tests/spread/rockcraft/extension-go/task.yaml
+++ b/tests/spread/rockcraft/extension-go/task.yaml
@@ -2,7 +2,6 @@ summary: go extension test
 environment:
   SCENARIO/bare: bare
   SCENARIO/base_2404: ubuntu-24.04
-  ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "true"
 
 execute: |
   NAME="go-${SCENARIO//./-}"

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -33,7 +33,6 @@ def expressjs_input_yaml_fixture():
 
 @pytest.fixture
 def expressjs_extension(mock_extensions, monkeypatch):
-    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
     extensions.register("expressjs-framework", extensions.ExpressJSFramework)
 
 

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -30,7 +30,6 @@ def fastapi_input_yaml_fixture():
 
 @pytest.fixture
 def fastapi_extension(mock_extensions, monkeypatch):
-    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
     extensions.register("fastapi-framework", extensions.FastAPIFramework)
 
 

--- a/tests/unit/extensions/test_go.py
+++ b/tests/unit/extensions/test_go.py
@@ -31,7 +31,6 @@ def go_input_yaml_fixture():
 
 @pytest.fixture
 def go_extension(mock_extensions, monkeypatch):
-    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
     extensions.register("go-framework", extensions.GoFramework)
 
 


### PR DESCRIPTION
Remove "experimental == True" for FastAPI, Go and Express extensions.

Closes #1190 

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
