### PR TITLE
docs: Update FastAPI tutorial to remove chiselling section

### DIFF
--- a/docs/tutorial/code/fastapi/task.yaml
+++ b/docs/tutorial/code/fastapi/task.yaml
@@ -69,35 +69,6 @@ execute: |
   docker rmi fastapi-hello-world:0.1
   # [docs:stop-docker-end]
 
-  sed -i "s/version: .*/version: 0.1-chiselled/g" rockcraft.yaml
-
-  # [docs:chisel-pack]
-  rockcraft pack
-  # [docs:chisel-pack-end]
-
-  # [docs:ls-bare-rock]
-  ls *.rock -l --block-size=MB
-  # [docs:ls-bare-rock-end]
-
-  # [docs:docker-run-chisel]
-  rockcraft.skopeo --insecure-policy \
-    copy oci-archive:fastapi-hello-world_0.1-chiselled_$(dpkg --print-architecture).rock \
-    docker-daemon:fastapi-hello-world:0.1-chiselled
-  docker images fastapi-hello-world:0.1-chiselled
-  docker run --rm -d -p 8000:8000 \
-    --name fastapi-hello-world fastapi-hello-world:0.1-chiselled
-  # [docs:docker-run-chisel-end]
-  retry -n 5 --wait 2 curl --fail localhost:8000
-
-  # [docs:curl-fastapi-bare-rock]
-  curl --fail localhost:8000
-  # [docs:curl-fastapi-bare-rock-end]
-
-  # [docs:stop-docker-chisel]
-  docker stop fastapi-hello-world
-  docker rmi fastapi-hello-world:0.1-chiselled
-  # [docs:stop-docker-chisel-end]
-
   cat time_app.py > app.py
   sed -i "s/version: .*/version: 0.2/g" rockcraft.yaml
 
@@ -127,7 +98,6 @@ execute: |
   rm -rf .venv __pycache__
   # delete all the files created during the tutorial
   rm fastapi-hello-world_0.1_$(dpkg --print-architecture).rock \
-    fastapi-hello-world_0.1-chiselled_$(dpkg --print-architecture).rock \
     fastapi-hello-world_0.2_$(dpkg --print-architecture).rock \
     rockcraft.yaml app.py requirements.txt
   # [docs:cleanup-end]

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -167,9 +167,6 @@ the ``.rock`` extension:
     :end-before: [docs:ls-rock-end]
     :dedent: 2
 
-The created rock is about 75MB in size. We will reduce its size later in this
-tutorial.
-
 .. note::
     If we changed the ``name`` or ``version`` in the project file or are not
     on an ``amd64`` platform, the name of the ``.rock`` file will be
@@ -289,102 +286,6 @@ respective image for now:
     :language: bash
     :start-after: [docs:stop-docker]
     :end-before: [docs:stop-docker-end]
-    :dedent: 2
-
-Chisel the rock
-===============
-
-This is an optional but recommended step, especially if we're looking to
-deploy the rock into a production environment. With :ref:`explanation-chisel`
-we can produce lean and production-ready rocks by getting rid of all the
-contents that are not needed for the FastAPI app to run. This results
-in a much smaller rock with a reduced attack surface.
-
-.. note::
-    It is recommended to run chiseled images in production. For development,
-    we may prefer non-chiseled images as they will include additional
-    development tooling (such as for debugging).
-
-The first step towards chiselling the rock is to ensure we are using a
-``bare`` :ref:`base <explanation-bases>`.
-
-So that we can compare the size after chiselling, open the project
-file and change the ``version`` (e.g. to ``0.1-chiselled``).
-The top of the ``rockcraft.yaml`` file should look similar to the following:
-
-.. code-block:: yaml
-    :caption: ~/fastapi-hello-world/rockcraft.yaml
-    :emphasize-lines: 6
-
-    name: fastapi-hello-world
-    # see https://documentation.ubuntu.com/rockcraft/latest/explanation/bases/
-    # for more information about bases and bare bases
-    base: bare # as an alternative, an ubuntu base can be used
-    build-base: ubuntu@24.04 # build-base is required when the base is bare
-    version: '0.1-chiselled'
-    summary: A summary of your FastAPI app # 79 char long summary
-    description: |
-        This is fastapi project's description. You have a paragraph or two to tell the
-        most important story about it. Keep it under 100 words though,
-        we live in tweetspace and your description wants to look good in the
-        container registries out there.
-    # the platforms this rock should be built on and run on.
-    # you can check your architecture with `dpkg --print-architecture`
-    platforms:
-        amd64:
-        # arm64:
-        # ppc64el:
-        # s390x:
-
-Pack the rock with the new ``bare`` base:
-
-.. literalinclude:: code/fastapi/task.yaml
-    :language: bash
-    :start-after: [docs:chisel-pack]
-    :end-before: [docs:chisel-pack-end]
-    :dedent: 2
-
-As before, verify that the new rock was created:
-
-.. literalinclude:: code/fastapi/task.yaml
-    :language: bash
-    :start-after: [docs:ls-bare-rock]
-    :end-before: [docs:ls-bare-rock-end]
-    :dedent: 2
-
-We'll verify that the new FastAPI rock is now approximately **35% smaller**
-in size! And that's just because of the simple change of ``base``.
-
-And the functionality is still the same. As before, we can confirm this by
-running the rock with Docker
-
-.. literalinclude:: code/fastapi/task.yaml
-    :language: text
-    :start-after: [docs:docker-run-chisel]
-    :end-before: [docs:docker-run-chisel-end]
-    :dedent: 2
-
-and then using the same ``curl`` request:
-
-.. literalinclude:: code/fastapi/task.yaml
-    :language: text
-    :start-after: [docs:curl-fastapi-bare-rock]
-    :end-before: [docs:curl-fastapi-bare-rock-end]
-    :dedent: 2
-
-The FastAPI app should still respond with
-``{"message":"Hello World"}``.
-
-Cleanup
-~~~~~~~
-
-And that's it. We can now stop the container and remove the corresponding
-image:
-
-.. literalinclude:: code/fastapi/task.yaml
-    :language: bash
-    :start-after: [docs:stop-docker-chisel]
-    :end-before: [docs:stop-docker-chisel-end]
     :dedent: 2
 
 .. _update-fastapi-application:

--- a/docs/tutorial/fastapi.rst
+++ b/docs/tutorial/fastapi.rst
@@ -111,7 +111,8 @@ The top of the file should look similar to the following snippet:
     name: fastapi-hello-world
     # see https://documentation.ubuntu.com/rockcraft/latest/explanation/bases/
     # for more information about bases and bare bases
-    base: ubuntu@24.04 # the base environment for this FastAPI app
+    base: bare
+    build-base: ubuntu@24.04
     version: '0.1' # just for humans. Semantic versioning is recommended
     summary: A summary of your FastAPI app # 79 char long summary
     description: |


### PR DESCRIPTION
Remove the outdated section on chiselling the FastAPI rock in the tutorial. The FastAPI extension uses the `bare` base by default now.

Caught during a UXR session that I conducted today.

Spread tests are failing overall, but the FastAPI test passed.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ran `make docs-lint` successfully] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [N/A] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
