### PR TITLE
docs: add a minimum LXD version for packing pro-rocks

### DIFF
--- a/docs/how-to/crafting/pack-a-pro-rock.rst
+++ b/docs/how-to/crafting/pack-a-pro-rock.rst
@@ -13,7 +13,7 @@ Prerequisites
 -------------
 
 - An Ubuntu Pro system (https://ubuntu.com/pro)
-- LXD installer (https://documentation.ubuntu.com/lxd/)
+- LXD version 5.21 or higher installed (https://documentation.ubuntu.com/lxd/)
 - Rockcraft version 1.18.0 or higher installed (https://snapcraft.io/rockcraft)
 
 Enable guest attachment


### PR DESCRIPTION
Some methods of installing Ubuntu might come with different versions of LXD, and not all of them support the guest attachment feature that Rockcraft uses for packing pro rocks.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
