### PR TITLE
docs: fix typo in explanation/lifecycle-layer

### DIFF
--- a/docs/explanation/lifecycle-layer.rst
+++ b/docs/explanation/lifecycle-layer.rst
@@ -163,7 +163,7 @@ symlink from the "base layer", which will make everything that assumed that
 the base binaries from ``usr/bin/`` would always be accessible through ``bin/``
 break.
 
-This issue is made much worse if the instead of breaking ``bin/`` we break the
+This issue is made much worse if instead of breaking ``bin/`` we break the
 ``lib*/`` symlinks. Consider:
 
 .. code-block:: bash


### PR DESCRIPTION
Docs under `/explanation/lifecycle-layer` has a misplaced `the`. This PR removes it.

| Before | After |
| --- | --- |
| <img width="1311" height="300" alt="image" src="https://github.com/user-attachments/assets/e03a0593-3124-4b08-b0e1-c85b0f53972e" /> |  <img width="1311" height="300" alt="image" src="https://github.com/user-attachments/assets/6e10e45e-0de2-4a2c-abf0-456b99a84e66" />|


---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make docs` and `make docs-lint`.
- [ ] I've successfully run `make lint && make test`.