### PR TITLE
feat(extensions): add Django framework V2 extension and factory dispatch

### DIFF
--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -21,7 +21,7 @@ from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
 from .fastapi import FastAPIFramework
 from .go import GoFramework
-from .gunicorn import DjangoFramework, DjangoFrameworkV2, FlaskFramework, django_framework_factory
+from .gunicorn import DjangoFramework, DjangoFrameworkV2, FlaskFramework, DjangoFrameworkFactory
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
 
@@ -36,7 +36,7 @@ __all__ = [
     "DjangoFrameworkV2",
 ]
 
-register("django-framework", django_framework_factory)  # type: ignore[arg-type]
+register("django-framework", DjangoFrameworkFactory)  # type: ignore[arg-type]
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -21,7 +21,7 @@ from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
 from .fastapi import FastAPIFramework
 from .go import GoFramework
-from .gunicorn import DjangoFramework, FlaskFramework
+from .gunicorn import DjangoFramework, DjangoFrameworkFactory, DjangoFrameworkV2, FlaskFramework
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
 
@@ -32,9 +32,12 @@ __all__ = [
     "register",
     "unregister",
     "gen_logging_part",
+    "DjangoFramework",
+    "DjangoFrameworkV2",
+    "DjangoFrameworkFactory",
 ]
 
-register("django-framework", DjangoFramework)
+register("django-framework", DjangoFrameworkFactory())  # type: ignore[arg-type]
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -21,7 +21,7 @@ from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
 from .fastapi import FastAPIFramework
 from .go import GoFramework
-from .gunicorn import DjangoFramework, DjangoFrameworkFactory, DjangoFrameworkV2, FlaskFramework
+from .gunicorn import DjangoFramework, DjangoFrameworkV2, FlaskFramework, django_framework_factory
 from .registry import get_extension_class, get_extension_names, register, unregister
 from .springboot import SpringBootFramework
 
@@ -34,10 +34,9 @@ __all__ = [
     "gen_logging_part",
     "DjangoFramework",
     "DjangoFrameworkV2",
-    "DjangoFrameworkFactory",
 ]
 
-register("django-framework", DjangoFrameworkFactory())  # type: ignore[arg-type]
+register("django-framework", django_framework_factory)  # type: ignore[arg-type]
 register("expressjs-framework", ExpressJSFramework)
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -28,6 +28,25 @@ from craft_cli import emit
 from rockcraft import errors
 
 
+def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
+    """Extract and normalize all bases used in the project.
+
+    :param yaml_data: the raw yaml data.
+    :return: a set of base strings (e.g., {"ubuntu@24.04", "ubuntu@26.04"}).
+    """
+    bases: set[str] = set()
+
+    if base_str := yaml_data.get("base"):
+        bases.add(base_str)
+
+    if platforms := yaml_data.get("platforms", {}):
+        for label in platforms:
+            if "@" in label:
+                bases.add(label)
+
+    return bases
+
+
 class Extension(abc.ABC):
     """Extension is the class from which all extensions inherit.
 
@@ -114,6 +133,58 @@ class Extension(abc.ABC):
                 f"Extension has invalid part names: {invalid_parts!r}. "
                 "Format is <extension-name>/<part-name>"
             )
+
+
+class _FrameworkFactory:
+    """Route to a V1 or V2 extension class based on the project's target bases.
+
+    Instances are callable and expose get_supported_bases and is_experimental
+    so they can be registered and introspected like an Extension subclass.
+
+    The V2 class always supersedes V1 if the base is supported by the V2 class.
+    """
+
+    def __init__(self, v1_cls: type[Extension], v2_cls: type[Extension]) -> None:
+        """Store the V1 and V2 extension classes.
+
+        :param v1_cls: the V1 extension class.
+        :param v2_cls: the V2 extension class.
+        """
+        self._v1_cls = v1_cls
+        self._v2_cls = v2_cls
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Route to V1 or V2 based on project bases.
+
+        :param project_root: the project root directory.
+        :param yaml_data: the raw yaml data.
+        :return: an Extension instance from the appropriate version.
+        """
+        bases = get_project_bases(yaml_data)
+        if any(base in self._v2_cls.get_supported_bases() for base in bases):
+            return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+        return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
+
+    def get_supported_bases(self) -> tuple[str, ...]:
+        """Return merged supported bases from both V1 and V2, deduped and ordered.
+
+        :return: tuple of supported base strings.
+        """
+        return tuple(
+            dict.fromkeys(
+                self._v1_cls.get_supported_bases() + self._v2_cls.get_supported_bases()
+            )
+        )
+
+    def is_experimental(self, base: str | None) -> bool:
+        """Check if experimental, delegating to the class that supports the base.
+
+        :param base: the target base string or None.
+        :return: True if the base is experimental, False otherwise.
+        """
+        if base in self._v2_cls.get_supported_bases():
+            return self._v2_cls.is_experimental(base)
+        return self._v1_cls.is_experimental(base)
 
 
 def get_extensions_data_dir() -> Path:

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -46,7 +46,7 @@ from ._python_utils import (
 )
 from ._utils import find_ubuntu_base_python_version
 from .app_parts import gen_logging_part
-from .extension import Extension, get_extensions_data_dir
+from .extension import Extension, _FrameworkFactory, get_extensions_data_dir
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -539,7 +539,7 @@ class DjangoFrameworkV2(DjangoFramework):
 
     For now this is behaviourally identical to :class:`DjangoFramework`; it exists so the
     framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
-    supported base differs.
+    supported base and experimental status differs.
     """
 
     @staticmethod
@@ -548,27 +548,14 @@ class DjangoFrameworkV2(DjangoFramework):
         """Return supported bases."""
         return ("ubuntu@26.04",)
 
-
-class DjangoFrameworkFactory:
-    """Return the correct DjangoFramework extension for the project's base."""
-
-    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
-        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
-        if "26.04" in yaml_data.get("base", ""):
-            return DjangoFrameworkV2(project_root=project_root, yaml_data=yaml_data)
-        return DjangoFramework(project_root=project_root, yaml_data=yaml_data)
-
     @staticmethod
-    def get_supported_bases() -> tuple[str, ...]:
-        """Return the union of V1 and V2 supported bases."""
-        return tuple(
-            dict.fromkeys(
-                DjangoFramework.get_supported_bases()
-                + DjangoFrameworkV2.get_supported_bases()
-            )
-        )
+    @override
+    def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
+        """Indicate if the extension is in an experimental state.
 
-    @staticmethod
-    def is_experimental(base: str | None) -> bool:
-        """Return whether the extension is experimental for the given base."""
-        return DjangoFramework.is_experimental(base)
+        This is always True for V2
+        """
+        return True
+
+
+django_framework_factory = _FrameworkFactory(DjangoFramework, DjangoFrameworkV2)

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -550,7 +550,7 @@ class DjangoFrameworkV2(DjangoFramework):
 
     @staticmethod
     @override
-    def is_experimental(base: str | None) -> bool:  # noqa: ARG004 (unused arg)
+    def is_experimental(base: str | None) -> bool:
         """Indicate if the extension is in an experimental state.
 
         This is always True for V2

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -532,3 +532,43 @@ class DjangoFramework(_GunicornBase):
             )
         if not self.yaml_data.get("services", {}).get("django", {}).get("command"):
             self.wsgi_path  # noqa: B018 (unused expression, just checking for errors)
+
+
+class DjangoFrameworkV2(DjangoFramework):
+    """Extension for 12-factor Django applications targeting ubuntu@26.04.
+
+    For now this is behaviourally identical to :class:`DjangoFramework`; it exists so the
+    framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
+    supported base differs.
+    """
+
+    @staticmethod
+    @override
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return supported bases."""
+        return ("ubuntu@26.04",)
+
+
+class DjangoFrameworkFactory:
+    """Return the correct DjangoFramework extension for the project's base."""
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
+        if "26.04" in yaml_data.get("base", ""):
+            return DjangoFrameworkV2(project_root=project_root, yaml_data=yaml_data)
+        return DjangoFramework(project_root=project_root, yaml_data=yaml_data)
+
+    @staticmethod
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return the union of V1 and V2 supported bases."""
+        return tuple(
+            dict.fromkeys(
+                DjangoFramework.get_supported_bases()
+                + DjangoFrameworkV2.get_supported_bases()
+            )
+        )
+
+    @staticmethod
+    def is_experimental(base: str | None) -> bool:
+        """Return whether the extension is experimental for the given base."""
+        return DjangoFramework.is_experimental(base)

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -558,4 +558,4 @@ class DjangoFrameworkV2(DjangoFramework):
         return True
 
 
-django_framework_factory = _FrameworkFactory(DjangoFramework, DjangoFrameworkV2)
+DjangoFrameworkFactory = _FrameworkFactory(DjangoFramework, DjangoFrameworkV2)

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -40,7 +40,7 @@ def flask_input_yaml_fixture():
 @pytest.fixture
 def django_extension(mock_extensions, monkeypatch):
     monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
-    extensions.register("django-framework", extensions.django_framework_factory)  # type: ignore[arg-type]
+    extensions.register("django-framework", extensions.DjangoFrameworkFactory)  # type: ignore[arg-type]
 
 
 @pytest.fixture(name="django_input_yaml")
@@ -1004,7 +1004,7 @@ def test_django_extension_django_service_override_disable_wsgi_path_check(tmp_pa
 
 def test_django_factory_dispatch_v1(tmp_path):
     """Factory returns DjangoFramework (V1) for ubuntu@22.04."""
-    factory = extensions.django_framework_factory
+    factory = extensions.DjangoFrameworkFactory
     instance = factory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@22.04"},
@@ -1015,7 +1015,7 @@ def test_django_factory_dispatch_v1(tmp_path):
 
 def test_django_factory_dispatch_v2(tmp_path):
     """Factory returns DjangoFrameworkV2 for ubuntu@26.04."""
-    factory = extensions.django_framework_factory
+    factory = extensions.DjangoFrameworkFactory
     instance = factory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@26.04"},
@@ -1031,7 +1031,7 @@ def test_django_framework_v2_supported_bases():
 
 def test_django_factory_supported_bases():
     """Factory's supported bases include both V1 and V2 bases."""
-    bases = extensions.django_framework_factory.get_supported_bases()
+    bases = extensions.DjangoFrameworkFactory.get_supported_bases()
     assert "ubuntu@26.04" in bases
     assert "ubuntu@22.04" in bases
     assert "ubuntu@24.04" in bases

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -39,7 +39,8 @@ def flask_input_yaml_fixture():
 
 @pytest.fixture
 def django_extension(mock_extensions, monkeypatch):
-    extensions.register("django-framework", extensions.DjangoFrameworkFactory())  # type: ignore[arg-type]
+    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
+    extensions.register("django-framework", extensions.django_framework_factory)  # type: ignore[arg-type]
 
 
 @pytest.fixture(name="django_input_yaml")
@@ -997,13 +998,13 @@ def test_django_extension_django_service_override_disable_wsgi_path_check(tmp_pa
 
 
 # ---------------------------------------------------------------------------
-# DjangoFrameworkV2 / DjangoFrameworkFactory tests
+# DjangoFrameworkV2 / django_framework_factory tests
 # ---------------------------------------------------------------------------
 
 
 def test_django_factory_dispatch_v1(tmp_path):
     """Factory returns DjangoFramework (V1) for ubuntu@22.04."""
-    factory = extensions.DjangoFrameworkFactory()
+    factory = extensions.django_framework_factory
     instance = factory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@22.04"},
@@ -1014,7 +1015,7 @@ def test_django_factory_dispatch_v1(tmp_path):
 
 def test_django_factory_dispatch_v2(tmp_path):
     """Factory returns DjangoFrameworkV2 for ubuntu@26.04."""
-    factory = extensions.DjangoFrameworkFactory()
+    factory = extensions.django_framework_factory
     instance = factory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@26.04"},
@@ -1030,7 +1031,7 @@ def test_django_framework_v2_supported_bases():
 
 def test_django_factory_supported_bases():
     """Factory's supported bases include both V1 and V2 bases."""
-    bases = extensions.DjangoFrameworkFactory.get_supported_bases()
+    bases = extensions.django_framework_factory.get_supported_bases()
     assert "ubuntu@26.04" in bases
     assert "ubuntu@22.04" in bases
     assert "ubuntu@24.04" in bases

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -39,7 +39,7 @@ def flask_input_yaml_fixture():
 
 @pytest.fixture
 def django_extension(mock_extensions, monkeypatch):
-    extensions.register("django-framework", extensions.DjangoFramework)
+    extensions.register("django-framework", extensions.DjangoFrameworkFactory())  # type: ignore[arg-type]
 
 
 @pytest.fixture(name="django_input_yaml")
@@ -994,3 +994,156 @@ def test_django_extension_django_service_override_disable_wsgi_path_check(tmp_pa
     extensions.apply_extensions(tmp_path, input_yaml)
     extensions.apply_extensions(tmp_path, input_yaml)
     extensions.apply_extensions(tmp_path, input_yaml)
+
+
+# ---------------------------------------------------------------------------
+# DjangoFrameworkV2 / DjangoFrameworkFactory tests
+# ---------------------------------------------------------------------------
+
+
+def test_django_factory_dispatch_v1(tmp_path):
+    """Factory returns DjangoFramework (V1) for ubuntu@22.04."""
+    factory = extensions.DjangoFrameworkFactory()
+    instance = factory(
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@22.04"},
+    )
+    assert isinstance(instance, extensions.DjangoFramework)
+    assert not isinstance(instance, extensions.DjangoFrameworkV2)
+
+
+def test_django_factory_dispatch_v2(tmp_path):
+    """Factory returns DjangoFrameworkV2 for ubuntu@26.04."""
+    factory = extensions.DjangoFrameworkFactory()
+    instance = factory(
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@26.04"},
+    )
+    assert isinstance(instance, extensions.DjangoFrameworkV2)
+
+
+def test_django_framework_v2_supported_bases():
+    """DjangoFrameworkV2 only supports ubuntu@26.04."""
+    assert "ubuntu@26.04" in extensions.DjangoFrameworkV2.get_supported_bases()
+    assert "ubuntu@22.04" not in extensions.DjangoFrameworkV2.get_supported_bases()
+
+
+def test_django_factory_supported_bases():
+    """Factory's supported bases include both V1 and V2 bases."""
+    bases = extensions.DjangoFrameworkFactory.get_supported_bases()
+    assert "ubuntu@26.04" in bases
+    assert "ubuntu@22.04" in bases
+    assert "ubuntu@24.04" in bases
+
+
+@pytest.mark.usefixtures("django_extension")
+def test_django_extension_v2_default(tmp_path):
+    """Full apply on ubuntu@26.04 succeeds and produces the expected snippet."""
+    django_input_yaml = {
+        "name": "foo-bar",
+        "base": "ubuntu@26.04",
+        "platforms": {"amd64": {}},
+        "extensions": ["django-framework"],
+    }
+    (tmp_path / "requirements.txt").write_text("Django")
+    django_project_dir = tmp_path / "foo_bar" / "foo_bar"
+    django_project_dir.mkdir(parents=True)
+    (django_project_dir / "wsgi.py").write_text("application = object()")
+
+    applied = extensions.apply_extensions(tmp_path, django_input_yaml)
+
+    source = applied["parts"]["django-framework/config-files"]["source"]
+    del applied["parts"]["django-framework/config-files"]["source"]
+    suffix = "share/rockcraft/extensions/django-framework"
+    assert source[-len(suffix) :].replace("\\", "/") == suffix
+
+    assert applied == {
+        "name": "foo-bar",
+        "base": "ubuntu@26.04",
+        "parts": {
+            "django-framework/config-files": {
+                "organize": {"gunicorn.conf.py": "django/gunicorn.conf.py"},
+                "plugin": "dump",
+                "permissions": [
+                    {
+                        "path": "django/gunicorn.conf.py",
+                        "owner": 584792,
+                        "group": 584792,
+                    },
+                ],
+            },
+            "django-framework/dependencies": {
+                "plugin": "python",
+                "python-packages": ["gunicorn~=23.0"],
+                "python-requirements": ["requirements.txt"],
+                "source": ".",
+                "stage-packages": ["python3-venv"],
+                "build-environment": [],
+            },
+            "django-framework/install-app": {
+                "organize": {"*": "django/app/", ".*": "django/app/"},
+                "plugin": "dump",
+                "source": "foo_bar",
+                "stage": ["-django/app/db.sqlite3"],
+                "permissions": [
+                    {
+                        "owner": 584792,
+                        "group": 584792,
+                    },
+                ],
+            },
+            "django-framework/runtime": {
+                "plugin": "nil",
+                "stage-packages": ["ca-certificates_data"],
+            },
+            "django-framework/logging": {
+                "plugin": "nil",
+                "override-build": (
+                    "craftctl default\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/opt/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/etc/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/var/log/django"
+                ),
+                "permissions": [
+                    {"path": "opt/promtail", "owner": 584792, "group": 584792},
+                    {"path": "etc/promtail", "owner": 584792, "group": 584792},
+                    {
+                        "path": "var/log/django",
+                        "owner": 584792,
+                        "group": 584792,
+                    },
+                ],
+            },
+            "django-framework/statsd-exporter": {
+                "build-snaps": ["go"],
+                "plugin": "go",
+                "source": "https://github.com/prometheus/statsd_exporter.git",
+                "source-tag": "v0.26.0",
+            },
+        },
+        "platforms": {"amd64": {}},
+        "run_user": "_daemon_",
+        "services": {
+            "django": {
+                "after": ["statsd-exporter"],
+                "command": (
+                    "/bin/python3 -m gunicorn -c /django/gunicorn.conf.py "
+                    "'foo_bar.wsgi:application' -k [ sync ]"
+                ),
+                "override": "replace",
+                "startup": "enabled",
+                "user": "_daemon_",
+            },
+            "statsd-exporter": {
+                "command": (
+                    "/bin/statsd_exporter --statsd.mapping-config=/statsd-mapping.conf "
+                    "--statsd.listen-udp=localhost:9125 "
+                    "--statsd.listen-tcp=localhost:9125"
+                ),
+                "override": "merge",
+                "startup": "enabled",
+                "summary": "statsd exporter service",
+                "user": "_daemon_",
+            },
+        },
+    }


### PR DESCRIPTION
Add DjangoFrameworkV2 (targets ubuntu@26.04, inherits DjangoFramework) and a DjangoFrameworkFactory that dispatch the V1 or V2 extension class depending on the base. Implements ISD283 (internal) for the django-framework extension.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.