### PR TITLE
fix: allow downgrades in overlay apt upgrade for FIPS builds

### DIFF
--- a/rockcraft/services/project.py
+++ b/rockcraft/services/project.py
@@ -39,7 +39,7 @@ APT_UPGRADE_PART = {
         if find /etc/apt/sources.list.d/ -iname "ubuntu-esm-*.sources" -or -iname "ubuntu-fips-*.sources" | grep -q "."; then
             echo "Upgrading base overlay system packages"
             apt-get update
-            apt-get -y upgrade
+            apt-get -y --allow-downgrades upgrade
             apt-get clean
             rm -rf /var/cache/apt
         else

--- a/tests/spread/pro/fips/rockcraft.yaml
+++ b/tests/spread/pro/fips/rockcraft.yaml
@@ -1,0 +1,14 @@
+name: fips-test
+summary: Rock to test FIPS Pro overlay upgrade.
+description: Test that --pro=fips-updates packs a rock with a full base.
+version: "latest"
+license: Apache-2.0
+
+base: ubuntu@24.04
+
+platforms:
+  amd64:
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/spread/pro/fips/task.yaml
+++ b/tests/spread/pro/fips/task.yaml
@@ -1,0 +1,19 @@
+summary: |
+  Test that packing a rock with FIPS Pro sources succeeds.
+
+  Uses a full base so the overlay apt upgrade step runs. The
+  fips-updates repository pins packages (e.g. libgcrypt20) to versions
+  older than the noble GA archive, so the overlay upgrade must pass
+  --allow-downgrades or apt aborts with:
+  "Packages were downgraded and -y was used without --allow-downgrades".
+
+execute: |
+  rockcraft pack --pro=fips-updates --verbosity=DEBUG > log 2>&1
+  rockcraft clean
+
+  # the overlay upgrade step must have run for a full base
+  MATCH 'Upgrading base overlay system packages' < log
+
+restore: |
+  rm -f log
+  rm -f fips-test_latest_*.rock


### PR DESCRIPTION
This is version of #1270 but on the rockcraft repo, so we can run Pro tests.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
