### PR TITLE
ci: fix osv scanner on docs

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Security scan
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
-      osv-extra-args: "--config=source/osv-scanner.toml"
+      osv-extra-args: "--config=osv-scanner.toml"
       uv-export-no-groups: |
         docs
         docs-sphinx-stack

--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -14,7 +14,11 @@ jobs:
     name: Security scan
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
-      packages: python-apt-dev
-      requirements-find-args: "! -path '*/docs/tutorial/**' ! -path '*/tests/spread/**' ! -path '*/tests/data/**'"
       osv-extra-args: "--config=source/osv-scanner.toml"
-      uv-export: false
+      uv-export-no-groups: |
+        docs
+        docs-sphinx-stack
+      osv-exclude-paths: |
+        docs/
+        tests/spread/
+        tests/data/


### PR DESCRIPTION
This should make OSV scanner ignore anything that comes from the docs now.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
