### PR TITLE
ci: make workflows conditional, add docs-only spread tests

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -14,6 +14,8 @@ jobs:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    needs: lint
+    if: ${{ needs.lint.outputs.source-files == 'true' }}
     with:
       lowest-python-version: ""
       fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,6 +6,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "*.md"
+      - ".readthedocs.yaml"
   push:
     branches:
       - "feature/**"

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -2,6 +2,9 @@ name: Snap
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
   push:
     branches:
       - "feature/**"

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
+      - "*.md"
   push:
     branches:
       - "feature/**"

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -4,15 +4,17 @@ on:
     paths:
       - .github/workflows/spread-docs.yaml
       - spread.yaml
+      - .readthedocs.yaml
       - docs/**/code/**
   push:
     branches:
       - main
     paths:
       - spread.yaml
+      - .readthedocs.yaml
       - docs/**/code/**
   schedule:
-    - cron: "0 2 * * 0"
+    - cron: "0 2 * * 0" # Run every Sunday at 02:00
 
 jobs:
   docs-snap-build:

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -15,7 +15,7 @@ on:
     - cron: "0 2 * * 0"
 
 jobs:
-  snap-build:
+  docs-snap-build:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -31,7 +31,7 @@ jobs:
           name: snap
           path: ${{ steps.rockcraft.outputs.snap }}
 
-  docs-tests:
+  docs-spread-tests:
     runs-on: [self-hosted, spread-installed]
     needs: [snap-build]
     timeout-minutes: 90

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -11,7 +11,7 @@ on:
       - spread.yaml
       - docs/**/code/**
   schedule:
-    - cron: "0 0 */2 * *"
+    - cron: "0 2 * * 0"
 
 jobs:
   snap-build:

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: canonical/action-build@v1
         id: rockcraft
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: snap
           path: ${{ steps.rockcraft.outputs.snap }}
@@ -45,13 +45,13 @@ jobs:
           mkdir "${{ github.workspace }}"
 
       - name: Checkout rockcraft
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Download snap artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: snap
           path: tests

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -41,11 +41,6 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
 
-      - name: Fix network issues related to docker and lxd
-        run: |
-          sudo iptables -P FORWARD ACCEPT
-          sudo ip6tables -P FORWARD ACCEPT
-
       - name: Checkout rockcraft
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -10,6 +10,8 @@ on:
     paths:
       - spread.yaml
       - docs/**/code/**
+  schedule:
+    - cron: "0 0 */2 * *"
 
 jobs:
   snap-build:
@@ -29,7 +31,7 @@ jobs:
           path: ${{ steps.rockcraft.outputs.snap }}
 
   docs-tests:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, spread-installed]
     needs: [snap-build]
     timeout-minutes: 90
 
@@ -54,18 +56,6 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: snap
-
-      - name: Install LXD
-        uses: canonical/setup-lxd@d492474f6c8ceed1b716bb34c8f575a428871c70
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.26
-
-      - name: Install spread
-        run: |
-          go install github.com/canonical/spread/cmd/spread@latest
 
       - name: Run docs spread tests
         run: |

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: snap
+          path: tests
 
       - name: Run docs spread tests
         run: |

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -2,6 +2,7 @@ name: Spread tests for docs
 on:
   pull_request:
     paths:
+      - .github/workflows/spread-docs.yaml
       - spread.yaml
       - docs/**/code/**
   push:

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -1,0 +1,80 @@
+name: Spread tests for docs
+on:
+  pull_request:
+    paths:
+      - spread.yaml
+      - docs/**/code/**
+  push:
+    branches:
+      - main
+    paths:
+      - spread.yaml
+      - docs/**/code/**
+
+jobs:
+  snap-build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Build snap
+        uses: canonical/action-build@v1
+        id: rockcraft
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap
+          path: ${{ steps.rockcraft.outputs.snap }}
+
+  docs-tests:
+    runs-on: ubuntu-24.04
+    needs: [snap-build]
+    timeout-minutes: 90
+
+    steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+
+      - name: Fix network issues related to docker and lxd
+        run: |
+          sudo iptables -P FORWARD ACCEPT
+          sudo ip6tables -P FORWARD ACCEPT
+
+      - name: Checkout rockcraft
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: snap
+
+      - name: Install LXD
+        uses: canonical/setup-lxd@d492474f6c8ceed1b716bb34c8f575a428871c70
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26
+
+      - name: Install spread
+        run: |
+          go install github.com/canonical/spread/cmd/spread@latest
+
+      - name: Run docs spread tests
+        run: |
+          spread google:...docs...
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -33,7 +33,7 @@ jobs:
 
   docs-spread-tests:
     runs-on: [self-hosted, spread-installed]
-    needs: [snap-build]
+    needs: [docs-snap-build]
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -10,16 +10,29 @@ on:
 jobs:
   snap-build:
     runs-on: ubuntu-24.04
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Check which files changed
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md})'
       - name: Build snap
         uses: canonical/action-build@v1
+        if: steps.filter.source-files == 'true'
         id: rockcraft
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4
+        if: steps.filter.source-files == 'true'
         with:
           name: snap
           path: ${{ steps.rockcraft.outputs.snap }}
@@ -27,6 +40,7 @@ jobs:
   snap-tests:
     runs-on: [self-hosted, spread-installed]
     needs: [snap-build]
+    if: ${{ needs.snap-build.outputs.source-files == 'true' }}
 
     steps:
       - name: Cleanup job workspace
@@ -59,7 +73,7 @@ jobs:
           fi
           spread google:tests/spread/pro/
 
-      - name: Run spread
+      - name: Run source spread tests
         run: |
           spread google:
 

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -1,4 +1,4 @@
-name: Spread
+name: Spread tests for source
 on:
   pull_request:
   push:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run source spread tests
         run: |
-          spread google:
+          spread google:...tests...
 
       - name: Discard spread workers
         if: always()

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 */2 * *"
 
 jobs:
-  source-snap-build:
+  snap-build:
     runs-on: ubuntu-24.04
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -14,7 +14,7 @@ jobs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check which files changed
@@ -31,7 +31,7 @@ jobs:
         if: steps.filter.outputs.source-files == 'true'
         id: rockcraft
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.filter.outputs.source-files == 'true'
         with:
           name: snap
@@ -48,12 +48,12 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
       - name: Checkout rockcraft
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
       - name: Download snap artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: snap
           path: tests

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 */2 * *"
 
 jobs:
-  snap-build:
+  source-snap-build:
     runs-on: ubuntu-24.04
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}
@@ -37,7 +37,7 @@ jobs:
           name: snap
           path: ${{ steps.rockcraft.outputs.snap }}
 
-  snap-tests:
+  source-spread-tests:
     runs-on: [self-hosted, spread-installed]
     needs: [snap-build]
     if: ${{ needs.snap-build.outputs.source-files == 'true' }}

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -25,7 +25,7 @@ jobs:
           # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
           filters: |
             source-files:
-              - '!({docs/**,*.md,**/*.md})'
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
       - name: Build snap
         uses: canonical/action-build@v1
         if: steps.filter.outputs.source-files == 'true'

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -28,11 +28,11 @@ jobs:
               - '!({docs/**,*.md,**/*.md})'
       - name: Build snap
         uses: canonical/action-build@v1
-        if: steps.filter.source-files == 'true'
+        if: steps.filter.outputs.source-files == 'true'
         id: rockcraft
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4
-        if: steps.filter.source-files == 'true'
+        if: steps.filter.outputs.source-files == 'true'
         with:
           name: snap
           path: ${{ steps.rockcraft.outputs.snap }}

--- a/spread.yaml
+++ b/spread.yaml
@@ -117,6 +117,7 @@ debug-each: |
   fi
 
 suites:
+  # !!! Let's test the docs-only workflow
   docs/tutorial/code/:
     summary: tests tutorial from the docs
     systems:


### PR DESCRIPTION
Make workflows and jobs conditional:

- Full QA / lint runs if source files change.
- QA / Test runs if source files change.
- The Spread workflow calls the `test/**` Spread tests if source files change.

Add a Docs Spread workflow that runs the `docs/**` Spread tests if docs files change.

With the QA workflow, if there's a change to the source, all linters run in one runner (`make lint`). But for the Spread tests, there's a hard split between the docs and source Spread tests, meaning each will spawn their own runner. This isn't bad, but it adds complexity and inconsistency between the different workflow types. If Starflow's QA workflow were completely split, we could properly partition the checks in both collections – QA source, QA docs, Spread source, Spread docs.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
