### PR TITLE
ci: run full spread workflow on scheduled suite

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -26,6 +26,11 @@ jobs:
           filters: |
             source-files:
               - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
+      - name: Default to 'true' for scheduled checks on main
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "source-files=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build snap
         uses: canonical/action-build@v1
         if: steps.filter.outputs.source-files == 'true'


### PR DESCRIPTION
The CI skips the full Spread tests for all CI runs. But for the scheduled CI on the `main` branch, there's no benefit in skipping those tests.

There's no way to mutate a workflow output with overriding it in a scriptlet, so this is the simplest way I could think of.

@tigarmo Any clever ways to test this other than in production?

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
