### PR TITLE
fix(docs): Update chisel documentation URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,7 +193,6 @@ extensions = [
     "sphinx_autodoc_typehints",  # must be loaded after napoleon
     "sphinxcontrib.details.directive",
     "sphinx_toolbox.collapse",
-    "sphinx.ext.intersphinx",
     # "sphinx_substitution_extensions",
     ]
 
@@ -281,7 +280,7 @@ intersphinx_mapping = {
     ),
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable/", None),
     "pebble": ("https://documentation.ubuntu.com/pebble", None),
-    "chisel": ("https://documentation.ubuntu.com/chisel/en/latest", None),
+    "chisel": ("https://ubuntu.com/chisel/docs/latest", None),
 }
 # See also:
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_disabled_reftypes


### PR DESCRIPTION
Update chisel documentation URL and remove duplicate intersphinx extension.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
