### PR TITLE
docs: Update redirects from chiselling to chiseling

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -21,3 +21,6 @@
 "how-to/chiselling/create-slice.rst" "how-to/chiseling/install-slice.rst"
 "how-to/chiselling/publish-slice.rst" "how-to/chiseling/install-slice.rst"
 "how-to/chiselling/use-chisel.rst" "how-to/chiseling/index.rst"
+"how-to/chiselling/index.rst" "how-to/chiseling/index.rst"
+"how-to/chiselling/chisel-existing-rock.rst" "how-to/chiseling/chisel-existing-rock.rst"
+"how-to/chiselling/install-slice.rst" "how-to/chiseling/install-slice.rst"


### PR DESCRIPTION
After #1162, links to the chiselling how-tos were broken. Only the links of deleted pages were updated in that PR. This PR adds redirects for the landing page and the two guides. 

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
