### PR TITLE
ci: always run spread workflow on schedule

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -27,12 +27,12 @@ jobs:
             source-files:
               - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
       - name: Build snap
-        uses: canonical/action-build@v1
-        if: steps.filter.outputs.source-files == 'true'
         id: rockcraft
+        uses: canonical/action-build@v1
+        if: ${{ steps.filter.outputs.source-files == 'true' || github.event_name == 'schedule' }}
       - name: Upload snap artifact
         uses: actions/upload-artifact@v7
-        if: steps.filter.outputs.source-files == 'true'
+        if: ${{ steps.filter.outputs.source-files == 'true' || github.event_name == 'schedule' }}
         with:
           name: snap
           path: ${{ steps.rockcraft.outputs.snap }}
@@ -40,7 +40,7 @@ jobs:
   source-spread-tests:
     runs-on: [self-hosted, spread-installed]
     needs: [snap-build]
-    if: ${{ needs.snap-build.outputs.source-files == 'true' }}
+    if: ${{ needs.snap-build.outputs.source-files == 'true' || github.event_name == 'schedule' }}
 
     steps:
       - name: Cleanup job workspace

--- a/spread.yaml
+++ b/spread.yaml
@@ -117,7 +117,6 @@ debug-each: |
   fi
 
 suites:
-  # !!! Let's test the docs-only workflow
   docs/tutorial/code/:
     summary: tests tutorial from the docs
     systems:


### PR DESCRIPTION
The CI has the chance to skip the full Spread tests for all CI runs. But for the bi-daily tests on the main branch, we should always run the full Spread suite.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
