### PR TITLE
fix: use major-version docs URLs in init output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,6 +277,7 @@ exclude_patterns = [
     "common/craft-application/reference/fetch-service.rst",
     "common/craft-application/reference/remote-builds.rst",
     "common/craft-application/reference/strict-platform-names.rst",
+    "common/craft-application/how-to-guides/pack-a-pro-artifact.rst",
     # Extra non-craft-parts exclusions can be added after this comment
     "reuse/*",
     "README.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 dependencies = [
     # To use a dev version of a craft library:
     # craft-lib @ git+https://github.com/canonical/craft-lib@ref
-    "craft-application>=7.1.0",
+    "craft-application>=7.2.0",
     "craft-archives>=2.2.1",
     "craft-cli>=3.4.1",
     "craft-parts>=2.35.0",

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -71,7 +71,7 @@ def test_lifecycle_args(
         base_layer_hash=b"deadbeef",
         cache_dir=project_path / "cache",
         ignore_local_sources=[".craft", "*.rock"],
-        ignore_outdated=[".craft", "*.rock"],
+        ignore_outdated=[".craft", "*.rock", ".spread-reuse.*"],
         parallel_build_count=4,
         partitions=None,
         project_name="test-rock",

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -13,10 +13,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import dataclasses
 from textwrap import dedent
 
 import pytest
+import rockcraft
 from rockcraft import cli, plugins
+from rockcraft.application import APP_METADATA
 
 pytestmark = [pytest.mark.usefixtures("enable_overlay_feature")]
 
@@ -73,3 +76,26 @@ def test_get_app_plugins_missing_project(tmp_path, monkeypatch, mocker):
     app._configure_early_services()
     _ = app._get_app_plugins()
     spied_get_plugins.assert_called_once_with(None)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_url"),
+    [
+        ("1.20.0", "https://documentation.ubuntu.com/rockcraft/1"),
+        ("2.0.1", "https://documentation.ubuntu.com/rockcraft/2"),
+    ],
+)
+def test_docs_url_uses_major_version(monkeypatch, version, expected_url):
+    """Released docs URLs point at the major version only.
+
+    Regression test for #1312. The expected URL is spelled out in full on
+    purpose: deriving it from the property under test would track any change to
+    the URL scheme instead of catching it.
+    """
+    # AppMetadata is a frozen dataclass whose 'version' field is init=False and
+    # derived in __post_init__ from the app package's __version__. replace()
+    # re-runs that derivation, so the real APP_METADATA is left alone.
+    monkeypatch.setattr(rockcraft, "__version__", version)
+    app_metadata = dataclasses.replace(APP_METADATA)
+
+    assert app_metadata.versioned_docs_url == expected_url

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ toml = [
 
 [[package]]
 name = "craft-application"
-version = "7.1.0"
+version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -620,9 +620,9 @@ dependencies = [
     { name = "snap-http" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c3/be96c01c1b92a7a7eb6cafa881ccd09a6b9e1db1355835fc98f001680cc3/craft_application-7.1.0.tar.gz", hash = "sha256:e0a3fb2080bf1dd6daf8b570262716f79a5f307a87d3ed2b986eaca50e07efed", size = 663202, upload-time = "2026-07-07T22:02:40.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/aa/592be376d6b4c066bb7bff882179478d07287c1fc65e81bdef32e0f1f514/craft_application-7.2.0.tar.gz", hash = "sha256:182646ef7febe78e1241b393f6cf2b21ec2a3dd00596d323f85c59c3bc705e11", size = 711407, upload-time = "2026-08-11T16:50:12.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/ce/169bdacdfbda0fe8a880d914be0794fc5379b7ec577546444f1572f4762d/craft_application-7.1.0-py3-none-any.whl", hash = "sha256:3319310644d1d935fd7e2fb285fa38bc87c490f3d4fb72fed934e6202164b7bc", size = 212571, upload-time = "2026-07-07T22:02:38.317Z" },
+    { url = "https://files.pythonhosted.org/packages/98/02/c8bb8ec7af9a9c1f7775fc5f8b4174b2ca045b7e5a2a5402fec0d7243792/craft_application-7.2.0-py3-none-any.whl", hash = "sha256:ca0e068f56137b1bb117a0ae92da84db0a9d59360f95106582c7881acb95ec61", size = 212573, upload-time = "2026-08-11T16:50:10.454Z" },
 ]
 
 [[package]]
@@ -2745,7 +2745,7 @@ types = [
 
 [package.metadata]
 requires-dist = [
-    { name = "craft-application", specifier = ">=7.1.0" },
+    { name = "craft-application", specifier = ">=7.2.0" },
     { name = "craft-archives", specifier = ">=2.2.1" },
     { name = "craft-cli", specifier = ">=3.4.1" },
     { name = "craft-parts", specifier = ">=2.35.0" },


### PR DESCRIPTION
`rockcraft init --profile <name>` prints a link to that profile's documentation. The printed URL contains the full application version, and that path returns 404:

```
$ curl -sIL -o /dev/null -w "%{http_code} %{url_effective}\n" \
    https://documentation.ubuntu.com/rockcraft/1.20.0/reference/extensions/spring-boot-framework/
404 https://ubuntu.com/containers/rockcraft/docs/1.20.0/reference/extensions/spring-boot-framework/
```

The documentation site serves the major version. `1`, `1.19`, `1.20` and `stable` all resolve to `/docs/1/` and return 200. Only the full `major.minor.patch` form fails.

The URL is built by `APP_METADATA.versioned_docs_url`, which calls `render_doc_url` in craft-application. Version 7.1.0, pinned in `uv.lock`, substitutes the version verbatim. Version 7.2.0 added `major_only=True`, which truncates to the major version. The fix already exists upstream; rockcraft just needs to pick it up.

## Changes

**`uv.lock`**: craft-application 7.1.0 to 7.2.0. Single package, no transitive dependency changes.

**`pyproject.toml`**: constraint floor raised from `>=7.1.0` to `>=7.2.0`. The old constraint already permitted 7.2.0, but the test added here fails against 7.1.0, so leaving the floor at 7.1.0 would permit an environment where the suite does not pass.

**`tests/unit/test_application.py`**: regression test. Two notes on how it is written:

* It asserts a hard-coded URL instead of deriving one from `versioned_docs_url`. The existing assertion in `tests/unit/test_cli.py` puts the same property on both sides of the comparison, so it passes whatever the URL scheme happens to be.
* It injects a release-shaped version. `AppMetadata.version` is an `init=False` field derived in `__post_init__` from `rockcraft.__version__`, and a git checkout produces a setuptools_scm string containing `+g`, which `render_doc_url` short-circuits to `latest` before reaching the truncation. Patching `rockcraft.__version__` and calling `dataclasses.replace(APP_METADATA)` re-runs the real derivation and leaves the module-level singleton untouched.

**`tests/unit/services/test_lifecycle.py`**: the `ignore_outdated` literal now includes `.spread-reuse.*`. That value is built entirely inside craft-application, and rockcraft has no references to it. `git log -L` on the line shows one commit, `1856eca build(deps): update craft-application to 6.2.1`, whose message does not mention `ignore_outdated`, so the literal records what craft-application emitted at the time rather than an intended contract. 7.2.0 appends `.spread-reuse.*` so that changes to spread test files do not force a re-pull of sources, which matches the reuse files this repo's CI generates and cleans up.

**`docs/conf.py`**: excludes `common/craft-application/how-to-guides/pack-a-pro-artifact.rst`. This one is a required companion to the bump rather than incidental cleanup. 7.2.0 ships that page as new shared documentation, which `link_common_docs` symlinks into the docs tree. The page uses substitutions rockcraft does not define (`|app|`, `|artifact|`, `|an-artifact|`, `|app-link|`, `|app-min-pro-version|`) and a `code-block` `:substitutions:` option that needs `sphinx_substitution_extensions`, which is commented out at `docs/conf.py:240`. Without the exclusion the docs build emits 16 errors and a toctree warning, and `.readthedocs.yaml` sets `fail_on_warning: true`, so the build fails. The exclusion sits alongside the five craft-application pages already excluded for the same reason. If rockcraft wants this page, enabling the extension and defining the substitutions would be a separate change.

## Testing

Fail to pass was verified directly. With `uv.lock` reverted to craft-application 7.1.0, both parametrisations of the new test fail:

```
AssertionError: assert 'https://documentation.ubuntu.com/rockcraft/1.20.0'
                    == 'https://documentation.ubuntu.com/rockcraft/1'
```

On 7.2.0 they pass.

Full suite on 7.2.0, deterministic ordering:

```
677 passed, 3 skipped
```

That covers `tests/unit` and `tests/integration`. `tests/spread` was not run, since it needs the spread binary and the self-hosted runners.

`make lint` passes in full, including sphinx-lint, vale, woke, linkcheck, twine check and `uv lock --check`. `make docs` completes with zero warnings; `docs/_dev/warnings.txt` is empty.

Fixes #1312

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation. The only documentation change is the exclusion described above.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing. No documentation pages were added or edited.
- [ ] I've updated the relevant release notes. `docs/release-notes/` currently ends at 1.20 and there is no file for the next release. Happy to add an entry if there is a target.