### PR TITLE
feat(extensions): add ExpressJS framework V2 extension and factory dispatch

### DIFF
--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -18,7 +18,7 @@
 
 from ._utils import apply_extensions
 from .app_parts import gen_logging_part
-from .expressjs import ExpressJSFramework, ExpressJSFrameworkFactory, ExpressJSFrameworkV2
+from .expressjs import ExpressJSFramework, ExpressJSFrameworkV2, expressjs_framework_factory
 from .fastapi import FastAPIFramework
 from .go import GoFramework
 from .gunicorn import DjangoFramework, FlaskFramework
@@ -34,11 +34,10 @@ __all__ = [
     "gen_logging_part",
     "ExpressJSFramework",
     "ExpressJSFrameworkV2",
-    "ExpressJSFrameworkFactory",
 ]
 
 register("django-framework", DjangoFramework)
-register("expressjs-framework", ExpressJSFrameworkFactory())  # type: ignore[arg-type]
+register("expressjs-framework", expressjs_framework_factory)  # type: ignore[arg-type]
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)
 register("go-framework", GoFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -18,7 +18,7 @@
 
 from ._utils import apply_extensions
 from .app_parts import gen_logging_part
-from .expressjs import ExpressJSFramework
+from .expressjs import ExpressJSFramework, ExpressJSFrameworkFactory, ExpressJSFrameworkV2
 from .fastapi import FastAPIFramework
 from .go import GoFramework
 from .gunicorn import DjangoFramework, FlaskFramework
@@ -32,10 +32,13 @@ __all__ = [
     "register",
     "unregister",
     "gen_logging_part",
+    "ExpressJSFramework",
+    "ExpressJSFrameworkV2",
+    "ExpressJSFrameworkFactory",
 ]
 
 register("django-framework", DjangoFramework)
-register("expressjs-framework", ExpressJSFramework)
+register("expressjs-framework", ExpressJSFrameworkFactory())  # type: ignore[arg-type]
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)
 register("go-framework", GoFramework)

--- a/rockcraft/extensions/__init__.py
+++ b/rockcraft/extensions/__init__.py
@@ -18,7 +18,7 @@
 
 from ._utils import apply_extensions
 from .app_parts import gen_logging_part
-from .expressjs import ExpressJSFramework, ExpressJSFrameworkV2, expressjs_framework_factory
+from .expressjs import ExpressJSFramework, ExpressJSFrameworkFactory, ExpressJSFrameworkV2
 from .fastapi import FastAPIFramework
 from .go import GoFramework
 from .gunicorn import DjangoFramework, FlaskFramework
@@ -37,7 +37,7 @@ __all__ = [
 ]
 
 register("django-framework", DjangoFramework)
-register("expressjs-framework", expressjs_framework_factory)  # type: ignore[arg-type]
+register("expressjs-framework", ExpressJSFrameworkFactory)  # type: ignore[arg-type]
 register("fastapi-framework", FastAPIFramework)
 register("flask-framework", FlaskFramework)
 register("go-framework", GoFramework)

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -26,7 +26,7 @@ from rockcraft.errors import ExtensionError
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from .app_parts import gen_logging_part
-from .extension import Extension
+from .extension import Extension, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -258,7 +258,7 @@ class ExpressJSFrameworkV2(ExpressJSFramework):
 
     For now this is behaviourally identical to :class:`ExpressJSFramework`; it exists so the
     framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
-    supported base differs.
+    supported base and experimental status differs.
     """
 
     @staticmethod
@@ -267,29 +267,14 @@ class ExpressJSFrameworkV2(ExpressJSFramework):
         """Return supported bases."""
         return ("ubuntu@26.04",)
 
-
-class ExpressJSFrameworkFactory:
-    """Return the correct ExpressJSFramework extension for the project's base."""
-
-    def __call__(
-        self, *, project_root: Path, yaml_data: dict[str, Any]
-    ) -> Extension:
-        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
-        if "26.04" in yaml_data.get("base", ""):
-            return ExpressJSFrameworkV2(project_root=project_root, yaml_data=yaml_data)
-        return ExpressJSFramework(project_root=project_root, yaml_data=yaml_data)
-
     @staticmethod
-    def get_supported_bases() -> tuple[str, ...]:
-        """Return the union of V1 and V2 supported bases."""
-        return tuple(
-            dict.fromkeys(
-                ExpressJSFramework.get_supported_bases()
-                + ExpressJSFrameworkV2.get_supported_bases()
-            )
-        )
-
-    @staticmethod
+    @override
     def is_experimental(base: str | None) -> bool:
-        """Return whether the extension is experimental for the given base."""
-        return ExpressJSFramework.is_experimental(base)
+        """Indicate if the extension is in an experimental state.
+
+        This is always True for V2.
+        """
+        return True
+
+
+expressjs_framework_factory = _FrameworkFactory(ExpressJSFramework, ExpressJSFrameworkV2)

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -17,7 +17,6 @@
 """An extension for the NodeJS based Javascript application extension."""
 
 import json
-from pathlib import Path
 from typing import Any, cast
 
 from typing_extensions import override

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -17,6 +17,7 @@
 """An extension for the NodeJS based Javascript application extension."""
 
 import json
+from pathlib import Path
 from typing import Any, cast
 
 from typing_extensions import override
@@ -250,3 +251,45 @@ class ExpressJSFramework(Extension):
     def _app_name(self) -> str:
         """Return the application name as defined on package.json."""
         return self._app_package_json["name"]
+
+
+class ExpressJSFrameworkV2(ExpressJSFramework):
+    """Extension for 12-factor ExpressJS applications targeting ubuntu@26.04.
+
+    For now this is behaviourally identical to :class:`ExpressJSFramework`; it exists so the
+    framework can dispatch to a paas-charm 2.0 implementation in the future. Only the
+    supported base differs.
+    """
+
+    @staticmethod
+    @override
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return supported bases."""
+        return ("ubuntu@26.04",)
+
+
+class ExpressJSFrameworkFactory:
+    """Return the correct ExpressJSFramework extension for the project's base."""
+
+    def __call__(
+        self, *, project_root: Path, yaml_data: dict[str, Any]
+    ) -> Extension:
+        """Dispatch to the V2 extension for ubuntu@26.04, otherwise V1."""
+        if "26.04" in yaml_data.get("base", ""):
+            return ExpressJSFrameworkV2(project_root=project_root, yaml_data=yaml_data)
+        return ExpressJSFramework(project_root=project_root, yaml_data=yaml_data)
+
+    @staticmethod
+    def get_supported_bases() -> tuple[str, ...]:
+        """Return the union of V1 and V2 supported bases."""
+        return tuple(
+            dict.fromkeys(
+                ExpressJSFramework.get_supported_bases()
+                + ExpressJSFrameworkV2.get_supported_bases()
+            )
+        )
+
+    @staticmethod
+    def is_experimental(base: str | None) -> bool:
+        """Return whether the extension is experimental for the given base."""
+        return ExpressJSFramework.is_experimental(base)

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -277,4 +277,4 @@ class ExpressJSFrameworkV2(ExpressJSFramework):
         return True
 
 
-expressjs_framework_factory = _FrameworkFactory(ExpressJSFramework, ExpressJSFrameworkV2)
+ExpressJSFrameworkFactory = _FrameworkFactory(ExpressJSFramework, ExpressJSFrameworkV2)

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -28,6 +28,25 @@ from craft_cli import emit
 from rockcraft import errors
 
 
+def get_project_bases(yaml_data: dict[str, Any]) -> set[str]:
+    """Extract and normalize all bases used in the project.
+
+    :param yaml_data: the raw yaml data.
+    :return: a set of base strings (e.g., {"ubuntu@24.04", "ubuntu@26.04"}).
+    """
+    bases: set[str] = set()
+
+    if base_str := yaml_data.get("base"):
+        bases.add(base_str)
+
+    if platforms := yaml_data.get("platforms", {}):
+        for label in platforms:
+            if "@" in label:
+                bases.add(label)
+
+    return bases
+
+
 class Extension(abc.ABC):
     """Extension is the class from which all extensions inherit.
 
@@ -114,6 +133,58 @@ class Extension(abc.ABC):
                 f"Extension has invalid part names: {invalid_parts!r}. "
                 "Format is <extension-name>/<part-name>"
             )
+
+
+class _FrameworkFactory:
+    """Route to a V1 or V2 extension class based on the project's target bases.
+
+    Instances are callable and expose get_supported_bases and is_experimental
+    so they can be registered and introspected like an Extension subclass.
+
+    The V2 class always supersedes V1 if the base is supported by the V2 class.
+    """
+
+    def __init__(self, v1_cls: type[Extension], v2_cls: type[Extension]) -> None:
+        """Store the V1 and V2 extension classes.
+
+        :param v1_cls: the V1 extension class.
+        :param v2_cls: the V2 extension class.
+        """
+        self._v1_cls = v1_cls
+        self._v2_cls = v2_cls
+
+    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+        """Route to V1 or V2 based on project bases.
+
+        :param project_root: the project root directory.
+        :param yaml_data: the raw yaml data.
+        :return: an Extension instance from the appropriate version.
+        """
+        bases = get_project_bases(yaml_data)
+        if any(base in self._v2_cls.get_supported_bases() for base in bases):
+            return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+        return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
+
+    def get_supported_bases(self) -> tuple[str, ...]:
+        """Return merged supported bases from both V1 and V2, deduped and ordered.
+
+        :return: tuple of supported base strings.
+        """
+        return tuple(
+            dict.fromkeys(
+                self._v1_cls.get_supported_bases() + self._v2_cls.get_supported_bases()
+            )
+        )
+
+    def is_experimental(self, base: str | None) -> bool:
+        """Check if experimental, delegating to the class that supports the base.
+
+        :param base: the target base string or None.
+        :return: True if the base is experimental, False otherwise.
+        """
+        if base in self._v2_cls.get_supported_bases():
+            return self._v2_cls.is_experimental(base)
+        return self._v1_cls.is_experimental(base)
 
 
 def get_extensions_data_dir() -> Path:

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -33,7 +33,7 @@ def expressjs_input_yaml_fixture():
 
 @pytest.fixture
 def expressjs_extension(mock_extensions):
-    extensions.register("expressjs-framework", extensions.ExpressJSFramework)
+    extensions.register("expressjs-framework", extensions.ExpressJSFrameworkFactory())  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -393,3 +393,93 @@ def test_expressjs_invalid_package_json_scripts_error(
         str(exc.value.doc_slug)
         == "/reference/extensions/express-framework/#project-requirements"
     )
+
+
+def test_expressjs_factory_dispatch(tmp_path):
+    factory = extensions.ExpressJSFrameworkFactory()
+
+    v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
+    assert isinstance(v1, extensions.ExpressJSFramework)
+    assert not isinstance(v1, extensions.ExpressJSFrameworkV2)
+
+    v2 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"})
+    assert isinstance(v2, extensions.ExpressJSFrameworkV2)
+
+
+def test_expressjs_v2_and_factory_supported_bases():
+    assert "ubuntu@26.04" in extensions.ExpressJSFrameworkV2.get_supported_bases()
+
+    factory_bases = extensions.ExpressJSFrameworkFactory.get_supported_bases()
+    assert "ubuntu@26.04" in factory_bases
+    # V1 bases must also be present
+    for base in extensions.ExpressJSFramework.get_supported_bases():
+        assert base in factory_bases
+
+
+@pytest.mark.usefixtures("expressjs_extension", "package_json_file")
+def test_expressjs_extension_ubuntu2604_default(tmp_path, expressjs_input_yaml):
+    expressjs_input_yaml["base"] = "ubuntu@26.04"
+    expressjs_input_yaml["parts"] = {
+        "expressjs-framework/install-app": {
+            "npm-include-node": False,
+            "npm-node-version": None,
+        }
+    }
+    applied = extensions.apply_extensions(tmp_path, expressjs_input_yaml)
+
+    expected = {
+        "base": "ubuntu@26.04",
+        "build-base": "ubuntu@24.04",
+        "name": "foo-bar",
+        "platforms": {"amd64": {}},
+        "run-user": "_daemon_",
+        "parts": {
+            "expressjs-framework/install-app": {
+                "plugin": "npm",
+                "source": "app/",
+                "npm-include-node": False,
+                "npm-node-version": None,
+                "override-build": (
+                    "rm -rf node_modules\n"
+                    "craftctl default\n"
+                    "npm config set script-shell=bash --location project\n"
+                    "cp ${CRAFT_PART_BUILD}/.npmrc ${CRAFT_PART_INSTALL}/lib/node_modules/"
+                    f"{_expressjs_project_name}/.npmrc\n"
+                    f"chown -R 584792:584792 ${{CRAFT_PART_INSTALL}}/lib/node_modules/{_expressjs_project_name}\n"
+                    f"ln -s /lib/node_modules/{_expressjs_project_name} "
+                    "${CRAFT_PART_INSTALL}/app\n"
+                    "chown -R 584792:584792 ${CRAFT_PART_INSTALL}/app\n"
+                ),
+                "build-packages": ["nodejs", "npm"],
+                "stage-packages": ["ca-certificates_data", "nodejs_bins"],
+                "build-environment": [{"UV_USE_IO_URING": "0"}],
+            },
+            "expressjs-framework/runtime": {
+                "plugin": "nil",
+                "stage-packages": ["npm"],
+            },
+            "expressjs-framework/logging": {
+                "plugin": "nil",
+                "override-build": (
+                    "craftctl default\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/opt/promtail\n"
+                    "mkdir -p $CRAFT_PART_INSTALL/etc/promtail"
+                ),
+                "permissions": [
+                    {"path": "opt/promtail", "owner": 584792, "group": 584792},
+                    {"path": "etc/promtail", "owner": 584792, "group": 584792},
+                ],
+            },
+        },
+        "services": {
+            "expressjs": {
+                "override": "replace",
+                "startup": "enabled",
+                "user": "_daemon_",
+                "working-dir": "/app",
+                "command": "npm start",
+                "environment": {"NODE_ENV": "production"},
+            },
+        },
+    }
+    assert applied == expected

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -33,7 +33,7 @@ def expressjs_input_yaml_fixture():
 
 @pytest.fixture
 def expressjs_extension(mock_extensions):
-    extensions.register("expressjs-framework", extensions.expressjs_framework_factory)  # type: ignore[arg-type]
+    extensions.register("expressjs-framework", extensions.ExpressJSFrameworkFactory)  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -396,7 +396,7 @@ def test_expressjs_invalid_package_json_scripts_error(
 
 
 def test_expressjs_factory_dispatch(tmp_path):
-    factory = extensions.expressjs_framework_factory
+    factory = extensions.ExpressJSFrameworkFactory
 
     v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
     assert isinstance(v1, extensions.ExpressJSFramework)
@@ -409,7 +409,7 @@ def test_expressjs_factory_dispatch(tmp_path):
 def test_expressjs_v2_and_factory_supported_bases():
     assert "ubuntu@26.04" in extensions.ExpressJSFrameworkV2.get_supported_bases()
 
-    factory_bases = extensions.expressjs_framework_factory.get_supported_bases()
+    factory_bases = extensions.ExpressJSFrameworkFactory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
     for base in extensions.ExpressJSFramework.get_supported_bases():
         assert base in factory_bases

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -33,7 +33,7 @@ def expressjs_input_yaml_fixture():
 
 @pytest.fixture
 def expressjs_extension(mock_extensions):
-    extensions.register("expressjs-framework", extensions.ExpressJSFrameworkFactory())  # type: ignore[arg-type]
+    extensions.register("expressjs-framework", extensions.expressjs_framework_factory)  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -396,7 +396,7 @@ def test_expressjs_invalid_package_json_scripts_error(
 
 
 def test_expressjs_factory_dispatch(tmp_path):
-    factory = extensions.ExpressJSFrameworkFactory()
+    factory = extensions.expressjs_framework_factory
 
     v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
     assert isinstance(v1, extensions.ExpressJSFramework)
@@ -409,15 +409,15 @@ def test_expressjs_factory_dispatch(tmp_path):
 def test_expressjs_v2_and_factory_supported_bases():
     assert "ubuntu@26.04" in extensions.ExpressJSFrameworkV2.get_supported_bases()
 
-    factory_bases = extensions.ExpressJSFrameworkFactory.get_supported_bases()
+    factory_bases = extensions.expressjs_framework_factory.get_supported_bases()
     assert "ubuntu@26.04" in factory_bases
-    # V1 bases must also be present
     for base in extensions.ExpressJSFramework.get_supported_bases():
         assert base in factory_bases
 
 
 @pytest.mark.usefixtures("expressjs_extension", "package_json_file")
-def test_expressjs_extension_ubuntu2604_default(tmp_path, expressjs_input_yaml):
+def test_expressjs_extension_ubuntu2604_default(tmp_path, monkeypatch, expressjs_input_yaml):
+    monkeypatch.setenv("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS", "1")
     expressjs_input_yaml["base"] = "ubuntu@26.04"
     expressjs_input_yaml["parts"] = {
         "expressjs-framework/install-app": {


### PR DESCRIPTION
Add ExpressJSFrameworkV2 (targets ubuntu@26.04, inherits ExpressJSFramework) and a ExpressJSFrameworkFactory that dispatch the V1 or V2 extension class depending on the base. Implements ISD283 (internal) for the expressjs-framework extension.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.