### PR TITLE
extensions: allow part names to use '.' separator for bases that disallow slashes

### DIFF
--- a/rockcraft/extensions/_utils.py
+++ b/rockcraft/extensions/_utils.py
@@ -41,9 +41,11 @@ def apply_extensions(project_root: Path, yaml_data: dict[str, Any]) -> dict[str,
     for extension_name in sorted(declared_extensions):
         extension_class = get_extension_class(extension_name)
         extension = extension_class(
-            project_root=project_root, yaml_data=copy.deepcopy(yaml_data)
+            project_root=project_root,
+            yaml_data=copy.deepcopy(yaml_data),
+            extension_name=extension_name,
         )
-        extension.validate(extension_name=extension_name)
+        extension.validate()
         _apply_extension(yaml_data, extension)
     return yaml_data
 

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -25,7 +25,7 @@ from rockcraft.errors import ExtensionError
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from .app_parts import gen_logging_part
-from .extension import Extension, ExtensionPart, _FrameworkFactory
+from .extension import Extension, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -78,20 +78,20 @@ class ExpressJSFramework(Extension):
             snippet["services"]["expressjs"]["command"] = "npm start"
 
         snippet["parts"] = {
-            self.get_part_name(ExtensionPart.INSTALL_APP): self._gen_install_app_part(),
+            self.get_part_name("install-app"): self._gen_install_app_part(),
         }
         runtime_part = self._gen_runtime_part()
         if runtime_part:
-            snippet["parts"][self.get_part_name(ExtensionPart.RUNTIME)] = runtime_part
+            snippet["parts"][self.get_part_name("runtime")] = runtime_part
             # There is a bug where ca-certificates_data and
             # expressjs-framework/runtime stage-packages with a transitive
             # dependency on ca-certificates will both contain
             # etc/ssl/certs/ca-certificates.crt with different content.
-            snippet["parts"][self.get_part_name(ExtensionPart.RUNTIME)]["stage"] = [
+            snippet["parts"][self.get_part_name("runtime")]["stage"] = [
                 "-etc/ssl/certs/ca-certificates.crt"
             ]
 
-        snippet["parts"][self.get_part_name(ExtensionPart.LOGGING)] = gen_logging_part()
+        snippet["parts"][self.get_part_name("logging")] = gen_logging_part()
         return snippet
 
     @override
@@ -213,7 +213,7 @@ class ExpressJSFramework(Extension):
     def _user_install_app_part(self) -> dict[str, Any]:
         """Return the user defined install app part."""
         return self.yaml_data.get("parts", {}).get(
-            self.get_part_name(ExtensionPart.INSTALL_APP), {}
+            self.get_part_name("install-app"), {}
         )
 
     @property

--- a/rockcraft/extensions/expressjs.py
+++ b/rockcraft/extensions/expressjs.py
@@ -25,7 +25,7 @@ from rockcraft.errors import ExtensionError
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from .app_parts import gen_logging_part
-from .extension import Extension, _FrameworkFactory
+from .extension import Extension, ExtensionPart, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -78,20 +78,20 @@ class ExpressJSFramework(Extension):
             snippet["services"]["expressjs"]["command"] = "npm start"
 
         snippet["parts"] = {
-            "expressjs-framework/install-app": self._gen_install_app_part(),
+            self.get_part_name(ExtensionPart.INSTALL_APP): self._gen_install_app_part(),
         }
         runtime_part = self._gen_runtime_part()
         if runtime_part:
-            snippet["parts"]["expressjs-framework/runtime"] = runtime_part
+            snippet["parts"][self.get_part_name(ExtensionPart.RUNTIME)] = runtime_part
             # There is a bug where ca-certificates_data and
             # expressjs-framework/runtime stage-packages with a transitive
             # dependency on ca-certificates will both contain
             # etc/ssl/certs/ca-certificates.crt with different content.
-            snippet["parts"]["expressjs-framework/runtime"]["stage"] = [
+            snippet["parts"][self.get_part_name(ExtensionPart.RUNTIME)]["stage"] = [
                 "-etc/ssl/certs/ca-certificates.crt"
             ]
 
-        snippet["parts"]["expressjs-framework/logging"] = gen_logging_part()
+        snippet["parts"][self.get_part_name(ExtensionPart.LOGGING)] = gen_logging_part()
         return snippet
 
     @override
@@ -213,7 +213,7 @@ class ExpressJSFramework(Extension):
     def _user_install_app_part(self) -> dict[str, Any]:
         """Return the user defined install app part."""
         return self.yaml_data.get("parts", {}).get(
-            "expressjs-framework/install-app", {}
+            self.get_part_name(ExtensionPart.INSTALL_APP), {}
         )
 
     @property

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -56,17 +56,18 @@ def get_project_base(yaml_data: dict[str, Any]) -> str | None:
 
 
 class ExtensionPart(enum.Enum):
-    """Common part names used by extensions."""
+    """Part names shared by two or more extensions.
 
-    BASE_LAYOUT = "base-layout"
+    Only add a member here if the part name is reused by multiple
+    extensions. Names specific to a single extension should be passed to
+    :meth:`Extension.get_part_name` as a plain string instead of being
+    added to this enum.
+    """
+
     DEPENDENCIES = "dependencies"
     INSTALL_APP = "install-app"
-    CONFIG_FILES = "config-files"
-    GRADLE_INIT_SCRIPT = "gradle-init-script"
     ASSETS = "assets"
     RUNTIME = "runtime"
-    RUNTIME_LIBS = "runtime-libs"
-    STATSD_EXPORTER = "statsd-exporter"
     LOGGING = "logging"
 
 
@@ -120,9 +121,14 @@ class Extension(abc.ABC):
         base = get_project_base(self.yaml_data)
         return "/" if base in BASES_ALLOW_SLASH_IN_PART_NAME else "."
 
-    def get_part_name(self, part: ExtensionPart) -> str:
-        """Return formatted internal part name."""
-        return f"{self.extension_name}{self._extension_name_sep}{part.value}"
+    def get_part_name(self, part: ExtensionPart | str) -> str:
+        """Return formatted internal part name.
+
+        :param part: either a shared :class:`ExtensionPart` member, or a
+            plain string for part-name suffixes specific to this extension.
+        """
+        suffix = part.value if isinstance(part, ExtensionPart) else part
+        return f"{self.extension_name}{self._extension_name_sep}{suffix}"
 
     @final
     def validate(self) -> None:

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -17,7 +17,6 @@
 """Extension base class definition."""
 
 import abc
-import enum
 import os
 import sys
 from collections.abc import Sequence
@@ -53,22 +52,6 @@ def get_project_base(yaml_data: dict[str, Any]) -> str | None:
         return None
 
     return base_str
-
-
-class ExtensionPart(enum.Enum):
-    """Part names shared by two or more extensions.
-
-    Only add a member here if the part name is reused by multiple
-    extensions. Names specific to a single extension should be passed to
-    :meth:`Extension.get_part_name` as a plain string instead of being
-    added to this enum.
-    """
-
-    DEPENDENCIES = "dependencies"
-    INSTALL_APP = "install-app"
-    ASSETS = "assets"
-    RUNTIME = "runtime"
-    LOGGING = "logging"
 
 
 class Extension(abc.ABC):
@@ -121,14 +104,9 @@ class Extension(abc.ABC):
         base = get_project_base(self.yaml_data)
         return "/" if base in BASES_ALLOW_SLASH_IN_PART_NAME else "."
 
-    def get_part_name(self, part: ExtensionPart | str) -> str:
-        """Return formatted internal part name.
-
-        :param part: either a shared :class:`ExtensionPart` member, or a
-            plain string for part-name suffixes specific to this extension.
-        """
-        suffix = part.value if isinstance(part, ExtensionPart) else part
-        return f"{self.extension_name}{self._extension_name_sep}{suffix}"
+    def get_part_name(self, part: str) -> str:
+        """Return formatted internal part name."""
+        return f"{self.extension_name}{self._extension_name_sep}{part}"
 
     @final
     def validate(self) -> None:

--- a/rockcraft/extensions/extension.py
+++ b/rockcraft/extensions/extension.py
@@ -17,12 +17,14 @@
 """Extension base class definition."""
 
 import abc
+import enum
 import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast, final
 
+from craft_application._const import BASES_ALLOW_SLASH_IN_PART_NAME
 from craft_cli import emit
 
 from rockcraft import errors
@@ -53,6 +55,21 @@ def get_project_base(yaml_data: dict[str, Any]) -> str | None:
     return base_str
 
 
+class ExtensionPart(enum.Enum):
+    """Common part names used by extensions."""
+
+    BASE_LAYOUT = "base-layout"
+    DEPENDENCIES = "dependencies"
+    INSTALL_APP = "install-app"
+    CONFIG_FILES = "config-files"
+    GRADLE_INIT_SCRIPT = "gradle-init-script"
+    ASSETS = "assets"
+    RUNTIME = "runtime"
+    RUNTIME_LIBS = "runtime-libs"
+    STATSD_EXPORTER = "statsd-exporter"
+    LOGGING = "logging"
+
+
 class Extension(abc.ABC):
     """Extension is the class from which all extensions inherit.
 
@@ -68,10 +85,12 @@ class Extension(abc.ABC):
         *,
         project_root: Path,
         yaml_data: dict[str, Any],
+        extension_name: str,
     ) -> None:
         """Create a new Extension."""
         self.project_root = project_root
         self.yaml_data = yaml_data
+        self.extension_name = extension_name
 
     @staticmethod
     @abc.abstractmethod
@@ -95,11 +114,20 @@ class Extension(abc.ABC):
     def get_parts_snippet(self) -> dict[str, Any]:
         """Return the parts to add to parts."""
 
+    @property
+    def _extension_name_sep(self) -> str:
+        """Return the string separating extension part name fragments."""
+        base = get_project_base(self.yaml_data)
+        return "/" if base in BASES_ALLOW_SLASH_IN_PART_NAME else "."
+
+    def get_part_name(self, part: ExtensionPart) -> str:
+        """Return formatted internal part name."""
+        return f"{self.extension_name}{self._extension_name_sep}{part.value}"
+
     @final
-    def validate(self, extension_name: str) -> None:
+    def validate(self) -> None:
         """Validate that the extension can be used with the current project.
 
-        :param extension_name: the name of the extension being parsed.
         :raises errors.ExtensionError: if the extension is incompatible with the project.
         """
         if "base" not in self.yaml_data:
@@ -112,7 +140,7 @@ class Extension(abc.ABC):
             "ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS"
         ):
             raise errors.ExtensionError(
-                f"Extension is experimental: {extension_name!r}",
+                f"Extension is experimental: {self.extension_name!r}",
                 doc_slug="/reference/extensions/",
                 resolution="Run with ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=True to enable "
                 "experimental extensions.",
@@ -120,24 +148,24 @@ class Extension(abc.ABC):
 
         if self.is_experimental(base):
             emit.progress(
-                f"*EXPERIMENTAL* extension {extension_name!r} enabled",
+                f"*EXPERIMENTAL* extension {self.extension_name!r} enabled",
                 permanent=True,
             )
 
         if base not in self.get_supported_bases():
             raise errors.ExtensionError(
-                f"Extension {extension_name!r} does not support base: {base!r}"
+                f"Extension {self.extension_name!r} does not support base: {base!r}"
             )
 
         invalid_parts = [
             p
             for p in self.get_parts_snippet()
-            if not p.startswith(f"{extension_name}/")
+            if not p.startswith(f"{self.extension_name}{self._extension_name_sep}")
         ]
         if invalid_parts:
             raise ValueError(
                 f"Extension has invalid part names: {invalid_parts!r}. "
-                "Format is <extension-name>/<part-name>"
+                f"Format is <extension-name>{self._extension_name_sep}<part-name>"
             )
 
 
@@ -148,11 +176,21 @@ class _FrameworkFactory:
         self._v1_cls = v1_cls
         self._v2_cls = v2_cls
 
-    def __call__(self, *, project_root: Path, yaml_data: dict[str, Any]) -> Extension:
+    def __call__(
+        self, *, project_root: Path, yaml_data: dict[str, Any], extension_name: str
+    ) -> Extension:
         base = get_project_base(yaml_data)
         if base in self._v1_cls.get_supported_bases():
-            return self._v1_cls(project_root=project_root, yaml_data=yaml_data)
-        return self._v2_cls(project_root=project_root, yaml_data=yaml_data)
+            return self._v1_cls(
+                project_root=project_root,
+                yaml_data=yaml_data,
+                extension_name=extension_name,
+            )
+        return self._v2_cls(
+            project_root=project_root,
+            yaml_data=yaml_data,
+            extension_name=extension_name,
+        )
 
     def get_supported_bases(self) -> tuple[str, ...]:
         return tuple(

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -31,7 +31,7 @@ from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from ._python_utils import has_global_variable
 from .app_parts import gen_logging_part
-from .extension import Extension, ExtensionPart, _FrameworkFactory
+from .extension import Extension, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -118,7 +118,7 @@ class FastAPIFramework(Extension):
             ]
 
         parts: dict[str, Any] = {
-            self.get_part_name(ExtensionPart.DEPENDENCIES): {
+            self.get_part_name("dependencies"): {
                 "plugin": "python",
                 "stage-packages": stage_packages,
                 "source": ".",
@@ -126,13 +126,13 @@ class FastAPIFramework(Extension):
                 "python-requirements": ["requirements.txt"],
                 "build-environment": build_environment,
             },
-            self.get_part_name(ExtensionPart.INSTALL_APP): {
+            self.get_part_name("install-app"): {
                 **self._get_install_app_part(),
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
         }
         if self.yaml_data["base"] == "bare":
-            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
+            parts[self.get_part_name("runtime")] = {
                 "plugin": "nil",
                 "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp\n"
                 "ln -sf /usr/bin/bash ${CRAFT_PART_INSTALL}/usr/bin/sh",
@@ -145,14 +145,14 @@ class FastAPIFramework(Extension):
         else:
             # There is a bug where ca-certificates_data and python-venv both provide
             # etc/ssl/certs/ca-certificates.crt with different content.
-            parts[self.get_part_name(ExtensionPart.DEPENDENCIES)]["stage"] = [
+            parts[self.get_part_name("dependencies")]["stage"] = [
                 "-etc/ssl/certs/ca-certificates.crt"
             ]
-            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
+            parts[self.get_part_name("runtime")] = {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             }
-        parts[self.get_part_name(ExtensionPart.LOGGING)] = gen_logging_part()
+        parts[self.get_part_name("logging")] = gen_logging_part()
         return parts
 
     def _get_install_app_part(self) -> dict[str, Any]:
@@ -185,13 +185,13 @@ class FastAPIFramework(Extension):
         """Return the prime list for the FastAPI project."""
         user_prime = (
             self.yaml_data.get("parts", {})
-            .get(self.get_part_name(ExtensionPart.INSTALL_APP), {})
+            .get(self.get_part_name("install-app"), {})
             .get("prime", [])
         )
         if not all(re.match(f"-? *{self.IMAGE_BASE_DIR}/", p) for p in user_prime):
             raise ExtensionError(
                 "fastapi-framework extension requires the 'prime' entry in the "
-                f"{self.get_part_name(ExtensionPart.INSTALL_APP)} part to start with {self.IMAGE_BASE_DIR}/",
+                f"{self.get_part_name('install-app')} part to start with {self.IMAGE_BASE_DIR}/",
                 doc_slug="/reference/extensions/fastapi-framework",
                 logpath_report=False,
             )

--- a/rockcraft/extensions/fastapi.py
+++ b/rockcraft/extensions/fastapi.py
@@ -31,7 +31,7 @@ from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from ._python_utils import has_global_variable
 from .app_parts import gen_logging_part
-from .extension import Extension, _FrameworkFactory
+from .extension import Extension, ExtensionPart, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -118,7 +118,7 @@ class FastAPIFramework(Extension):
             ]
 
         parts: dict[str, Any] = {
-            "fastapi-framework/dependencies": {
+            self.get_part_name(ExtensionPart.DEPENDENCIES): {
                 "plugin": "python",
                 "stage-packages": stage_packages,
                 "source": ".",
@@ -126,13 +126,13 @@ class FastAPIFramework(Extension):
                 "python-requirements": ["requirements.txt"],
                 "build-environment": build_environment,
             },
-            "fastapi-framework/install-app": {
+            self.get_part_name(ExtensionPart.INSTALL_APP): {
                 **self._get_install_app_part(),
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
         }
         if self.yaml_data["base"] == "bare":
-            parts["fastapi-framework/runtime"] = {
+            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
                 "plugin": "nil",
                 "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp\n"
                 "ln -sf /usr/bin/bash ${CRAFT_PART_INSTALL}/usr/bin/sh",
@@ -145,14 +145,14 @@ class FastAPIFramework(Extension):
         else:
             # There is a bug where ca-certificates_data and python-venv both provide
             # etc/ssl/certs/ca-certificates.crt with different content.
-            parts["fastapi-framework/dependencies"]["stage"] = [
+            parts[self.get_part_name(ExtensionPart.DEPENDENCIES)]["stage"] = [
                 "-etc/ssl/certs/ca-certificates.crt"
             ]
-            parts["fastapi-framework/runtime"] = {
+            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             }
-        parts["fastapi-framework/logging"] = gen_logging_part()
+        parts[self.get_part_name(ExtensionPart.LOGGING)] = gen_logging_part()
         return parts
 
     def _get_install_app_part(self) -> dict[str, Any]:
@@ -185,13 +185,13 @@ class FastAPIFramework(Extension):
         """Return the prime list for the FastAPI project."""
         user_prime = (
             self.yaml_data.get("parts", {})
-            .get("fastapi-framework/install-app", {})
+            .get(self.get_part_name(ExtensionPart.INSTALL_APP), {})
             .get("prime", [])
         )
         if not all(re.match(f"-? *{self.IMAGE_BASE_DIR}/", p) for p in user_prime):
             raise ExtensionError(
                 "fastapi-framework extension requires the 'prime' entry in the "
-                f"fastapi-framework/install-app part to start with {self.IMAGE_BASE_DIR}/",
+                f"{self.get_part_name(ExtensionPart.INSTALL_APP)} part to start with {self.IMAGE_BASE_DIR}/",
                 doc_slug="/reference/extensions/fastapi-framework",
                 logpath_report=False,
             )

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -70,7 +70,7 @@ class GoFramework(Extension):
 
         snippet["parts"] = {
             # This is needed in case there is no assets part, as the working directory is /app
-            self.get_part_name(ExtensionPart.BASE_LAYOUT): {
+            self.get_part_name("base-layout"): {
                 "plugin": "nil",
                 "override-build": "mkdir -p ${CRAFT_PART_INSTALL}/app",
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -26,7 +26,7 @@ from rockcraft.errors import ExtensionError
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from .app_parts import gen_logging_part
-from .extension import Extension, _FrameworkFactory
+from .extension import Extension, ExtensionPart, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -70,28 +70,28 @@ class GoFramework(Extension):
 
         snippet["parts"] = {
             # This is needed in case there is no assets part, as the working directory is /app
-            "go-framework/base-layout": {
+            self.get_part_name(ExtensionPart.BASE_LAYOUT): {
                 "plugin": "nil",
                 "override-build": "mkdir -p ${CRAFT_PART_INSTALL}/app",
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
-            "go-framework/install-app": self._get_install_app_part(),
-            "go-framework/runtime": {
+            self.get_part_name(ExtensionPart.INSTALL_APP): self._get_install_app_part(),
+            self.get_part_name(ExtensionPart.RUNTIME): {
                 "plugin": "nil",
                 "stage-packages": stage_packages,
             },
-            "go-framework/logging": gen_logging_part(),
+            self.get_part_name(ExtensionPart.LOGGING): gen_logging_part(),
         }
 
         if self.yaml_data["base"] == "bare":
-            snippet["parts"]["go-framework/runtime"].update(
+            snippet["parts"][self.get_part_name(ExtensionPart.RUNTIME)].update(
                 {
                     "override-build": "ln -sf /usr/bin/bash ${CRAFT_PART_INSTALL}/usr/bin/sh"
                 }
             )
         assets_part = self._get_install_assets_part()
         if assets_part:
-            snippet["parts"]["go-framework/assets"] = assets_part
+            snippet["parts"][self.get_part_name(ExtensionPart.ASSETS)] = assets_part
 
         return snippet
 
@@ -122,7 +122,7 @@ class GoFramework(Extension):
     def _get_install_app_part(self) -> dict[str, Any]:
         """Generate install-app part with the Go plugin."""
         install_app = self._get_nested(
-            self.yaml_data, ["parts", "go-framework/install-app"]
+            self.yaml_data, ["parts", self.get_part_name(ExtensionPart.INSTALL_APP)]
         )
 
         build_environment = install_app.get("build-environment", [])
@@ -162,7 +162,7 @@ class GoFramework(Extension):
     def _check_go_overridden(self) -> bool:
         """Check if the user overrode the go snap or package for the build step."""
         install_app = self._get_nested(
-            self.yaml_data, ["parts", "go-framework/install-app"]
+            self.yaml_data, ["parts", self.get_part_name(ExtensionPart.INSTALL_APP)]
         )
         build_snaps = install_app.get("build-snaps", [])
         if build_snaps:
@@ -201,13 +201,13 @@ class GoFramework(Extension):
     def _assets_stage(self) -> list[str]:
         """Return the assets stage list for the Go project."""
         user_stage: list[str] = self._get_nested(
-            self.yaml_data, ["parts", "go-framework/assets"]
+            self.yaml_data, ["parts", self.get_part_name(ExtensionPart.ASSETS)]
         ).get("stage", [])
 
         if not all(re.match("-? *app/", p) for p in user_stage):
             raise ExtensionError(
                 "go-framework extension requires the 'stage' entry in the "
-                "go-framework/assets part to start with app",
+                f"{self.get_part_name(ExtensionPart.ASSETS)} part to start with app",
                 doc_slug="/reference/extensions/go-framework",
                 logpath_report=False,
             )

--- a/rockcraft/extensions/go.py
+++ b/rockcraft/extensions/go.py
@@ -26,7 +26,7 @@ from rockcraft.errors import ExtensionError
 from rockcraft.usernames import SUPPORTED_GLOBAL_USERNAMES
 
 from .app_parts import gen_logging_part
-from .extension import Extension, ExtensionPart, _FrameworkFactory
+from .extension import Extension, _FrameworkFactory
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -75,23 +75,23 @@ class GoFramework(Extension):
                 "override-build": "mkdir -p ${CRAFT_PART_INSTALL}/app",
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
-            self.get_part_name(ExtensionPart.INSTALL_APP): self._get_install_app_part(),
-            self.get_part_name(ExtensionPart.RUNTIME): {
+            self.get_part_name("install-app"): self._get_install_app_part(),
+            self.get_part_name("runtime"): {
                 "plugin": "nil",
                 "stage-packages": stage_packages,
             },
-            self.get_part_name(ExtensionPart.LOGGING): gen_logging_part(),
+            self.get_part_name("logging"): gen_logging_part(),
         }
 
         if self.yaml_data["base"] == "bare":
-            snippet["parts"][self.get_part_name(ExtensionPart.RUNTIME)].update(
+            snippet["parts"][self.get_part_name("runtime")].update(
                 {
                     "override-build": "ln -sf /usr/bin/bash ${CRAFT_PART_INSTALL}/usr/bin/sh"
                 }
             )
         assets_part = self._get_install_assets_part()
         if assets_part:
-            snippet["parts"][self.get_part_name(ExtensionPart.ASSETS)] = assets_part
+            snippet["parts"][self.get_part_name("assets")] = assets_part
 
         return snippet
 
@@ -122,7 +122,7 @@ class GoFramework(Extension):
     def _get_install_app_part(self) -> dict[str, Any]:
         """Generate install-app part with the Go plugin."""
         install_app = self._get_nested(
-            self.yaml_data, ["parts", self.get_part_name(ExtensionPart.INSTALL_APP)]
+            self.yaml_data, ["parts", self.get_part_name("install-app")]
         )
 
         build_environment = install_app.get("build-environment", [])
@@ -162,7 +162,7 @@ class GoFramework(Extension):
     def _check_go_overridden(self) -> bool:
         """Check if the user overrode the go snap or package for the build step."""
         install_app = self._get_nested(
-            self.yaml_data, ["parts", self.get_part_name(ExtensionPart.INSTALL_APP)]
+            self.yaml_data, ["parts", self.get_part_name("install-app")]
         )
         build_snaps = install_app.get("build-snaps", [])
         if build_snaps:
@@ -201,13 +201,13 @@ class GoFramework(Extension):
     def _assets_stage(self) -> list[str]:
         """Return the assets stage list for the Go project."""
         user_stage: list[str] = self._get_nested(
-            self.yaml_data, ["parts", self.get_part_name(ExtensionPart.ASSETS)]
+            self.yaml_data, ["parts", self.get_part_name("assets")]
         ).get("stage", [])
 
         if not all(re.match("-? *app/", p) for p in user_stage):
             raise ExtensionError(
                 "go-framework extension requires the 'stage' entry in the "
-                f"{self.get_part_name(ExtensionPart.ASSETS)} part to start with app",
+                f"{self.get_part_name('assets')} part to start with app",
                 doc_slug="/reference/extensions/go-framework",
                 logpath_report=False,
             )

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -132,7 +132,7 @@ class _GunicornBase(Extension):
                 **self.gen_install_app_part(),
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
-            self.get_part_name(ExtensionPart.CONFIG_FILES): {
+            self.get_part_name("config-files"): {
                 "plugin": "dump",
                 "source": str(data_dir / f"{self.framework}-framework"),
                 "organize": {
@@ -146,7 +146,7 @@ class _GunicornBase(Extension):
                     },
                 ],
             },
-            self.get_part_name(ExtensionPart.STATSD_EXPORTER): {
+            self.get_part_name("statsd-exporter"): {
                 "build-snaps": ["go"],
                 "source-tag": "v0.26.0",
                 "plugin": "go",
@@ -176,7 +176,7 @@ class _GunicornBase(Extension):
                     "ca-certificates_data",
                 ],
             }
-            parts[self.get_part_name(ExtensionPart.RUNTIME_LIBS)] = {
+            parts[self.get_part_name("runtime-libs")] = {
                 "plugin": "nil",
                 "stage-packages": ["libstdc++6"],
             }

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -46,7 +46,12 @@ from ._python_utils import (
 )
 from ._utils import find_ubuntu_base_python_version
 from .app_parts import gen_logging_part
-from .extension import Extension, _FrameworkFactory, get_extensions_data_dir
+from .extension import (
+    Extension,
+    ExtensionPart,
+    _FrameworkFactory,
+    get_extensions_data_dir,
+)
 
 USER_UID: int = SUPPORTED_GLOBAL_USERNAMES["_daemon_"]["uid"]
 
@@ -115,7 +120,7 @@ class _GunicornBase(Extension):
             python_requirements.append("requirements.txt")
 
         parts: dict[str, Any] = {
-            f"{self.framework}-framework/dependencies": {
+            self.get_part_name(ExtensionPart.DEPENDENCIES): {
                 "plugin": "python",
                 "stage-packages": stage_packages,
                 "source": ".",
@@ -123,11 +128,11 @@ class _GunicornBase(Extension):
                 "python-requirements": python_requirements,
                 "build-environment": build_environment,
             },
-            f"{self.framework}-framework/install-app": {
+            self.get_part_name(ExtensionPart.INSTALL_APP): {
                 **self.gen_install_app_part(),
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
-            f"{self.framework}-framework/config-files": {
+            self.get_part_name(ExtensionPart.CONFIG_FILES): {
                 "plugin": "dump",
                 "source": str(data_dir / f"{self.framework}-framework"),
                 "organize": {
@@ -141,13 +146,13 @@ class _GunicornBase(Extension):
                     },
                 ],
             },
-            f"{self.framework}-framework/statsd-exporter": {
+            self.get_part_name(ExtensionPart.STATSD_EXPORTER): {
                 "build-snaps": ["go"],
                 "source-tag": "v0.26.0",
                 "plugin": "go",
                 "source": "https://github.com/prometheus/statsd_exporter.git",
             },
-            f"{self.framework}-framework/logging": gen_logging_part(
+            self.get_part_name(ExtensionPart.LOGGING): gen_logging_part(
                 override_build_lines=[
                     f"mkdir -p $CRAFT_PART_INSTALL/var/log/{self.framework}"
                 ],
@@ -161,7 +166,7 @@ class _GunicornBase(Extension):
             ),
         }
         if self.yaml_data["base"] == "bare":
-            parts[f"{self.framework}-framework/runtime"] = {
+            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
                 "plugin": "nil",
                 "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp\n"
                 "ln -sf /usr/bin/bash ${CRAFT_PART_INSTALL}/usr/bin/sh",
@@ -171,17 +176,17 @@ class _GunicornBase(Extension):
                     "ca-certificates_data",
                 ],
             }
-            parts[f"{self.framework}-framework/runtime-libs"] = {
+            parts[self.get_part_name(ExtensionPart.RUNTIME_LIBS)] = {
                 "plugin": "nil",
                 "stage-packages": ["libstdc++6"],
             }
         else:
             # There is a bug where ca-certificates_data and python-venv both provide
             # etc/ssl/certs/ca-certificates.crt with different content.
-            parts[f"{self.framework}-framework/dependencies"]["stage"] = [
+            parts[self.get_part_name(ExtensionPart.DEPENDENCIES)]["stage"] = [
                 "-etc/ssl/certs/ca-certificates.crt"
             ]
-            parts[f"{self.framework}-framework/runtime"] = {
+            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             }
@@ -378,13 +383,13 @@ class FlaskFramework(_GunicornBase):
         """Return the prime list for the Flask project."""
         user_prime: list[str] = (
             self.yaml_data.get("parts", {})
-            .get("flask-framework/install-app", {})
+            .get(self.get_part_name(ExtensionPart.INSTALL_APP), {})
             .get("prime", [])
         )
         if not all(re.match("-? *flask/app", p) for p in user_prime):
             raise ExtensionError(
                 "flask-framework extension requires the 'prime' entry in the "
-                "flask-framework/install-app part to start with flask/app",
+                f"{self.get_part_name(ExtensionPart.INSTALL_APP)} part to start with flask/app",
                 doc_slug="/reference/extensions/flask-framework",
                 logpath_report=False,
             )
@@ -525,7 +530,9 @@ class DjangoFramework(_GunicornBase):
     @override
     def gen_install_app_part(self) -> dict[str, Any]:
         """Return the prime list for the Django project."""
-        if "django-framework/install-app" not in self.yaml_data.get("parts", {}):
+        if self.get_part_name(ExtensionPart.INSTALL_APP) not in self.yaml_data.get(
+            "parts", {}
+        ):
             return {
                 "plugin": "dump",
                 "source": self.name,

--- a/rockcraft/extensions/gunicorn.py
+++ b/rockcraft/extensions/gunicorn.py
@@ -48,7 +48,6 @@ from ._utils import find_ubuntu_base_python_version
 from .app_parts import gen_logging_part
 from .extension import (
     Extension,
-    ExtensionPart,
     _FrameworkFactory,
     get_extensions_data_dir,
 )
@@ -120,7 +119,7 @@ class _GunicornBase(Extension):
             python_requirements.append("requirements.txt")
 
         parts: dict[str, Any] = {
-            self.get_part_name(ExtensionPart.DEPENDENCIES): {
+            self.get_part_name("dependencies"): {
                 "plugin": "python",
                 "stage-packages": stage_packages,
                 "source": ".",
@@ -128,7 +127,7 @@ class _GunicornBase(Extension):
                 "python-requirements": python_requirements,
                 "build-environment": build_environment,
             },
-            self.get_part_name(ExtensionPart.INSTALL_APP): {
+            self.get_part_name("install-app"): {
                 **self.gen_install_app_part(),
                 "permissions": [{"owner": USER_UID, "group": USER_UID}],
             },
@@ -152,7 +151,7 @@ class _GunicornBase(Extension):
                 "plugin": "go",
                 "source": "https://github.com/prometheus/statsd_exporter.git",
             },
-            self.get_part_name(ExtensionPart.LOGGING): gen_logging_part(
+            self.get_part_name("logging"): gen_logging_part(
                 override_build_lines=[
                     f"mkdir -p $CRAFT_PART_INSTALL/var/log/{self.framework}"
                 ],
@@ -166,7 +165,7 @@ class _GunicornBase(Extension):
             ),
         }
         if self.yaml_data["base"] == "bare":
-            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
+            parts[self.get_part_name("runtime")] = {
                 "plugin": "nil",
                 "override-build": "mkdir -m 777 ${CRAFT_PART_INSTALL}/tmp\n"
                 "ln -sf /usr/bin/bash ${CRAFT_PART_INSTALL}/usr/bin/sh",
@@ -183,10 +182,10 @@ class _GunicornBase(Extension):
         else:
             # There is a bug where ca-certificates_data and python-venv both provide
             # etc/ssl/certs/ca-certificates.crt with different content.
-            parts[self.get_part_name(ExtensionPart.DEPENDENCIES)]["stage"] = [
+            parts[self.get_part_name("dependencies")]["stage"] = [
                 "-etc/ssl/certs/ca-certificates.crt"
             ]
-            parts[self.get_part_name(ExtensionPart.RUNTIME)] = {
+            parts[self.get_part_name("runtime")] = {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             }
@@ -383,13 +382,13 @@ class FlaskFramework(_GunicornBase):
         """Return the prime list for the Flask project."""
         user_prime: list[str] = (
             self.yaml_data.get("parts", {})
-            .get(self.get_part_name(ExtensionPart.INSTALL_APP), {})
+            .get(self.get_part_name("install-app"), {})
             .get("prime", [])
         )
         if not all(re.match("-? *flask/app", p) for p in user_prime):
             raise ExtensionError(
                 "flask-framework extension requires the 'prime' entry in the "
-                f"{self.get_part_name(ExtensionPart.INSTALL_APP)} part to start with flask/app",
+                f"{self.get_part_name('install-app')} part to start with flask/app",
                 doc_slug="/reference/extensions/flask-framework",
                 logpath_report=False,
             )
@@ -530,9 +529,7 @@ class DjangoFramework(_GunicornBase):
     @override
     def gen_install_app_part(self) -> dict[str, Any]:
         """Return the prime list for the Django project."""
-        if self.get_part_name(ExtensionPart.INSTALL_APP) not in self.yaml_data.get(
-            "parts", {}
-        ):
+        if self.get_part_name("install-app") not in self.yaml_data.get("parts", {}):
             return {
                 "plugin": "dump",
                 "source": self.name,

--- a/rockcraft/extensions/springboot.py
+++ b/rockcraft/extensions/springboot.py
@@ -160,7 +160,7 @@ class SpringBootFramework(Extension):
         """Return the user's override-build part for gradle-init-script part."""
         return (
             self.yaml_data.get("parts", {})
-            .get(self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT), {})
+            .get(self.get_part_name("gradle-init-script"), {})
             .get("override-build", "")
         )
 
@@ -169,7 +169,7 @@ class SpringBootFramework(Extension):
         if not self.user_gradle_init_script_part_override_build_override:
             return {}
         return {
-            self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT): {
+            self.get_part_name("gradle-init-script"): {
                 "plugin": "nil",
                 "source": ".",
                 "override-build": self.user_gradle_init_script_part_override_build_override,
@@ -245,13 +245,13 @@ class SpringBootFramework(Extension):
 
         override_build_cmds: list[str] = []
         if self.yaml_data.get("parts", {}).get(
-            self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT), {}
+            self.get_part_name("gradle-init-script"), {}
         ):
             gradle_install_app_part["build-environment"] = [
                 {"GRADLE_USER_HOME": "${CRAFT_PART_BUILD}/.gradle/"}
             ]
             gradle_install_app_part["after"] = [
-                self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT)
+                self.get_part_name("gradle-init-script")
             ]
             override_build_cmds += [
                 "mkdir -p ${CRAFT_PART_BUILD}/.gradle/",

--- a/rockcraft/extensions/springboot.py
+++ b/rockcraft/extensions/springboot.py
@@ -25,7 +25,7 @@ from typing_extensions import override
 
 from rockcraft.errors import ExtensionError
 
-from .extension import Extension, _FrameworkFactory
+from .extension import Extension, ExtensionPart, _FrameworkFactory
 
 
 class SpringBootFramework(Extension):
@@ -67,13 +67,13 @@ class SpringBootFramework(Extension):
 
         snippet["parts"] = {
             **self.gen_gradle_init_script_part(),
-            "spring-boot-framework/install-app": self.gen_install_app_part(),
-            "spring-boot-framework/runtime": self.gen_runtime_app_part(),
+            self.get_part_name(ExtensionPart.INSTALL_APP): self.gen_install_app_part(),
+            self.get_part_name(ExtensionPart.RUNTIME): self.gen_runtime_app_part(),
         }
 
         assets_part = self.gen_assets_part()
         if assets_part:
-            snippet["parts"]["spring-boot-framework/assets"] = assets_part
+            snippet["parts"][self.get_part_name(ExtensionPart.ASSETS)] = assets_part
 
         return snippet
 
@@ -160,7 +160,7 @@ class SpringBootFramework(Extension):
         """Return the user's override-build part for gradle-init-script part."""
         return (
             self.yaml_data.get("parts", {})
-            .get("spring-boot-framework/gradle-init-script", {})
+            .get(self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT), {})
             .get("override-build", "")
         )
 
@@ -169,7 +169,7 @@ class SpringBootFramework(Extension):
         if not self.user_gradle_init_script_part_override_build_override:
             return {}
         return {
-            "spring-boot-framework/gradle-init-script": {
+            self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT): {
                 "plugin": "nil",
                 "source": ".",
                 "override-build": self.user_gradle_init_script_part_override_build_override,
@@ -208,7 +208,7 @@ class SpringBootFramework(Extension):
     def _user_install_app_build_packages_override(self) -> list[str]:
         return (
             self.yaml_data.get("parts", {})
-            .get("spring-boot-framework/install-app", {})
+            .get(self.get_part_name(ExtensionPart.INSTALL_APP), {})
             .get("build-packages", [])
         )
 
@@ -245,13 +245,13 @@ class SpringBootFramework(Extension):
 
         override_build_cmds: list[str] = []
         if self.yaml_data.get("parts", {}).get(
-            "spring-boot-framework/gradle-init-script", {}
+            self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT), {}
         ):
             gradle_install_app_part["build-environment"] = [
                 {"GRADLE_USER_HOME": "${CRAFT_PART_BUILD}/.gradle/"}
             ]
             gradle_install_app_part["after"] = [
-                "spring-boot-framework/gradle-init-script"
+                self.get_part_name(ExtensionPart.GRADLE_INIT_SCRIPT)
             ]
             override_build_cmds += [
                 "mkdir -p ${CRAFT_PART_BUILD}/.gradle/",
@@ -280,12 +280,12 @@ class SpringBootFramework(Extension):
         """Return the runtime part."""
         user_build_packages_override = (
             self.yaml_data.get("parts", {})
-            .get("spring-boot-framework/runtime", {})
+            .get(self.get_part_name(ExtensionPart.RUNTIME), {})
             .get("build-packages")
         )
         runtime_part = {
             "plugin": "jlink",
-            "after": ["spring-boot-framework/install-app"],
+            "after": [self.get_part_name(ExtensionPart.INSTALL_APP)],
             "build-packages": (
                 user_build_packages_override
                 if user_build_packages_override
@@ -323,14 +323,14 @@ class SpringBootFramework(Extension):
         """Return the assets stage list for the Spring Boot project."""
         user_stage: list[str] = (
             self.yaml_data.get("parts", {})
-            .get("spring-boot-framework/assets", {})
+            .get(self.get_part_name(ExtensionPart.ASSETS), {})
             .get("stage", [])
         )
 
         if not all(re.match("-? *app/", p) for p in user_stage):
             raise ExtensionError(
                 "The spring-boot-framework extension requires the 'stage' entry in the "
-                "spring-boot-framework/assets part to start with 'app/'",
+                f"{self.get_part_name(ExtensionPart.ASSETS)} part to start with 'app/'",
                 doc_slug="/reference/extensions/spring-boot-framework",
                 logpath_report=False,
             )

--- a/rockcraft/extensions/springboot.py
+++ b/rockcraft/extensions/springboot.py
@@ -25,7 +25,7 @@ from typing_extensions import override
 
 from rockcraft.errors import ExtensionError
 
-from .extension import Extension, ExtensionPart, _FrameworkFactory
+from .extension import Extension, _FrameworkFactory
 
 
 class SpringBootFramework(Extension):
@@ -67,13 +67,13 @@ class SpringBootFramework(Extension):
 
         snippet["parts"] = {
             **self.gen_gradle_init_script_part(),
-            self.get_part_name(ExtensionPart.INSTALL_APP): self.gen_install_app_part(),
-            self.get_part_name(ExtensionPart.RUNTIME): self.gen_runtime_app_part(),
+            self.get_part_name("install-app"): self.gen_install_app_part(),
+            self.get_part_name("runtime"): self.gen_runtime_app_part(),
         }
 
         assets_part = self.gen_assets_part()
         if assets_part:
-            snippet["parts"][self.get_part_name(ExtensionPart.ASSETS)] = assets_part
+            snippet["parts"][self.get_part_name("assets")] = assets_part
 
         return snippet
 
@@ -208,7 +208,7 @@ class SpringBootFramework(Extension):
     def _user_install_app_build_packages_override(self) -> list[str]:
         return (
             self.yaml_data.get("parts", {})
-            .get(self.get_part_name(ExtensionPart.INSTALL_APP), {})
+            .get(self.get_part_name("install-app"), {})
             .get("build-packages", [])
         )
 
@@ -280,12 +280,12 @@ class SpringBootFramework(Extension):
         """Return the runtime part."""
         user_build_packages_override = (
             self.yaml_data.get("parts", {})
-            .get(self.get_part_name(ExtensionPart.RUNTIME), {})
+            .get(self.get_part_name("runtime"), {})
             .get("build-packages")
         )
         runtime_part = {
             "plugin": "jlink",
-            "after": [self.get_part_name(ExtensionPart.INSTALL_APP)],
+            "after": [self.get_part_name("install-app")],
             "build-packages": (
                 user_build_packages_override
                 if user_build_packages_override
@@ -323,14 +323,14 @@ class SpringBootFramework(Extension):
         """Return the assets stage list for the Spring Boot project."""
         user_stage: list[str] = (
             self.yaml_data.get("parts", {})
-            .get(self.get_part_name(ExtensionPart.ASSETS), {})
+            .get(self.get_part_name("assets"), {})
             .get("stage", [])
         )
 
         if not all(re.match("-? *app/", p) for p in user_stage):
             raise ExtensionError(
                 "The spring-boot-framework extension requires the 'stage' entry in the "
-                f"{self.get_part_name(ExtensionPart.ASSETS)} part to start with 'app/'",
+                f"{self.get_part_name('assets')} part to start with 'app/'",
                 doc_slug="/reference/extensions/spring-boot-framework",
                 logpath_report=False,
             )

--- a/tests/unit/extensions/test_expressjs.py
+++ b/tests/unit/extensions/test_expressjs.py
@@ -401,11 +401,19 @@ def test_expressjs_invalid_package_json_scripts_error(
 def test_expressjs_factory_dispatch(tmp_path):
     factory = extensions.ExpressJSFrameworkFactory
 
-    v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
+    v1 = factory(
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@24.04"},
+        extension_name="expressjs-framework",
+    )
     assert isinstance(v1, extensions.ExpressJSFramework)
     assert not isinstance(v1, extensions.ExpressJSFrameworkV2)
 
-    v2 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"})
+    v2 = factory(
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@26.04"},
+        extension_name="expressjs-framework",
+    )
     assert isinstance(v2, extensions.ExpressJSFrameworkV2)
 
 
@@ -426,7 +434,7 @@ def test_expressjs_extension_ubuntu2604_default(
     expressjs_input_yaml["base"] = "ubuntu@26.04"
     expressjs_input_yaml["build-base"] = "ubuntu@26.04"
     expressjs_input_yaml["parts"] = {
-        "expressjs-framework/install-app": {
+        "expressjs-framework.install-app": {
             "npm-include-node": False,
             "npm-node-version": None,
         }
@@ -440,7 +448,7 @@ def test_expressjs_extension_ubuntu2604_default(
         "platforms": {"amd64": {}},
         "run-user": "_daemon_",
         "parts": {
-            "expressjs-framework/install-app": {
+            "expressjs-framework.install-app": {
                 "plugin": "npm",
                 "source": "app/",
                 "npm-include-node": False,
@@ -460,12 +468,12 @@ def test_expressjs_extension_ubuntu2604_default(
                 "stage-packages": ["ca-certificates_data", "nodejs_bins"],
                 "build-environment": [{"UV_USE_IO_URING": "0"}],
             },
-            "expressjs-framework/runtime": {
+            "expressjs-framework.runtime": {
                 "plugin": "nil",
                 "stage-packages": ["npm"],
                 "stage": ["-etc/ssl/certs/ca-certificates.crt"],
             },
-            "expressjs-framework/logging": {
+            "expressjs-framework.logging": {
                 "plugin": "nil",
                 "override-build": (
                     "craftctl default\n"

--- a/tests/unit/extensions/test_fastapi.py
+++ b/tests/unit/extensions/test_fastapi.py
@@ -337,7 +337,9 @@ def test_fastapi_extension_incorrect_prime_prefix_error(tmp_path, fastapi_input_
 def test_factory_dispatch_v1(tmp_path):
     """Factory returns FastAPIFramework (V1) for ubuntu@24.04."""
     instance = extensions.FastAPIFrameworkFactory(
-        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"}
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@24.04"},
+        extension_name="fastapi-framework",
     )
     assert isinstance(instance, extensions.FastAPIFramework)
     assert not isinstance(instance, extensions.FastAPIFrameworkV2)
@@ -346,7 +348,9 @@ def test_factory_dispatch_v1(tmp_path):
 def test_factory_dispatch_v2(tmp_path):
     """Factory returns FastAPIFrameworkV2 for ubuntu@26.04."""
     instance = extensions.FastAPIFrameworkFactory(
-        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@26.04"},
+        extension_name="fastapi-framework",
     )
     assert isinstance(instance, extensions.FastAPIFrameworkV2)
 
@@ -360,6 +364,7 @@ def test_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@24.04",
         },
+        extension_name="fastapi-framework",
     )
     assert isinstance(v1, extensions.FastAPIFramework)
     assert not isinstance(v1, extensions.FastAPIFrameworkV2)
@@ -371,6 +376,7 @@ def test_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@26.04",
         },
+        extension_name="fastapi-framework",
     )
     assert isinstance(v2, extensions.FastAPIFrameworkV2)
 
@@ -436,7 +442,7 @@ def test_fastapi_extension_default_26_04(tmp_path, monkeypatch):
         "platforms": {"amd64": {}},
         "run_user": "_daemon_",
         "parts": {
-            "fastapi-framework/dependencies": {
+            "fastapi-framework.dependencies": {
                 "build-environment": [],
                 "plugin": "python",
                 "stage-packages": ["python3-venv"],
@@ -445,7 +451,7 @@ def test_fastapi_extension_default_26_04(tmp_path, monkeypatch):
                 "python-requirements": ["requirements.txt"],
                 "stage": ["-etc/ssl/certs/ca-certificates.crt"],
             },
-            "fastapi-framework/install-app": {
+            "fastapi-framework.install-app": {
                 "plugin": "dump",
                 "source": ".",
                 "organize": {
@@ -454,11 +460,11 @@ def test_fastapi_extension_default_26_04(tmp_path, monkeypatch):
                 "stage": ["app/app.py"],
                 "permissions": [{"owner": 584792, "group": 584792}],
             },
-            "fastapi-framework/runtime": {
+            "fastapi-framework.runtime": {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             },
-            "fastapi-framework/logging": {
+            "fastapi-framework.logging": {
                 "plugin": "nil",
                 "override-build": (
                     "craftctl default\n"

--- a/tests/unit/extensions/test_go.py
+++ b/tests/unit/extensions/test_go.py
@@ -281,11 +281,19 @@ def test_go_extension_extra_assets_overridden(tmp_path, go_input_yaml):
 
 def test_go_framework_factory_dispatch(tmp_path):
     factory = extensions.GoFrameworkFactory
-    v1 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@24.04"})
+    v1 = factory(
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@24.04"},
+        extension_name="go-framework",
+    )
     assert isinstance(v1, extensions.GoFramework)
     assert not isinstance(v1, extensions.GoFrameworkV2)
 
-    v2 = factory(project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"})
+    v2 = factory(
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@26.04"},
+        extension_name="go-framework",
+    )
     assert isinstance(v2, extensions.GoFrameworkV2)
 
 
@@ -298,6 +306,7 @@ def test_go_framework_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@24.04",
         },
+        extension_name="go-framework",
     )
     assert isinstance(v1, extensions.GoFramework)
     assert not isinstance(v1, extensions.GoFrameworkV2)
@@ -309,6 +318,7 @@ def test_go_framework_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@26.04",
         },
+        extension_name="go-framework",
     )
     assert isinstance(v2, extensions.GoFrameworkV2)
 
@@ -363,25 +373,25 @@ def test_go_extension_default_26_04(tmp_path, monkeypatch):
         "platforms": {"amd64": {}},
         "run_user": "_daemon_",
         "parts": {
-            "go-framework/base-layout": {
+            "go-framework.base-layout": {
                 "override-build": "mkdir -p ${CRAFT_PART_INSTALL}/app",
                 "plugin": "nil",
                 "permissions": [{"owner": 584792, "group": 584792}],
             },
-            "go-framework/install-app": {
+            "go-framework.install-app": {
                 "plugin": "go",
                 "source": ".",
                 "build-snaps": ["go"],
                 "organize": {"bin/goprojectname": "usr/local/bin/goprojectname"},
                 "stage": ["usr/local/bin/goprojectname"],
             },
-            "go-framework/runtime": {
+            "go-framework.runtime": {
                 "plugin": "nil",
                 "stage-packages": [
                     "ca-certificates_data",
                 ],
             },
-            "go-framework/logging": {
+            "go-framework.logging": {
                 "plugin": "nil",
                 "override-build": (
                     "craftctl default\n"

--- a/tests/unit/extensions/test_gunicorn.py
+++ b/tests/unit/extensions/test_gunicorn.py
@@ -796,13 +796,17 @@ def test_flask_extension_app_in_non_matching_directory(tmp_path):
 def test_flask_framework_factory_dispatch(tmp_path):
     """Test that FlaskFrameworkFactory dispatches to the correct class by base."""
     v1 = FlaskFrameworkFactory(
-        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@22.04"}
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@22.04"},
+        extension_name="flask-framework",
     )
     assert isinstance(v1, FlaskFramework)
     assert not isinstance(v1, FlaskFrameworkV2)
 
     v2 = FlaskFrameworkFactory(
-        project_root=tmp_path, yaml_data={"name": "x", "base": "ubuntu@26.04"}
+        project_root=tmp_path,
+        yaml_data={"name": "x", "base": "ubuntu@26.04"},
+        extension_name="flask-framework",
     )
     assert isinstance(v2, FlaskFrameworkV2)
 
@@ -816,6 +820,7 @@ def test_flask_framework_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@24.04",
         },
+        extension_name="flask-framework",
     )
     assert isinstance(v1, FlaskFramework)
     assert not isinstance(v1, FlaskFrameworkV2)
@@ -827,6 +832,7 @@ def test_flask_framework_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@26.04",
         },
+        extension_name="flask-framework",
     )
     assert isinstance(v2, FlaskFrameworkV2)
 
@@ -862,8 +868,8 @@ def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
     }
 
     applied = extensions.apply_extensions(tmp_path, flask_input_yaml_26)
-    source = applied["parts"]["flask-framework/config-files"]["source"]
-    del applied["parts"]["flask-framework/config-files"]["source"]
+    source = applied["parts"]["flask-framework.config-files"]["source"]
+    del applied["parts"]["flask-framework.config-files"]["source"]
     suffix = "share/rockcraft/extensions/flask-framework"
     assert source[-len(suffix) :].replace("\\", "/") == suffix
 
@@ -871,7 +877,7 @@ def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
         "name": "foo-bar",
         "base": "ubuntu@26.04",
         "parts": {
-            "flask-framework/config-files": {
+            "flask-framework.config-files": {
                 "organize": {
                     "gunicorn.conf.py": "flask/gunicorn.conf.py",
                 },
@@ -884,7 +890,7 @@ def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
                     }
                 ],
             },
-            "flask-framework/dependencies": {
+            "flask-framework.dependencies": {
                 "plugin": "python",
                 "python-packages": ["gunicorn~=23.0"],
                 "python-requirements": ["requirements.txt"],
@@ -893,7 +899,7 @@ def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
                 "build-environment": [],
                 "stage": ["-etc/ssl/certs/ca-certificates.crt"],
             },
-            "flask-framework/install-app": {
+            "flask-framework.install-app": {
                 "organize": {
                     "app.py": "flask/app/app.py",
                     "static": "flask/app/static",
@@ -909,11 +915,11 @@ def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
                     },
                 ],
             },
-            "flask-framework/runtime": {
+            "flask-framework.runtime": {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             },
-            "flask-framework/logging": {
+            "flask-framework.logging": {
                 "plugin": "nil",
                 "override-build": (
                     "craftctl default\n"
@@ -931,7 +937,7 @@ def test_flask_v2_full_apply_26_04(tmp_path, monkeypatch):
                     },
                 ],
             },
-            "flask-framework/statsd-exporter": {
+            "flask-framework.statsd-exporter": {
                 "build-snaps": ["go"],
                 "plugin": "go",
                 "source": "https://github.com/prometheus/statsd_exporter.git",
@@ -1187,6 +1193,7 @@ def test_django_factory_dispatch_v1(tmp_path):
     instance = factory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@22.04"},
+        extension_name="django-framework",
     )
     assert isinstance(instance, extensions.DjangoFramework)
     assert not isinstance(instance, extensions.DjangoFrameworkV2)
@@ -1198,6 +1205,7 @@ def test_django_factory_dispatch_v2(tmp_path):
     instance = factory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@26.04"},
+        extension_name="django-framework",
     )
     assert isinstance(instance, extensions.DjangoFrameworkV2)
 
@@ -1212,6 +1220,7 @@ def test_django_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@24.04",
         },
+        extension_name="django-framework",
     )
     assert isinstance(v1, extensions.DjangoFramework)
     assert not isinstance(v1, extensions.DjangoFrameworkV2)
@@ -1223,6 +1232,7 @@ def test_django_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@26.04",
         },
+        extension_name="django-framework",
     )
     assert isinstance(v2, extensions.DjangoFrameworkV2)
 
@@ -1258,8 +1268,8 @@ def test_django_extension_v2_default(tmp_path):
 
     applied = extensions.apply_extensions(tmp_path, django_input_yaml)
 
-    source = applied["parts"]["django-framework/config-files"]["source"]
-    del applied["parts"]["django-framework/config-files"]["source"]
+    source = applied["parts"]["django-framework.config-files"]["source"]
+    del applied["parts"]["django-framework.config-files"]["source"]
     suffix = "share/rockcraft/extensions/django-framework"
     assert source[-len(suffix) :].replace("\\", "/") == suffix
 
@@ -1267,7 +1277,7 @@ def test_django_extension_v2_default(tmp_path):
         "name": "foo-bar",
         "base": "ubuntu@26.04",
         "parts": {
-            "django-framework/config-files": {
+            "django-framework.config-files": {
                 "organize": {"gunicorn.conf.py": "django/gunicorn.conf.py"},
                 "plugin": "dump",
                 "permissions": [
@@ -1278,7 +1288,7 @@ def test_django_extension_v2_default(tmp_path):
                     },
                 ],
             },
-            "django-framework/dependencies": {
+            "django-framework.dependencies": {
                 "plugin": "python",
                 "python-packages": ["gunicorn~=23.0"],
                 "python-requirements": ["requirements.txt"],
@@ -1287,7 +1297,7 @@ def test_django_extension_v2_default(tmp_path):
                 "build-environment": [],
                 "stage": ["-etc/ssl/certs/ca-certificates.crt"],
             },
-            "django-framework/install-app": {
+            "django-framework.install-app": {
                 "organize": {"*": "django/app/", ".*": "django/app/"},
                 "plugin": "dump",
                 "source": "foo_bar",
@@ -1299,11 +1309,11 @@ def test_django_extension_v2_default(tmp_path):
                     },
                 ],
             },
-            "django-framework/runtime": {
+            "django-framework.runtime": {
                 "plugin": "nil",
                 "stage-packages": ["ca-certificates_data"],
             },
-            "django-framework/logging": {
+            "django-framework.logging": {
                 "plugin": "nil",
                 "override-build": (
                     "craftctl default\n"
@@ -1321,7 +1331,7 @@ def test_django_extension_v2_default(tmp_path):
                     },
                 ],
             },
-            "django-framework/statsd-exporter": {
+            "django-framework.statsd-exporter": {
                 "build-snaps": ["go"],
                 "plugin": "go",
                 "source": "https://github.com/prometheus/statsd_exporter.git",

--- a/tests/unit/extensions/test_springboot.py
+++ b/tests/unit/extensions/test_springboot.py
@@ -589,6 +589,7 @@ def test_factory_dispatch_v1(tmp_path):
     instance = SpringBootFrameworkFactory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@24.04"},
+        extension_name="spring-boot-framework",
     )
     assert isinstance(instance, SpringBootFramework)
     assert not isinstance(instance, SpringBootFrameworkV2)
@@ -599,6 +600,7 @@ def test_factory_dispatch_v2(tmp_path):
     instance = SpringBootFrameworkFactory(
         project_root=tmp_path,
         yaml_data={"name": "x", "base": "ubuntu@26.04"},
+        extension_name="spring-boot-framework",
     )
     assert isinstance(instance, SpringBootFrameworkV2)
 
@@ -612,6 +614,7 @@ def test_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@24.04",
         },
+        extension_name="spring-boot-framework",
     )
     assert isinstance(v1, SpringBootFramework)
     assert not isinstance(v1, SpringBootFrameworkV2)
@@ -623,6 +626,7 @@ def test_factory_dispatch_bare_by_build_base(tmp_path):
             "base": "bare",
             "build-base": "ubuntu@26.04",
         },
+        extension_name="spring-boot-framework",
     )
     assert isinstance(v2, SpringBootFrameworkV2)
 
@@ -660,7 +664,7 @@ def test_spring_boot_extension_default_ubuntu_26_04(tmp_path, monkeypatch):
         "platforms": {"amd64": {}},
         "run-user": "_daemon_",
         "parts": {
-            "spring-boot-framework/install-app": {
+            "spring-boot-framework.install-app": {
                 "plugin": "maven",
                 "source": ".",
                 "build-packages": ["default-jdk", "maven"],
@@ -670,9 +674,9 @@ def test_spring_boot_extension_default_ubuntu_26_04(tmp_path, monkeypatch):
                     "find ${CRAFT_PART_INSTALL} -name '*-plain.jar' -type f -delete"
                 ),
             },
-            "spring-boot-framework/runtime": {
+            "spring-boot-framework.runtime": {
                 "plugin": "jlink",
-                "after": ["spring-boot-framework/install-app"],
+                "after": ["spring-boot-framework.install-app"],
                 "build-packages": ["default-jdk"],
             },
         },


### PR DESCRIPTION
## Summary

Extension part names generated by the framework extensions historically
used a `/` separator (e.g. `flask-framework/install-app`). Newer bases
(e.g. `ubuntu@26.04`) don't allow slashes in part names, so this PR
introduces a shared `Extension.get_part_name()` helper that picks `/` or
`.` as the separator depending on whether the project's base is listed
in craft-application's `BASES_ALLOW_SLASH_IN_PART_NAME`.

Pulled in from https://github.com/canon-cat/rockcraft/pull/3 and extended
to cover all the framework extensions (that PR only updated
`expressjs-framework`).

## Changes

- `Extension` now takes an `extension_name` argument and exposes
  `get_part_name(ExtensionPart)` / `ExtensionPart` enum for building part
  names consistently.
- `_FrameworkFactory` and `apply_extensions()` pass `extension_name`
  through to extension constructors; `Extension.validate()` no longer
  takes `extension_name` as an argument (it's read from `self`).
- Applied `get_part_name()` to all part-name usages in:
  - `expressjs.py`
  - `fastapi.py`
  - `go.py`
  - `gunicorn.py` (flask-framework, django-framework)
  - `springboot.py`
- Updated the corresponding unit tests, including new expectations for
  the `.`-separated part names on `ubuntu@26.04`.

## Checklist

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test` (extensions-related tests; two pre-existing, unrelated `apt` backend failures in `test_lifecycle.py` were observed on both `main` and this branch in this sandboxed environment).
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I added a meta description if one was missing.
- [ ] I've updated the relevant release notes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>