### PR TITLE
fix: Exclude ca-certificates.crt when ca-certificates_data and deb ca-certificates

### DIFF
--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -83,6 +83,14 @@ class ExpressJSFramework(Extension):
         runtime_part = self._gen_runtime_part()
         if runtime_part:
             snippet["parts"]["expressjs-framework/runtime"] = runtime_part
+            # There is a bug where ca-certificates_data and
+            # expressjs-framework/runtime stage-packages with a transitive
+            # dependency on ca-certificates will both contain
+            # etc/ssl/certs/ca-certificates.crt with different content.
+            snippet["parts"]["expressjs-framework/runtime"]["stage"] = [
+                "-etc/ssl/certs/ca-certificates.crt"
+            ]
+
         snippet["parts"]["expressjs-framework/logging"] = gen_logging_part()
         return snippet
 

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -143,6 +143,11 @@ class FastAPIFramework(Extension):
                 ],
             }
         else:
+            # There is a bug where ca-certificates_data and python-venv both provide
+            # etc/ssl/certs/ca-certificates.crt with different content.
+            parts["fastapi-framework/dependencies"]["stage"] = [
+                "-etc/ssl/certs/ca-certificates.crt"
+            ]
             parts["fastapi-framework/runtime"] = {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -176,6 +176,11 @@ class _GunicornBase(Extension):
                 "stage-packages": ["libstdc++6"],
             }
         else:
+            # There is a bug where ca-certificates_data and python-venv both provide
+            # etc/ssl/certs/ca-certificates.crt with different content.
+            parts[f"{self.framework}-framework/dependencies"]["stage"] = [
+                "-etc/ssl/certs/ca-certificates.crt"
+            ]
             parts[f"{self.framework}-framework/runtime"] = {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -91,6 +91,7 @@ def package_json_file(app_path):
                     },
                     "expressjs-framework/runtime": {
                         "plugin": "nil",
+                        "stage": ["-etc/ssl/certs/ca-certificates.crt"],
                         "stage-packages": ["npm"],
                     },
                     "expressjs-framework/logging": {
@@ -214,6 +215,7 @@ def package_json_file(app_path):
                     },
                     "expressjs-framework/runtime": {
                         "plugin": "nil",
+                        "stage": ["-etc/ssl/certs/ca-certificates.crt"],
                         "stage-packages": [
                             "libstdc++6",
                             "zlib1g",
@@ -285,6 +287,7 @@ def package_json_file(app_path):
                     },
                     "expressjs-framework/runtime": {
                         "plugin": "nil",
+                        "stage": ["-etc/ssl/certs/ca-certificates.crt"],
                         "stage-packages": ["libstdc++6", "zlib1g"],
                     },
                     "expressjs-framework/logging": {

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -53,6 +53,7 @@ def test_fastapi_extension_default(tmp_path, fastapi_input_yaml, packages):
                 "plugin": "python",
                 "stage-packages": ["python3-venv"],
                 "source": ".",
+                "stage": ["-etc/ssl/certs/ca-certificates.crt"],
                 "python-packages": ["uvicorn"],
                 "python-requirements": ["requirements.txt"],
             },

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -94,6 +94,7 @@ def test_flask_extension_default(
                 "python-packages": ["gunicorn~=23.0"],
                 "python-requirements": ["requirements.txt"],
                 "source": ".",
+                "stage": ["-etc/ssl/certs/ca-certificates.crt"],
                 "stage-packages": ["python3-venv"],
                 "build-environment": [],
             },
@@ -329,6 +330,7 @@ def test_flask_extension_override_parts(tmp_path, flask_input_yaml):
         "python-packages": ["gunicorn~=23.0"],
         "python-requirements": ["requirements.txt", "requirements-jammy.txt"],
         "source": ".",
+        "stage": ["-etc/ssl/certs/ca-certificates.crt"],
         "stage-packages": ["python3-venv"],
         "build-environment": [],
     }
@@ -827,6 +829,7 @@ def test_django_extension_default(
                 "python-packages": ["gunicorn~=23.0"],
                 "python-requirements": ["requirements.txt"],
                 "source": ".",
+                "stage": ["-etc/ssl/certs/ca-certificates.crt"],
                 "stage-packages": ["python3-venv"],
                 "build-environment": [],
             },


### PR DESCRIPTION
Describe your changes.

When there are two parts, one of thn with stage-packages and a transitive dependency to ca-certificates and another one with the chisel ca-certificates_data, there will be a conflict related to the file `/etc/ssl/certs/ca-certificates.crt`. See issue https://github.com/canonical/rockcraft/issues/1261

For Fastapi and Gunicorn based extensions, the problem occurs with non bare images, as they stage the package python3-venv. For expressjs, it happens in bare and non bare images (they always stage the package npm).

The fix for the problematic cases is to exclude `etc/ssl/certs/ca-certificates.crt` in the part that imports the deb package with the transitive dependency for ca-certificates.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
