### PR TITLE
fix: allow downgrades in overlay apt upgrade for FIPS builds

### DIFF
--- a/rockcraft/services/project.py
+++ b/rockcraft/services/project.py
@@ -39,7 +39,7 @@ APT_UPGRADE_PART = {
         if find /etc/apt/sources.list.d/ -iname "ubuntu-esm-*.sources" -or -iname "ubuntu-fips-*.sources" | grep -q "."; then
             echo "Upgrading base overlay system packages"
             apt-get update
-            apt-get -y upgrade
+            apt-get -y --allow-downgrades upgrade
             apt-get clean
             rm -rf /var/cache/apt
         else

--- a/tests/spread/pro/fips/rockcraft.yaml
+++ b/tests/spread/pro/fips/rockcraft.yaml
@@ -1,0 +1,14 @@
+name: fips-test
+summary: Rock to test FIPS Pro overlay upgrade.
+description: Test that --pro=fips-updates packs a rock with a full base.
+version: "latest"
+license: Apache-2.0
+
+base: ubuntu@24.04
+
+platforms:
+  amd64:
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/pro/fips/task.yaml
+++ b/tests/spread/pro/fips/task.yaml
@@ -1,0 +1,19 @@
+summary: |
+  Test that packing a rock with FIPS Pro sources succeeds.
+
+  Uses a full base so the overlay apt upgrade step runs. The
+  fips-updates repository pins packages (e.g. libgcrypt20) to versions
+  older than the noble GA archive, so the overlay upgrade must pass
+  --allow-downgrades or apt aborts with:
+  "Packages were downgraded and -y was used without --allow-downgrades".
+
+execute: |
+  rockcraft pack --pro=fips-updates --verbosity=DEBUG > log 2>&1
+  rockcraft clean
+
+  # the overlay upgrade step must have run for a full base
+  MATCH 'Upgrading base overlay system packages' < log
+
+restore: |
+  rm -f log
+  rm -f fips-test_latest_*.rock


### PR DESCRIPTION
## Summary

- Add `--allow-downgrades` to `apt-get -y upgrade` in the overlay step when Pro/FIPS sources are detected
- Fixes FIPS rock builds failing because the `fips-updates` repository pins `libgcrypt20` to a version older than the noble GA archive, causing apt to refuse the downgrade without `--allow-downgrades`

## Problem

When building FIPS rocks on noble, the `esm.ubuntu.com/fips-updates` repository pins `libgcrypt20` to the FIPS-certified version which is older than the GA version in the standard noble archive. During the overlay `apt-get -y upgrade` step, apt detects this as a downgrade and aborts with:
```
E: Packages were downgraded and -y was used without --allow-downgrades.
```

This started affecting builds recently (e.g. https://github.com/canonical/cilium-rocks/actions/runs/28017207023/job/83118786893).

## Fix

The `--allow-downgrades` flag is safe here because:

1. This code path only executes when Pro/FIPS sources are present (guarded by the `find` check for `ubuntu-esm-*.sources` or `ubuntu-fips-*.sources`)
2. The downgrade is intentional - the FIPS pin sets the preferred version and apt should honor it
3. No other packages are affected since only pinned packages will be downgraded

It is also future safe because it does not break existing build pipelines and allows the rockcraft team to fix future occurances of the issue when on their own pace.