### PR TITLE
docs: exclude 'including local files and remote resources' from build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,6 +216,7 @@ exclude_patterns = [
     "common/craft-parts/explanation/gradle_plugin.rst",
     "common/craft-parts/how-to/customise-the-build-with-craftctl.rst",
     "common/craft-parts/how-to/use_parts.rst",
+    "common/craft-parts/how-to/include_files.rst",
     "common/craft-parts/reference/partition_specific_output_directory_variables.rst",
     "common/craft-parts/reference/parts_steps.rst",
     "common/craft-parts/reference/step_execution_environment.rst",


### PR DESCRIPTION
This will prevent the common folder's copy of the file from appearing in the in-site search results.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
