### PR TITLE
feat(extensions): add FastAPI framework V2 extension and factory dispatch

### DIFF
--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -19,7 +19,7 @@
 from ._utils import apply_extensions
 from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
-from .fastapi import FastAPIFramework, FastAPIFrameworkFactory, FastAPIFrameworkV2
+from .fastapi import FastAPIFramework, FastAPIFrameworkV2, fastapi_framework_factory
 from .go import GoFramework
 from .gunicorn import DjangoFramework, FlaskFramework
 from .registry import get_extension_class, get_extension_names, register, unregister
@@ -34,12 +34,11 @@ __all__ = [
     "gen_logging_part",
     "FastAPIFramework",
     "FastAPIFrameworkV2",
-    "FastAPIFrameworkFactory",
 ]
 
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
-register("fastapi-framework", FastAPIFrameworkFactory())  # type: ignore[arg-type]
+register("fastapi-framework", fastapi_framework_factory)  # type: ignore[arg-type]
 register("flask-framework", FlaskFramework)
 register("go-framework", GoFramework)
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -19,7 +19,7 @@
 from ._utils import apply_extensions
 from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
-from .fastapi import FastAPIFramework
+from .fastapi import FastAPIFramework, FastAPIFrameworkFactory, FastAPIFrameworkV2
 from .go import GoFramework
 from .gunicorn import DjangoFramework, FlaskFramework
 from .registry import get_extension_class, get_extension_names, register, unregister
@@ -32,11 +32,14 @@ __all__ = [
     "register",
     "unregister",
     "gen_logging_part",
+    "FastAPIFramework",
+    "FastAPIFrameworkV2",
+    "FastAPIFrameworkFactory",
 ]
 
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
-register("fastapi-framework", FastAPIFramework)
+register("fastapi-framework", FastAPIFrameworkFactory())  # type: ignore[arg-type]
 register("flask-framework", FlaskFramework)
 register("go-framework", GoFramework)
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -19,7 +19,7 @@
 from ._utils import apply_extensions
 from .app_parts import gen_logging_part
 from .expressjs import ExpressJSFramework
-from .fastapi import FastAPIFramework, FastAPIFrameworkV2, fastapi_framework_factory
+from .fastapi import FastAPIFramework, FastAPIFrameworkV2, FastAPIFrameworkFactory
 from .go import GoFramework
 from .gunicorn import DjangoFramework, FlaskFramework
 from .registry import get_extension_class, get_extension_names, register, unregister
@@ -38,7 +38,7 @@ __all__ = [
 
 register("django-framework", DjangoFramework)
 register("expressjs-framework", ExpressJSFramework)
-register("fastapi-framework", fastapi_framework_factory)  # type: ignore[arg-type]
+register("fastapi-framework", FastAPIFrameworkFactory)  # type: ignore[arg-type]
 register("flask-framework", FlaskFramework)
 register("go-framework", GoFramework)
 register("spring-boot-framework", SpringBootFramework)

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -28,6 +28,25 @@ from craft_cli import emit
 from rockcraft import errors
 
 
+def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
+    """Extract and normalize all bases used in the project.
+
+    :param yaml_data: the raw yaml data.
+    :return: a set of base strings (e.g., {"ubuntu@24.04", "ubuntu@26.04"}).
+    """
+    bases: set[str] = set()
+
+    if base_str := yaml_data.get("base"):
+        bases.add(base_str)
+
+    if platforms := yaml_data.get("platforms", {}):
+        for label in platforms:
+            if "@" in label:
+                bases.add(label)
+
+    return bases
+
+
 class Extension(abc.ABC):
     """Extension is the class from which all extensions inherit.
 
@@ -114,6 +133,58 @@ class Extension(abc.ABC):
                 f"Extension has invalid part names: {invalid_parts!r}. "
                 "Format is <extension-name>/<part-name>"
             )
+
+
+class _FrameworkFactory:
+    """Route to a V1 or V2 extension class based on the project's target bases.
+
+    Instances are callable and expose get_supported_bases and is_experimental
+    so they can be registered and introspected like an Extension subclass.
+
+    The V2 class always supersedes V1 if the base is supported by the V2 class.
+    """
+
+    def __init__(self, v1_cls: type[Extension], v2_cls: type[Extension]) -> None:
+        """Store the V1 and V2 extension classes.
+
+        :param v1_cls: the V1 extension class.
+        :param v2_cls: the V2 extension class.
+        """
+        self._v1_cls = v1_cls
+        self._v2_cls = v2_cls
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Route to V1 or V2 based on project bases.
+
+        :param project_root: the project root directory.
+        :param yaml_data: the raw yaml data.
+        :return: an Extension instance from the appropriate version.
+        """
+        bases = get_project_bases(yaml_data)
+        if any(base in self._v2_cls.get_supported_bases() for base in bases):
+            return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+        return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
+
+    def get_supported_bases(self) -> tuple[str, ...]:
+        """Return merged supported bases from both V1 and V2, deduped and ordered.
+
+        :return: tuple of supported base strings.
+        """
+        return tuple(
+            dict.fromkeys(
+                self._v1_cls.get_supported_bases() + self._v2_cls.get_supported_bases()
+            )
+        )
+
+    def is_experimental(self, base: str | None) -> bool:
+        """Check if experimental, delegating to the class that supports the base.
+
+        :param base: the target base string or None.
+        :return: True if the base is experimental, False otherwise.
+        """
+        if base in self._v2_cls.get_supported_bases():
+            return self._v2_cls.is_experimental(base)
+        return self._v1_cls.is_experimental(base)
 
 
 def get_extensions_data_dir() -> Path:

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -21,7 +21,6 @@ import os
 import pathlib
 import posixpath
 import re
-from pathlib import Path
 from typing import Any
 
 from typing_extensions import override

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -21,6 +21,7 @@ import os
 import pathlib
 import posixpath
 import re
+from pathlib import Path
 from typing import Any
 
 from typing_extensions import override
@@ -294,3 +295,43 @@ class FastAPIFramework(Extension):
         except SyntaxError as e:
             return [f"Syntax error in  python file in ASGI search path: {e}"]
         return []
+
+
+class FastAPIFrameworkV2(FastAPIFramework):
+    """Extension for 12-factor FastAPI applications targeting ubuntu@26.04.
+
+    For now this is behaviourally identical to :class:`FastAPIFramework`; it exists so the
+    framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
+    supported base differs.
+    """
+
+    @staticmethod
+    @override
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return supported bases."""
+        return ("ubuntu@26.04",)
+
+
+class FastAPIFrameworkFactory:
+    """Return the correct FastAPIFramework extension for the project's base."""
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> "Extension":
+        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
+        if "26.04" in yaml_data.get("base", ""):
+            return FastAPIFrameworkV2(project_root=project_root, yaml_data=yaml_data)
+        return FastAPIFramework(project_root=project_root, yaml_data=yaml_data)
+
+    @staticmethod
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return the union of V1 and V2 supported bases."""
+        return tuple(
+            dict.fromkeys(
+                FastAPIFramework.get_supported_bases()
+                + FastAPIFrameworkV2.get_supported_bases()
+            )
+        )
+
+    @staticmethod
+    def is_experimental(base: str | None) -> bool:
+        """Return whether the extension is experimental for the given base."""
+        return FastAPIFramework.is_experimental(base)

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -32,7 +32,7 @@ from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from ._python_utils import has_global_variable
 from .app_parts import gen_logging_part
-from .extension import Extension
+from .extension import Extension, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -302,7 +302,7 @@ class FastAPIFrameworkV2(FastAPIFramework):
 
     For now this is behaviourally identical to :class:`FastAPIFramework`; it exists so the
     framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
-    supported base differs.
+    supported base and experimental status differs.
     """
 
     @staticmethod
@@ -311,27 +311,14 @@ class FastAPIFrameworkV2(FastAPIFramework):
         """Return supported bases."""
         return ("ubuntu@26.04",)
 
-
-class FastAPIFrameworkFactory:
-    """Return the correct FastAPIFramework extension for the project's base."""
-
-    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> "Extension":
-        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
-        if "26.04" in yaml_data.get("base", ""):
-            return FastAPIFrameworkV2(project_root=project_root, yaml_data=yaml_data)
-        return FastAPIFramework(project_root=project_root, yaml_data=yaml_data)
-
     @staticmethod
-    def get_supported_bases() -> tuple[str, ...]:
-        """Return the union of V1 and V2 supported bases."""
-        return tuple(
-            dict.fromkeys(
-                FastAPIFramework.get_supported_bases()
-                + FastAPIFrameworkV2.get_supported_bases()
-            )
-        )
-
-    @staticmethod
+    @override
     def is_experimental(base: str | None) -> bool:
-        """Return whether the extension is experimental for the given base."""
-        return FastAPIFramework.is_experimental(base)
+        """Indicate if the extension is in an experimental state.
+
+        This is always True for V2
+        """
+        return True
+
+
+fastapi_framework_factory = _FrameworkFactory(FastAPIFramework, FastAPIFrameworkV2)

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -321,4 +321,4 @@ class FastAPIFrameworkV2(FastAPIFramework):
         return True
 
 
-fastapi_framework_factory = _FrameworkFactory(FastAPIFramework, FastAPIFrameworkV2)
+FastAPIFrameworkFactory = _FrameworkFactory(FastAPIFramework, FastAPIFrameworkV2)

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -30,7 +30,7 @@ def fastapi_input_yaml_fixture():
 
 @pytest.fixture
 def fastapi_extension(mock_extensions):
-    extensions.register("fastapi-framework", extensions.fastapi_framework_factory)  # type: ignore[arg-type]
+    extensions.register("fastapi-framework", extensions.FastAPIFrameworkFactory)  # type: ignore[arg-type]
 
 
 @pytest.mark.usefixtures("fastapi_extension")
@@ -335,7 +335,7 @@ def test_fastapi_extension_incorrect_prime_prefix_error(tmp_path, fastapi_input_
 
 def test_factory_dispatch_v1(tmp_path):
     """Factory returns FastAPIFramework (V1) for ubuntu@24.04."""
-    instance = extensions.fastapi_framework_factory(
+    instance = extensions.FastAPIFrameworkFactory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"}
     )
     assert isinstance(instance, extensions.FastAPIFramework)
@@ -344,7 +344,7 @@ def test_factory_dispatch_v1(tmp_path):
 
 def test_factory_dispatch_v2(tmp_path):
     """Factory returns FastAPIFrameworkV2 for ubuntu@26.04."""
-    instance = extensions.fastapi_framework_factory(
+    instance = extensions.FastAPIFrameworkFactory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
     )
     assert isinstance(instance, extensions.FastAPIFrameworkV2)
@@ -357,14 +357,14 @@ def test_v2_supported_bases():
 
 def test_factory_supported_bases():
     """fastapi_framework_factory includes both V1 and V2 bases."""
-    factory_bases = extensions.fastapi_framework_factory.get_supported_bases()
+    factory_bases = extensions.FastAPIFrameworkFactory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
     for base in extensions.FastAPIFramework.get_supported_bases():
         assert base in factory_bases
 
 
-def test_fastapi_framework_factory_is_experimental():
-    factory = extensions.fastapi_framework_factory
+def test_FastAPIFrameworkFactory_is_experimental():
+    factory = extensions.FastAPIFrameworkFactory
     assert factory.is_experimental("ubuntu@26.04") is True
     assert factory.is_experimental("ubuntu@24.04") is False
     assert factory.is_experimental("bare") is False

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -30,7 +30,7 @@ def fastapi_input_yaml_fixture():
 
 @pytest.fixture
 def fastapi_extension(mock_extensions):
-    extensions.register("fastapi-framework", extensions.FastAPIFrameworkFactory())  # type: ignore[arg-type]
+    extensions.register("fastapi-framework", extensions.fastapi_framework_factory)  # type: ignore[arg-type]
 
 
 @pytest.mark.usefixtures("fastapi_extension")
@@ -335,7 +335,7 @@ def test_fastapi_extension_incorrect_prime_prefix_error(tmp_path, fastapi_input_
 
 def test_factory_dispatch_v1(tmp_path):
     """Factory returns FastAPIFramework (V1) for ubuntu@24.04."""
-    instance = extensions.FastAPIFrameworkFactory()(
+    instance = extensions.fastapi_framework_factory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"}
     )
     assert isinstance(instance, extensions.FastAPIFramework)
@@ -344,7 +344,7 @@ def test_factory_dispatch_v1(tmp_path):
 
 def test_factory_dispatch_v2(tmp_path):
     """Factory returns FastAPIFrameworkV2 for ubuntu@26.04."""
-    instance = extensions.FastAPIFrameworkFactory()(
+    instance = extensions.fastapi_framework_factory(
         project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
     )
     assert isinstance(instance, extensions.FastAPIFrameworkV2)
@@ -356,16 +356,44 @@ def test_v2_supported_bases():
 
 
 def test_factory_supported_bases():
-    """FastAPIFrameworkFactory includes both V1 and V2 bases."""
-    factory_bases = extensions.FastAPIFrameworkFactory.get_supported_bases()
+    """fastapi_framework_factory includes both V1 and V2 bases."""
+    factory_bases = extensions.fastapi_framework_factory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
     for base in extensions.FastAPIFramework.get_supported_bases():
         assert base in factory_bases
 
 
+def test_fastapi_framework_factory_is_experimental():
+    factory = extensions.fastapi_framework_factory
+    assert factory.is_experimental("ubuntu@26.04") is True
+    assert factory.is_experimental("ubuntu@24.04") is False
+    assert factory.is_experimental("bare") is False
+
+
+def test_v2_is_experimental():
+    """FastAPIFrameworkV2 is experimental."""
+    assert extensions.FastAPIFrameworkV2.is_experimental("ubuntu@26.04") is True
+
+
 @pytest.mark.usefixtures("fastapi_extension")
-def test_fastapi_extension_default_26_04(tmp_path):
+def test_fastapi_extension_26_04_experimental_no_env(tmp_path):
+    """Test that V2 extension requires experimental env var."""
+    (tmp_path / "requirements.txt").write_text("fastapi")
+    (tmp_path / "app.py").write_text("app = object()")
+    input_yaml = {
+        "name": "foo-bar",
+        "base": "ubuntu@26.04",
+        "platforms": {"amd64": {}},
+        "extensions": ["fastapi-framework"],
+    }
+    with pytest.raises(ExtensionError, match="Extension is experimental"):
+        extensions.apply_extensions(tmp_path, input_yaml)
+
+
+@pytest.mark.usefixtures("fastapi_extension")
+def test_fastapi_extension_default_26_04(tmp_path, monkeypatch):
     """Full apply on ubuntu@26.04 yields the same output as 24.04 but with a 26.04 base."""
+    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
     (tmp_path / "requirements.txt").write_text("fastapi")
     (tmp_path / "app.py").write_text("app = object()")
     input_yaml = {

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -30,7 +30,7 @@ def fastapi_input_yaml_fixture():
 
 @pytest.fixture
 def fastapi_extension(mock_extensions):
-    extensions.register("fastapi-framework", extensions.FastAPIFramework)
+    extensions.register("fastapi-framework", extensions.FastAPIFrameworkFactory())  # type: ignore[arg-type]
 
 
 @pytest.mark.usefixtures("fastapi_extension")
@@ -331,3 +331,101 @@ def test_fastapi_extension_incorrect_prime_prefix_error(tmp_path, fastapi_input_
         extensions.apply_extensions(tmp_path, fastapi_input_yaml)
     assert "start with app/" in str(exc)
     assert "start with app/" in str(exc)
+
+
+def test_factory_dispatch_v1(tmp_path):
+    """Factory returns FastAPIFramework (V1) for ubuntu@24.04."""
+    instance = extensions.FastAPIFrameworkFactory()(
+        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"}
+    )
+    assert isinstance(instance, extensions.FastAPIFramework)
+    assert not isinstance(instance, extensions.FastAPIFrameworkV2)
+
+
+def test_factory_dispatch_v2(tmp_path):
+    """Factory returns FastAPIFrameworkV2 for ubuntu@26.04."""
+    instance = extensions.FastAPIFrameworkFactory()(
+        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
+    )
+    assert isinstance(instance, extensions.FastAPIFrameworkV2)
+
+
+def test_v2_supported_bases():
+    """FastAPIFrameworkV2 supports ubuntu@26.04."""
+    assert "ubuntu@26.04" in extensions.FastAPIFrameworkV2.get_supported_bases()
+
+
+def test_factory_supported_bases():
+    """FastAPIFrameworkFactory includes both V1 and V2 bases."""
+    factory_bases = extensions.FastAPIFrameworkFactory.get_supported_bases()
+    assert "ubuntu@26.04" in factory_bases
+    for base in extensions.FastAPIFramework.get_supported_bases():
+        assert base in factory_bases
+
+
+@pytest.mark.usefixtures("fastapi_extension")
+def test_fastapi_extension_default_26_04(tmp_path):
+    """Full apply on ubuntu@26.04 yields the same output as 24.04 but with a 26.04 base."""
+    (tmp_path / "requirements.txt").write_text("fastapi")
+    (tmp_path / "app.py").write_text("app = object()")
+    input_yaml = {
+        "name": "foo-bar",
+        "base": "ubuntu@26.04",
+        "platforms": {"amd64": {}},
+        "extensions": ["fastapi-framework"],
+    }
+    applied = extensions.apply_extensions(tmp_path, input_yaml)
+
+    assert applied == {
+        "base": "ubuntu@26.04",
+        "name": "foo-bar",
+        "platforms": {"amd64": {}},
+        "run_user": "_daemon_",
+        "parts": {
+            "fastapi-framework/dependencies": {
+                "build-environment": [],
+                "plugin": "python",
+                "stage-packages": ["python3-venv"],
+                "source": ".",
+                "python-packages": ["uvicorn"],
+                "python-requirements": ["requirements.txt"],
+            },
+            "fastapi-framework/install-app": {
+                "plugin": "dump",
+                "source": ".",
+                "organize": {
+                    "app.py": "app/app.py",
+                },
+                "stage": ["app/app.py"],
+                "permissions": [{"owner": 584792, "group": 584792}],
+            },
+            "fastapi-framework/runtime": {
+                "plugin": "nil",
+                "stage-packages": ["ca-certificates_data"],
+            },
+            "fastapi-framework/logging": {
+                "plugin": "nil",
+                "override-build": (
+                    "craftctl default\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/opt/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/etc/promtail"
+                ),
+                "permissions": [
+                    {"path": "opt/promtail", "owner": 584792, "group": 584792},
+                    {"path": "etc/promtail", "owner": 584792, "group": 584792},
+                ],
+            },
+        },
+        "services": {
+            "fastapi": {
+                "command": "/bin/python3 -m uvicorn app:app",
+                "override": "replace",
+                "startup": "enabled",
+                "user": "_daemon_",
+                "working-dir": "/app",
+                "environment": {
+                    "UVICORN_HOST": "0.0.0.0",  # noqa: S104
+                },
+            },
+        },
+    }


### PR DESCRIPTION
Add FastAPIFrameworkV2 (targets ubuntu@26.04, inherits FastAPIFramework) and a FastAPIFrameworkFactory that dispatch the V1 or V2 extension class depending on the base. Implements ISD283 (internal) for the fastapi-framework extension.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.