### PR TITLE
feat(extensions): add Go framework V2 extension and factory dispatch

### DIFF
--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -20,7 +20,7 @@ from ._utils import apply_extensions
 from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
 from .fastapi import FastAPIFramework
-from .go import GoFramework
+from .go import GoFramework, GoFrameworkV2, go_framework_factory
 from .gunicorn import DjangoFramework, FlaskFramework
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
@@ -32,11 +32,14 @@ __all__ = [
     "register",
     "unregister",
     "gen_logging_part",
+    "GoFramework",
+    "GoFrameworkV2",
+    "go_framework_factory",
 ]
 
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)
-register("go-framework", GoFramework)
+register("go-framework", go_framework_factory)  # type: ignore[arg-type]
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -20,7 +20,7 @@ from ._utils import apply_extensions
 from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
 from .fastapi import FastAPIFramework
-from .go import GoFramework, GoFrameworkV2, go_framework_factory
+from .go import GoFramework, GoFrameworkV2, GoFrameworkFactory
 from .gunicorn import DjangoFramework, FlaskFramework
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
@@ -40,5 +40,5 @@ register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)
-register("go-framework", go_framework_factory)  # type: ignore[arg-type]
+register("go-framework", GoFrameworkFactory)  # type: ignore[arg-type]
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -34,7 +34,6 @@ __all__ = [
     "gen_logging_part",
     "GoFramework",
     "GoFrameworkV2",
-    "go_framework_factory",
 ]
 
 register("django-framework", DjangoFramework)

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -28,6 +28,25 @@ from craft_cli import emit
 from rockcraft import errors
 
 
+def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
+    """Extract and normalize all bases used in the project.
+
+    :param yaml_data: the raw yaml data.
+    :return: a set of base strings (e.g., {"ubuntu@24.04", "ubuntu@26.04"}).
+    """
+    bases: set[str] = set()
+
+    if base_str := yaml_data.get("base"):
+        bases.add(base_str)
+
+    if platforms := yaml_data.get("platforms", {}):
+        for label in platforms:
+            if "@" in label:
+                bases.add(label)
+
+    return bases
+
+
 class Extension(abc.ABC):
     """Extension is the class from which all extensions inherit.
 
@@ -114,6 +133,58 @@ class Extension(abc.ABC):
                 f"Extension has invalid part names: {invalid_parts!r}. "
                 "Format is <extension-name>/<part-name>"
             )
+
+
+class _FrameworkFactory:
+    """Route to a V1 or V2 extension class based on the project's target bases.
+
+    Instances are callable and expose get_supported_bases and is_experimental
+    so they can be registered and introspected like an Extension subclass.
+
+    The V2 class always supersedes V1 if the base is supported by the V2 class.
+    """
+
+    def __init__(self, v1_cls: type[Extension], v2_cls: type[Extension]) -> None:
+        """Store the V1 and V2 extension classes.
+
+        :param v1_cls: the V1 extension class.
+        :param v2_cls: the V2 extension class.
+        """
+        self._v1_cls = v1_cls
+        self._v2_cls = v2_cls
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Route to V1 or V2 based on project bases.
+
+        :param project_root: the project root directory.
+        :param yaml_data: the raw yaml data.
+        :return: an Extension instance from the appropriate version.
+        """
+        bases = get_project_bases(yaml_data)
+        if any(base in self._v2_cls.get_supported_bases() for base in bases):
+            return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+        return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
+
+    def get_supported_bases(self) -> tuple[str, ...]:
+        """Return merged supported bases from both V1 and V2, deduped and ordered.
+
+        :return: tuple of supported base strings.
+        """
+        return tuple(
+            dict.fromkeys(
+                self._v1_cls.get_supported_bases() + self._v2_cls.get_supported_bases()
+            )
+        )
+
+    def is_experimental(self, base: str | None) -> bool:
+        """Check if experimental, delegating to the class that supports the base.
+
+        :param base: the target base string or None.
+        :return: True if the base is experimental, False otherwise.
+        """
+        if base in self._v2_cls.get_supported_bases():
+            return self._v2_cls.is_experimental(base)
+        return self._v1_cls.is_experimental(base)
 
 
 def get_extensions_data_dir() -> Path:

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -236,7 +236,7 @@ class GoFrameworkV2(GoFramework):
 
     For now this is behaviourally identical to :class:`GoFramework`; it exists so the
     framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
-    supported base differs.
+    supported base and experimental status differs.
     """
 
     @staticmethod
@@ -247,8 +247,11 @@ class GoFrameworkV2(GoFramework):
 
     @staticmethod
     @override
-    def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
-        """Check if the extension is in an experimental state."""
+    def is_experimental(base: str | None) -> bool:
+        """Indicate if the extension is in an experimental state.
+
+        This is always True for V2
+        """
         return True
 
 

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -255,4 +255,4 @@ class GoFrameworkV2(GoFramework):
         return True
 
 
-go_framework_factory = _FrameworkFactory(GoFramework, GoFrameworkV2)
+GoFrameworkFactory = _FrameworkFactory(GoFramework, GoFrameworkV2)

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -26,7 +26,7 @@ from rockcraft.errors import ExtensionError
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from .app_parts import gen_logging_part
-from .extension import Extension
+from .extension import Extension, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -229,3 +229,27 @@ class GoFramework(Extension):
         for key in paths:
             obj = obj.get(key, {})
         return obj
+
+
+class GoFrameworkV2(GoFramework):
+    """Extension for 12-factor Go applications targeting ubuntu@26.04.
+
+    For now this is behaviourally identical to :class:`GoFramework`; it exists so the
+    framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
+    supported base differs.
+    """
+
+    @staticmethod
+    @override
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return supported bases."""
+        return ("ubuntu@26.04",)
+
+    @staticmethod
+    @override
+    def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
+        """Check if the extension is in an experimental state."""
+        return True
+
+
+go_framework_factory = _FrameworkFactory(GoFramework, GoFrameworkV2)

--- a/tests/unit/extensions/test_go.py
+++ b/tests/unit/extensions/test_go.py
@@ -31,7 +31,7 @@ def go_input_yaml_fixture():
 
 @pytest.fixture
 def go_extension(mock_extensions):
-    extensions.register("go-framework", extensions.go_framework_factory)  # type: ignore[arg-type]
+    extensions.register("go-framework", extensions.GoFrameworkFactory)  # type: ignore[arg-type]
 
 
 @pytest.mark.usefixtures("go_extension")
@@ -279,7 +279,7 @@ def test_go_extension_extra_assets_overridden(tmp_path, go_input_yaml):
 
 
 def test_go_framework_factory_dispatch(tmp_path):
-    factory = extensions.go_framework_factory
+    factory = extensions.GoFrameworkFactory
     v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
     assert isinstance(v1, extensions.GoFramework)
     assert not isinstance(v1, extensions.GoFrameworkV2)
@@ -293,14 +293,14 @@ def test_go_framework_v2_supported_bases():
 
 
 def test_go_framework_factory_supported_bases():
-    factory_bases = extensions.go_framework_factory.get_supported_bases()
+    factory_bases = extensions.GoFrameworkFactory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
     for base in extensions.GoFramework.get_supported_bases():
         assert base in factory_bases
 
 
 def test_go_framework_factory_is_experimental():
-    factory = extensions.go_framework_factory
+    factory = extensions.GoFrameworkFactory
     assert factory.is_experimental("ubuntu@26.04") is True
     assert factory.is_experimental("ubuntu@24.04") is False
     assert factory.is_experimental("bare") is False

--- a/tests/unit/extensions/test_go.py
+++ b/tests/unit/extensions/test_go.py
@@ -31,7 +31,7 @@ def go_input_yaml_fixture():
 
 @pytest.fixture
 def go_extension(mock_extensions):
-    extensions.register("go-framework", extensions.GoFramework)
+    extensions.register("go-framework", extensions.go_framework_factory)  # type: ignore[arg-type]
 
 
 @pytest.mark.usefixtures("go_extension")
@@ -275,4 +275,106 @@ def test_go_extension_extra_assets_overridden(tmp_path, go_input_yaml):
             "foobar": "app/foobar",
         },
         "stage": ["app/foobar"],
+    }
+
+
+def test_go_framework_factory_dispatch(tmp_path):
+    factory = extensions.go_framework_factory
+    v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
+    assert isinstance(v1, extensions.GoFramework)
+    assert not isinstance(v1, extensions.GoFrameworkV2)
+
+    v2 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"})
+    assert isinstance(v2, extensions.GoFrameworkV2)
+
+
+def test_go_framework_v2_supported_bases():
+    assert "ubuntu@26.04" in extensions.GoFrameworkV2.get_supported_bases()
+
+
+def test_go_framework_factory_supported_bases():
+    factory_bases = extensions.go_framework_factory.get_supported_bases()
+    assert "ubuntu@26.04" in factory_bases
+    for base in extensions.GoFramework.get_supported_bases():
+        assert base in factory_bases
+
+
+def test_go_framework_factory_is_experimental():
+    factory = extensions.go_framework_factory
+    assert factory.is_experimental("ubuntu@26.04") is True
+    assert factory.is_experimental("ubuntu@24.04") is False
+    assert factory.is_experimental("bare") is False
+
+
+@pytest.mark.usefixtures("go_extension")
+def test_go_extension_26_04_experimental_no_env(tmp_path):
+    (tmp_path / "go.mod").write_text("module projectname\n\ngo 1.22.4")
+    go_input_yaml = {
+        "name": "goprojectname",
+        "base": "ubuntu@26.04",
+        "platforms": {"amd64": {}},
+        "extensions": ["go-framework"],
+    }
+    with pytest.raises(ExtensionError, match="Extension is experimental"):
+        extensions.apply_extensions(tmp_path, go_input_yaml)
+
+
+@pytest.mark.usefixtures("go_extension")
+def test_go_extension_default_26_04(tmp_path, monkeypatch):
+    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
+    (tmp_path / "go.mod").write_text("module projectname\n\ngo 1.22.4")
+    go_input_yaml = {
+        "name": "goprojectname",
+        "base": "ubuntu@26.04",
+        "platforms": {"amd64": {}},
+        "extensions": ["go-framework"],
+    }
+    applied = extensions.apply_extensions(tmp_path, go_input_yaml)
+
+    assert applied == {
+        "base": "ubuntu@26.04",
+        "name": "goprojectname",
+        "platforms": {"amd64": {}},
+        "run_user": "_daemon_",
+        "parts": {
+            "go-framework/base-layout": {
+                "override-build": "mkdir -p ${CRAFT_PART_INSTALL}/app",
+                "plugin": "nil",
+                "permissions": [{"owner": 584792, "group": 584792}],
+            },
+            "go-framework/install-app": {
+                "plugin": "go",
+                "source": ".",
+                "build-snaps": ["go"],
+                "organize": {"bin/goprojectname": "usr/local/bin/goprojectname"},
+                "stage": ["usr/local/bin/goprojectname"],
+            },
+            "go-framework/runtime": {
+                "plugin": "nil",
+                "stage-packages": [
+                    "ca-certificates_data",
+                ],
+            },
+            "go-framework/logging": {
+                "plugin": "nil",
+                "override-build": (
+                    "craftctl default\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/opt/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/etc/promtail"
+                ),
+                "permissions": [
+                    {"path": "opt/promtail", "owner": 584792, "group": 584792},
+                    {"path": "etc/promtail", "owner": 584792, "group": 584792},
+                ],
+            },
+        },
+        "services": {
+            "go": {
+                "command": "goprojectname",
+                "override": "replace",
+                "startup": "enabled",
+                "user": "_daemon_",
+                "working-dir": "/app",
+            },
+        },
     }


### PR DESCRIPTION
Add GoFrameworkV2 (targets ubuntu@26.04, inherits GoFramework) and a GoFrameworkFactory that dispatch the V1 or V2 extension class depending on the base. Implements ISD283 (internal) for the go-framework extension.

Describe your changes.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
