### PR TITLE
docs: clarify how to build the documentation

### DIFF
--- a/docs/how-to/documentation/build-docs.rst
+++ b/docs/how-to/documentation/build-docs.rst
@@ -3,6 +3,13 @@
 Build the documentation
 =======================
 
+Clone the Rockcraft repository and run the following commands from the
+repository root, not from the ``docs/`` directory.
+
+To build the documentation locally, ensure that ``make`` and ``python3-venv``
+are installed on your system. The ``make setup-docs`` command creates the
+documentation virtual environment automatically.
+
 Use the provided ``Makefile`` to install the documentation requirements:
 
 .. literalinclude:: ../code/build-docs/task.yaml
@@ -31,3 +38,7 @@ on each file change, and will reload the browser view.
 
 Note that ``make docs-auto`` automatically activates the virtual environment,
 as long as it already exists.
+
+To check the documentation for problems locally, run ``make docs-lint`` from the
+repository root. If you want to inspect the documentation subproject targets
+directly, run ``make help`` from the ``docs/`` directory.


### PR DESCRIPTION
## Summary
- clarify that the documented commands should be run from the repository root
- document the python3-venv prerequisite and that make setup-docs creates the docs virtual environment
- mention make docs-lint and how to inspect docs subproject targets from the docs/ directory

## Issue
- closes #627