### PR TITLE
feat(extensions): add Flask framework V2 extension and factory dispatch

### DIFF
--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -25,7 +25,7 @@ from .gunicorn import (
     DjangoFramework,
     FlaskFramework,
     FlaskFrameworkV2,
-    flask_framework_factory,
+    FlaskFrameworkFactory,
 )
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
@@ -45,6 +45,6 @@ __all__ = [
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
-register("flask-framework", flask_framework_factory)  # type: ignore[arg-type]
+register("flask-framework", FlaskFrameworkFactory)  # type: ignore[arg-type]
 register("go-framework", GoFramework)
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -24,8 +24,8 @@ from .go import GoFramework
 from .gunicorn import (
     DjangoFramework,
     FlaskFramework,
-    FlaskFrameworkFactory,
     FlaskFrameworkV2,
+    flask_framework_factory,
 )
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
@@ -39,13 +39,12 @@ __all__ = [
     "gen_logging_part",
     "DjangoFramework",
     "FlaskFramework",
-    "FlaskFrameworkFactory",
     "FlaskFrameworkV2",
 ]
 
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
-register("flask-framework", FlaskFrameworkFactory())  # type: ignore[arg-type]
+register("flask-framework", flask_framework_factory)  # type: ignore[arg-type]
 register("go-framework", GoFramework)
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -21,7 +21,12 @@ from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
 from .fastapi import FastAPIFramework
 from .go import GoFramework
-from .gunicorn import DjangoFramework, FlaskFramework
+from .gunicorn import (
+    DjangoFramework,
+    FlaskFramework,
+    FlaskFrameworkFactory,
+    FlaskFrameworkV2,
+)
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
 
@@ -32,11 +37,15 @@ __all__ = [
     "register",
     "unregister",
     "gen_logging_part",
+    "DjangoFramework",
+    "FlaskFramework",
+    "FlaskFrameworkFactory",
+    "FlaskFrameworkV2",
 ]
 
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
-register("flask-framework", FlaskFramework)
+register("flask-framework", FlaskFrameworkFactory())  # type: ignore[arg-type]
 register("go-framework", GoFramework)
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -28,6 +28,25 @@ from craft_cli import emit
 from rockcraft import errors
 
 
+def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
+    """Extract and normalize all bases used in the project.
+
+    :param yaml_data: the raw yaml data.
+    :return: a set of base strings (e.g., {"ubuntu@24.04", "ubuntu@26.04"}).
+    """
+    bases: set[str] = set()
+
+    if base_str := yaml_data.get("base"):
+        bases.add(base_str)
+
+    if platforms := yaml_data.get("platforms", {}):
+        for label in platforms:
+            if "@" in label:
+                bases.add(label)
+
+    return bases
+
+
 class Extension(abc.ABC):
     """Extension is the class from which all extensions inherit.
 
@@ -114,6 +133,58 @@ class Extension(abc.ABC):
                 f"Extension has invalid part names: {invalid_parts!r}. "
                 "Format is <extension-name>/<part-name>"
             )
+
+
+class _FrameworkFactory:
+    """Route to a V1 or V2 extension class based on the project's target bases.
+
+    Instances are callable and expose get_supported_bases and is_experimental
+    so they can be registered and introspected like an Extension subclass.
+
+    The V2 class always supersedes V1 if the base is supported by the V2 class.
+    """
+
+    def __init__(self, v1_cls: type[Extension], v2_cls: type[Extension]) -> None:
+        """Store the V1 and V2 extension classes.
+
+        :param v1_cls: the V1 extension class.
+        :param v2_cls: the V2 extension class.
+        """
+        self._v1_cls = v1_cls
+        self._v2_cls = v2_cls
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Route to V1 or V2 based on project bases.
+
+        :param project_root: the project root directory.
+        :param yaml_data: the raw yaml data.
+        :return: an Extension instance from the appropriate version.
+        """
+        bases = get_project_bases(yaml_data)
+        if any(base in self._v2_cls.get_supported_bases() for base in bases):
+            return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+        return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
+
+    def get_supported_bases(self) -> tuple[str, ...]:
+        """Return merged supported bases from both V1 and V2, deduped and ordered.
+
+        :return: tuple of supported base strings.
+        """
+        return tuple(
+            dict.fromkeys(
+                self._v1_cls.get_supported_bases() + self._v2_cls.get_supported_bases()
+            )
+        )
+
+    def is_experimental(self, base: str | None) -> bool:
+        """Check if experimental, delegating to the class that supports the base.
+
+        :param base: the target base string or None.
+        :return: True if the base is experimental, False otherwise.
+        """
+        if base in self._v2_cls.get_supported_bases():
+            return self._v2_cls.is_experimental(base)
+        return self._v1_cls.is_experimental(base)
 
 
 def get_extensions_data_dir() -> Path:

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -222,18 +222,6 @@ def prepend_to_env(
     return separator.join(paths) + f"${{{env_variable}:+{separator}${env_variable}}}"
 
 
-def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
-    """Extract and normalize all bases used in the project."""
-    bases: set[str] = set()
-    if base_str := yaml_data.get("base"):
-        bases.add(base_str)
-    if platforms := yaml_data.get("platforms", {}):
-        for label in platforms:
-            if "@" in label:
-                bases.add(label)
-    return bases
-
-
 class _FrameworkFactory:
     """Route to V1 or V2 extension based on project bases."""
 

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -220,3 +220,41 @@ def prepend_to_env(
                   a separator token at the end.
     """
     return separator.join(paths) + f"${{{env_variable}:+{separator}${env_variable}}}"
+
+
+def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
+    """Extract and normalize all bases used in the project."""
+    bases: set[str] = set()
+    if base_str := yaml_data.get("base"):
+        bases.add(base_str)
+    if platforms := yaml_data.get("platforms", {}):
+        for label in platforms:
+            if "@" in label:
+                bases.add(label)
+    return bases
+
+
+class _FrameworkFactory:
+    """Route to V1 or V2 extension based on project bases."""
+
+    def __init__(self, v1_cls: type[Extension], v2_cls: type[Extension]) -> None:
+        self._v1_cls = v1_cls
+        self._v2_cls = v2_cls
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        bases = get_project_bases(yaml_data)
+        if any(base in self._v2_cls.get_supported_bases() for base in bases):
+            return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+        return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
+
+    def get_supported_bases(self) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                self._v1_cls.get_supported_bases() + self._v2_cls.get_supported_bases()
+            )
+        )
+
+    def is_experimental(self, base: str | None) -> bool:
+        if base in self._v2_cls.get_supported_bases():
+            return self._v2_cls.is_experimental(base)
+        return self._v1_cls.is_experimental(base)

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -459,6 +459,46 @@ class FlaskFramework(_GunicornBase):
             )
 
 
+class FlaskFrameworkV2(FlaskFramework):
+    """Extension for 12-factor Flask applications targeting ubuntu@26.04.
+
+    For now this is behaviourally identical to :class:`FlaskFramework`; it exists so the
+    framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
+    supported base differs.
+    """
+
+    @staticmethod
+    @override
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return supported bases."""
+        return ("ubuntu@26.04",)
+
+
+class FlaskFrameworkFactory:
+    """Return the correct FlaskFramework extension for the project's base."""
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
+        if "26.04" in yaml_data.get("base", ""):
+            return FlaskFrameworkV2(project_root=project_root, yaml_data=yaml_data)
+        return FlaskFramework(project_root=project_root, yaml_data=yaml_data)
+
+    @staticmethod
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return the union of V1 and V2 supported bases."""
+        return tuple(
+            dict.fromkeys(
+                FlaskFramework.get_supported_bases()
+                + FlaskFrameworkV2.get_supported_bases()
+            )
+        )
+
+    @staticmethod
+    def is_experimental(base: str | None) -> bool:
+        """Return whether the extension is experimental for the given base."""
+        return FlaskFramework.is_experimental(base)
+
+
 class DjangoFramework(_GunicornBase):
     """An extension for constructing Python applications based on the Django framework."""
 

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -480,7 +480,7 @@ class FlaskFrameworkV2(FlaskFramework):
         return True
 
 
-flask_framework_factory = _FrameworkFactory(FlaskFramework, FlaskFrameworkV2)
+FlaskFrameworkFactory = _FrameworkFactory(FlaskFramework, FlaskFrameworkV2)
 
 
 class DjangoFramework(_GunicornBase):

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -475,7 +475,7 @@ class FlaskFrameworkV2(FlaskFramework):
 
     @staticmethod
     @override
-    def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
+    def is_experimental(base: str | None) -> bool:
         """Check if the extension is in an experimental state."""
         return True
 

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -46,7 +46,7 @@ from ._python_utils import (
 )
 from ._utils import find_ubuntu_base_python_version
 from .app_parts import gen_logging_part
-from .extension import Extension, get_extensions_data_dir
+from .extension import Extension, _FrameworkFactory, get_extensions_data_dir
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -473,30 +473,14 @@ class FlaskFrameworkV2(FlaskFramework):
         """Return supported bases."""
         return ("ubuntu@26.04",)
 
-
-class FlaskFrameworkFactory:
-    """Return the correct FlaskFramework extension for the project's base."""
-
-    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
-        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
-        if "26.04" in yaml_data.get("base", ""):
-            return FlaskFrameworkV2(project_root=project_root, yaml_data=yaml_data)
-        return FlaskFramework(project_root=project_root, yaml_data=yaml_data)
-
     @staticmethod
-    def get_supported_bases() -> tuple[str, ...]:
-        """Return the union of V1 and V2 supported bases."""
-        return tuple(
-            dict.fromkeys(
-                FlaskFramework.get_supported_bases()
-                + FlaskFrameworkV2.get_supported_bases()
-            )
-        )
+    @override
+    def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
+        """Check if the extension is in an experimental state."""
+        return True
 
-    @staticmethod
-    def is_experimental(base: str | None) -> bool:
-        """Return whether the extension is experimental for the given base."""
-        return FlaskFramework.is_experimental(base)
+
+flask_framework_factory = _FrameworkFactory(FlaskFramework, FlaskFrameworkV2)
 
 
 class DjangoFramework(_GunicornBase):

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -24,7 +24,7 @@ from rockcraft.errors import ExtensionError
 
 @pytest.fixture
 def flask_extension(mock_extensions):
-    extensions.register("flask-framework", extensions.FlaskFrameworkFactory())  # type: ignore[arg-type]
+    extensions.register("flask-framework", extensions.flask_framework_factory)  # type: ignore[arg-type]
 
 
 @pytest.fixture(name="flask_input_yaml")
@@ -786,38 +786,36 @@ def test_flask_extension_app_in_non_matching_directory(tmp_path):
 
 
 def test_flask_framework_factory_dispatch(tmp_path):
-    """Test that FlaskFrameworkFactory dispatches to the correct class by base."""
+    """Test that flask_framework_factory dispatches to the correct class by base."""
     from rockcraft.extensions.gunicorn import (
         FlaskFramework,
-        FlaskFrameworkFactory,
         FlaskFrameworkV2,
+        flask_framework_factory,
     )
 
-    factory = FlaskFrameworkFactory()
-
-    v1 = factory(
+    v1 = flask_framework_factory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@22.04"}
     )
     assert isinstance(v1, FlaskFramework)
     assert not isinstance(v1, FlaskFrameworkV2)
 
-    v2 = factory(
+    v2 = flask_framework_factory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
     )
     assert isinstance(v2, FlaskFrameworkV2)
 
 
 def test_flask_framework_v2_supported_bases():
-    """Test FlaskFrameworkV2 and FlaskFrameworkFactory supported bases."""
+    """Test FlaskFrameworkV2 and flask_framework_factory supported bases."""
     from rockcraft.extensions.gunicorn import (
         FlaskFramework,
-        FlaskFrameworkFactory,
         FlaskFrameworkV2,
+        flask_framework_factory,
     )
 
     assert "ubuntu@26.04" in FlaskFrameworkV2.get_supported_bases()
 
-    factory_bases = FlaskFrameworkFactory.get_supported_bases()
+    factory_bases = flask_framework_factory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
     assert "ubuntu@22.04" in factory_bases
     assert "ubuntu@24.04" in factory_bases
@@ -827,8 +825,9 @@ def test_flask_framework_v2_supported_bases():
 
 
 @pytest.mark.usefixtures("flask_extension")
-def test_flask_v2_full_apply_26_04(tmp_path):
+def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
     """Test that the flask-framework extension applies correctly on ubuntu@26.04."""
+    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
     (tmp_path / "requirements.txt").write_text("flask")
     (tmp_path / "app.py").write_text("app = object()")
     (tmp_path / "static").mkdir()

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -24,7 +24,7 @@ from rockcraft.errors import ExtensionError
 
 @pytest.fixture
 def flask_extension(mock_extensions):
-    extensions.register("flask-framework", extensions.FlaskFramework)
+    extensions.register("flask-framework", extensions.FlaskFrameworkFactory())  # type: ignore[arg-type]
 
 
 @pytest.fixture(name="flask_input_yaml")
@@ -783,6 +783,164 @@ def test_flask_extension_app_in_non_matching_directory(tmp_path):
         ExtensionError, match="Missing WSGI entrypoint in default search locations"
     ):
         extensions.apply_extensions(tmp_path, flask_input_yaml)
+
+
+def test_flask_framework_factory_dispatch(tmp_path):
+    """Test that FlaskFrameworkFactory dispatches to the correct class by base."""
+    from rockcraft.extensions.gunicorn import (
+        FlaskFramework,
+        FlaskFrameworkFactory,
+        FlaskFrameworkV2,
+    )
+
+    factory = FlaskFrameworkFactory()
+
+    v1 = factory(
+        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@22.04"}
+    )
+    assert isinstance(v1, FlaskFramework)
+    assert not isinstance(v1, FlaskFrameworkV2)
+
+    v2 = factory(
+        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
+    )
+    assert isinstance(v2, FlaskFrameworkV2)
+
+
+def test_flask_framework_v2_supported_bases():
+    """Test FlaskFrameworkV2 and FlaskFrameworkFactory supported bases."""
+    from rockcraft.extensions.gunicorn import (
+        FlaskFramework,
+        FlaskFrameworkFactory,
+        FlaskFrameworkV2,
+    )
+
+    assert "ubuntu@26.04" in FlaskFrameworkV2.get_supported_bases()
+
+    factory_bases = FlaskFrameworkFactory.get_supported_bases()
+    assert "ubuntu@26.04" in factory_bases
+    assert "ubuntu@22.04" in factory_bases
+    assert "ubuntu@24.04" in factory_bases
+    # All V1 bases are included
+    for base in FlaskFramework.get_supported_bases():
+        assert base in factory_bases
+
+
+@pytest.mark.usefixtures("flask_extension")
+def test_flask_v2_full_apply_26_04(tmp_path):
+    """Test that the flask-framework extension applies correctly on ubuntu@26.04."""
+    (tmp_path / "requirements.txt").write_text("flask")
+    (tmp_path / "app.py").write_text("app = object()")
+    (tmp_path / "static").mkdir()
+    (tmp_path / "node_modules").mkdir()
+
+    flask_input_yaml_26 = {
+        "name": "foo-bar",
+        "base": "ubuntu@26.04",
+        "platforms": {"amd64": {}},
+        "extensions": ["flask-framework"],
+    }
+
+    applied = extensions.apply_extensions(tmp_path, flask_input_yaml_26)
+    source = applied["parts"]["flask-framework/config-files"]["source"]
+    del applied["parts"]["flask-framework/config-files"]["source"]
+    suffix = "share/rockcraft/extensions/flask-framework"
+    assert source[-len(suffix) :].replace("\\", "/") == suffix
+
+    assert applied == {
+        "name": "foo-bar",
+        "base": "ubuntu@26.04",
+        "parts": {
+            "flask-framework/config-files": {
+                "organize": {
+                    "gunicorn.conf.py": "flask/gunicorn.conf.py",
+                },
+                "plugin": "dump",
+                "permissions": [
+                    {
+                        "path": "flask/gunicorn.conf.py",
+                        "owner": 584792,
+                        "group": 584792,
+                    }
+                ],
+            },
+            "flask-framework/dependencies": {
+                "plugin": "python",
+                "python-packages": ["gunicorn~=23.0"],
+                "python-requirements": ["requirements.txt"],
+                "source": ".",
+                "stage-packages": ["python3-venv"],
+                "build-environment": [],
+            },
+            "flask-framework/install-app": {
+                "organize": {
+                    "app.py": "flask/app/app.py",
+                    "static": "flask/app/static",
+                },
+                "plugin": "dump",
+                "prime": ["flask/app/app.py", "flask/app/static"],
+                "source": ".",
+                "stage": ["flask/app/app.py", "flask/app/static"],
+                "permissions": [
+                    {
+                        "owner": 584792,
+                        "group": 584792,
+                    },
+                ],
+            },
+            "flask-framework/runtime": {
+                "plugin": "nil",
+                "stage-packages": ["ca-certificates_data"],
+            },
+            "flask-framework/logging": {
+                "plugin": "nil",
+                "override-build": (
+                    "craftctl default\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/opt/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/etc/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/var/log/flask"
+                ),
+                "permissions": [
+                    {"path": "opt/promtail", "owner": 584792, "group": 584792},
+                    {"path": "etc/promtail", "owner": 584792, "group": 584792},
+                    {
+                        "path": "var/log/flask",
+                        "owner": 584792,
+                        "group": 584792,
+                    },
+                ],
+            },
+            "flask-framework/statsd-exporter": {
+                "build-snaps": ["go"],
+                "plugin": "go",
+                "source": "https://github.com/prometheus/statsd_exporter.git",
+                "source-tag": "v0.26.0",
+            },
+        },
+        "platforms": {"amd64": {}},
+        "run_user": "_daemon_",
+        "services": {
+            "flask": {
+                "after": ["statsd-exporter"],
+                "command": "/bin/python3 -m gunicorn -c "
+                "/flask/gunicorn.conf.py 'app:app' -k [ sync ]",
+                "override": "replace",
+                "startup": "enabled",
+                "user": "_daemon_",
+            },
+            "statsd-exporter": {
+                "command": (
+                    "/bin/statsd_exporter --statsd.mapping-config=/statsd-mapping.conf "
+                    "--statsd.listen-udp=localhost:9125 "
+                    "--statsd.listen-tcp=localhost:9125"
+                ),
+                "override": "merge",
+                "startup": "enabled",
+                "summary": "statsd exporter service",
+                "user": "_daemon_",
+            },
+        },
+    }
 
 
 @pytest.mark.usefixtures("django_extension")

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -24,7 +24,7 @@ from rockcraft.errors import ExtensionError
 
 @pytest.fixture
 def flask_extension(mock_extensions):
-    extensions.register("flask-framework", extensions.flask_framework_factory)  # type: ignore[arg-type]
+    extensions.register("flask-framework", extensions.FlaskFrameworkFactory)  # type: ignore[arg-type]
 
 
 @pytest.fixture(name="flask_input_yaml")
@@ -786,36 +786,36 @@ def test_flask_extension_app_in_non_matching_directory(tmp_path):
 
 
 def test_flask_framework_factory_dispatch(tmp_path):
-    """Test that flask_framework_factory dispatches to the correct class by base."""
+    """Test that FlaskFrameworkFactory dispatches to the correct class by base."""
     from rockcraft.extensions.gunicorn import (
         FlaskFramework,
         FlaskFrameworkV2,
-        flask_framework_factory,
+        FlaskFrameworkFactory,
     )
 
-    v1 = flask_framework_factory(
+    v1 = FlaskFrameworkFactory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@22.04"}
     )
     assert isinstance(v1, FlaskFramework)
     assert not isinstance(v1, FlaskFrameworkV2)
 
-    v2 = flask_framework_factory(
+    v2 = FlaskFrameworkFactory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
     )
     assert isinstance(v2, FlaskFrameworkV2)
 
 
 def test_flask_framework_v2_supported_bases():
-    """Test FlaskFrameworkV2 and flask_framework_factory supported bases."""
+    """Test FlaskFrameworkV2 and FlaskFrameworkFactory supported bases."""
     from rockcraft.extensions.gunicorn import (
         FlaskFramework,
         FlaskFrameworkV2,
-        flask_framework_factory,
+        FlaskFrameworkFactory,
     )
 
     assert "ubuntu@26.04" in FlaskFrameworkV2.get_supported_bases()
 
-    factory_bases = flask_framework_factory.get_supported_bases()
+    factory_bases = FlaskFrameworkFactory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
     assert "ubuntu@22.04" in factory_bases
     assert "ubuntu@24.04" in factory_bases


### PR DESCRIPTION
Add FlaskFrameworkV2 (targets ubuntu@26.04, inherits FlaskFramework) and a FlaskFrameworkFactory that dispatch the V1 or V2 extension class depending on the base. Implements ISD283 (internal) for the flask-framework extension.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.