### PR TITLE
chore(docs): update boot-version in Spring Boot tutorial

### DIFF
--- a/docs/tutorial/code/spring-boot/task.yaml
+++ b/docs/tutorial/code/spring-boot/task.yaml
@@ -27,7 +27,7 @@ execute: |
     --path spring-boot-hello-world \
     --project maven-project \
     --language java \
-    --boot-version 3.5.10 \
+    --boot-version 4.1.0 \
     --version 0.0.1 \
     --group com.example \
     --artifact demo \


### PR DESCRIPTION
In a UXR session today, we found out that the `devpack-for-spring boot start` command in the Spring Boot tutorial no longer works. Based on https://start.spring.io/ , it seems like version 3.5.10 is no longer offered. Therefore, the tutorial no longer works. The Spread test caught this issue last month (perhaps even earlier).

This PR updates the Spring Boot version to 4.1.0 -- this version was validated by checking the Spring Initialzr website and confirming that this version is supported.

:heavy_check_mark:  Spring Boot Spread test passed (other unrelated tests failed)

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [N/A] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
