### PR TITLE
fix(commands): reference rockcraft.yaml in extensions help

### DIFF
--- a/rockcraft/commands/extensions.py
+++ b/rockcraft/commands/extensions.py
@@ -82,13 +82,13 @@ class ExtensionsCommand(ListExtensionsCommand, abc.ABC):
 
 
 class ExpandExtensionsCommand(AppCommand, abc.ABC):
-    """Expand the extensions in the snapcraft.yaml file."""
+    """Expand the extensions in the rockcraft.yaml file."""
 
     name = "expand-extensions"
-    help_msg = "Expand extensions in snapcraft.yaml"
+    help_msg = "Expand extensions in rockcraft.yaml"
     overview = textwrap.dedent(
         """
-        Extensions listed rockcraft.yaml will be
+        Extensions listed in rockcraft.yaml will be
         expanded and shown as output.
         """
     )

--- a/tests/unit/commands/test_expand_extensions.py
+++ b/tests/unit/commands/test_expand_extensions.py
@@ -71,6 +71,13 @@ def setup_extensions(mock_extensions):
     extensions.register(FullExtension.NAME, FullExtension)
 
 
+def test_expand_extensions_help_references_rockcraft_yaml():
+    assert ExpandExtensionsCommand.help_msg == "Expand extensions in rockcraft.yaml"
+    assert "rockcraft.yaml" in ExpandExtensionsCommand.overview
+    assert "snapcraft.yaml" not in ExpandExtensionsCommand.help_msg
+    assert "snapcraft.yaml" not in ExpandExtensionsCommand.overview
+
+
 @pytest.mark.usefixtures("tmp_path", "setup_extensions")
 def test_expand_extensions(emitter, fake_app_config):
     # ExpandExtensionsCommand loads "rockcraft.yaml" on the cwd


### PR DESCRIPTION
## Summary

Update the expand-extensions help text to refer to rockcraft.yaml instead of snapcraft.yaml.

Fixes #658.