### PR TITLE
docs: update intersphinx paths

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,8 +321,8 @@ rst_prolog = """
 intersphinx_mapping = {
     "12-factor": ("https://canonical.com/juju/docs/12-factor/latest", None),
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable", None),
-    "pebble": ("https://documentation.ubuntu.com/pebble", None),
-    "chisel": ("https://documentation.ubuntu.com/chisel/en/latest", None),
+    "pebble": ("https://ubuntu.com/docs/pebble/", None),
+    "chisel": ("https://ubuntu.com/chisel/docs/latest/", None),
 }
 # See also:
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_disabled_reftypes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -319,11 +319,8 @@ rst_prolog = """
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 
 intersphinx_mapping = {
-    "12-factor": (
-        "https://canonical.com/juju/docs/12-factor/latest/",
-        None,
-    ),
-    "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable/", None),
+    "12-factor": ("https://canonical.com/juju/docs/12-factor/latest", None),
+    "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable", None),
     "pebble": ("https://documentation.ubuntu.com/pebble", None),
     "chisel": ("https://documentation.ubuntu.com/chisel/en/latest", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,6 +185,7 @@ linkcheck_ignore = [
     # 2026-06-03: Ignore Canonical sites until filtering is resolved
     "https://snapcraft.io",
     "https://juju.is",
+    "https://launchpad.net/builders",
 ]
 
 # Anchor strings to ignore

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -320,7 +320,7 @@ rst_prolog = """
 
 intersphinx_mapping = {
     "12-factor": (
-        "https://canonical-12-factor-app-support.readthedocs-hosted.com/latest/",
+        "https://canonical.com/juju/docs/12-factor/latest/",
         None,
     ),
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable/", None),


### PR DESCRIPTION
Update the intersphinx mapping for the 12-factor docs. We recently migrated to a new URL, and the previous RTD project was deleted.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
