### PR TITLE
fix: update vale to remove spelling error issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -32,4 +32,4 @@ sphinx-llm~=0.4
 
 # Vale dependencies
 rst2html
-vale~=3.13
+vale==3.13.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ docs = [
 # We disable the unused but default SP dependencies slated for removal
 # https://warthogs.atlassian.net/browse/DOCPR-2387
 docs-sphinx-stack = [
-    "canonical-sphinx~=0.6",
+    "canonical-sphinx>=0.5.1",
     "myst-parser~=4.0",
     "packaging~=26.1",
     "rst2html>=2020.7.4",
@@ -70,14 +70,14 @@ docs-sphinx-stack = [
     "sphinx-contributor-listing~=0.1",
     "sphinx-design==0.6.1",
     "sphinx-filtered-toctree~=0.1",
+    "sphinx-last-updated-by-git~=0.3",
     "sphinx-llm~=0.4",
     "sphinx-notfound-page~=1.1",
-    "sphinx-related-links>=0.1.2",
+    "sphinx-related-links~=0.1",
     "sphinx-rerediraffe>=0.0.3,<1.0.0",
     "sphinx-reredirects==0.1.6",
     "sphinx-roles~=0.1",
-    "sphinx-sitemap~=2.6.0",
-    #"sphinx-tabs~=3.5",
+    "sphinx-sitemap~=2.9",
     "sphinx-tabs~=3.5",
     "sphinx-terminal~=1.0",
     "sphinx-ubuntu-images~=0.1",
@@ -85,8 +85,8 @@ docs-sphinx-stack = [
     "sphinxcontrib-jquery~=4.1",
     "sphinxcontrib-svg2pdfconverter[cairosvg]~=2.1",
     "sphinxext-opengraph~=0.13",
-    "vale~=3.13",
-]
+    "vale==3.13.0.0",
+]   
 
 dev = [
     "build>=0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ docs-sphinx-stack = [
     "sphinxcontrib-svg2pdfconverter[cairosvg]~=2.1",
     "sphinxext-opengraph~=0.13",
     "vale==3.13.0.0",
-]   
+]
 
 dev = [
     "build>=0.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2677,6 +2677,7 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-filtered-toctree" },
+    { name = "sphinx-last-updated-by-git" },
     { name = "sphinx-lint" },
     { name = "sphinx-llm" },
     { name = "sphinx-notfound-page" },
@@ -2708,6 +2709,7 @@ docs-sphinx-stack = [
     { name = "sphinx-contributor-listing" },
     { name = "sphinx-design" },
     { name = "sphinx-filtered-toctree" },
+    { name = "sphinx-last-updated-by-git" },
     { name = "sphinx-llm" },
     { name = "sphinx-notfound-page" },
     { name = "sphinx-related-links" },
@@ -2781,7 +2783,7 @@ dev-questing = [{ name = "python-apt", marker = "sys_platform == 'linux'", speci
 dev-resolute = [{ name = "python-apt", marker = "sys_platform == 'linux'", specifier = "~=3.0", index = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }]
 dev-stonking = [{ name = "python-apt", marker = "sys_platform == 'linux'", specifier = "~=3.0", index = "https://people.canonical.com/~lengau/python-apt-ubuntu-wheels/" }]
 docs = [
-    { name = "canonical-sphinx", specifier = "~=0.6" },
+    { name = "canonical-sphinx", specifier = ">=0.5.1" },
     { name = "myst-parser", specifier = "~=4.0" },
     { name = "packaging", specifier = "~=26.1" },
     { name = "pydantic-kitbash", specifier = "~=1.0.1" },
@@ -2794,14 +2796,15 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design", specifier = "==0.6.1" },
     { name = "sphinx-filtered-toctree", specifier = "~=0.1" },
+    { name = "sphinx-last-updated-by-git", specifier = "~=0.3" },
     { name = "sphinx-lint", specifier = "~=1.0" },
     { name = "sphinx-llm", specifier = "~=0.4" },
     { name = "sphinx-notfound-page", specifier = "~=1.1" },
-    { name = "sphinx-related-links", specifier = ">=0.1.2" },
+    { name = "sphinx-related-links", specifier = "~=0.1" },
     { name = "sphinx-rerediraffe", specifier = ">=0.0.3,<1.0.0" },
     { name = "sphinx-reredirects", specifier = "==0.1.6" },
     { name = "sphinx-roles", specifier = "~=0.1" },
-    { name = "sphinx-sitemap", specifier = "~=2.6.0" },
+    { name = "sphinx-sitemap", specifier = "~=2.9" },
     { name = "sphinx-substitution-extensions", specifier = "==2025.1.2" },
     { name = "sphinx-tabs", specifier = "~=3.5" },
     { name = "sphinx-terminal", specifier = "~=1.0" },
@@ -2811,10 +2814,10 @@ docs = [
     { name = "sphinxcontrib-jquery", specifier = "~=4.1" },
     { name = "sphinxcontrib-svg2pdfconverter", extras = ["cairosvg"], specifier = "~=2.1" },
     { name = "sphinxext-opengraph", specifier = "~=0.13" },
-    { name = "vale", specifier = "~=3.13" },
+    { name = "vale", specifier = "==3.13.0.0" },
 ]
 docs-sphinx-stack = [
-    { name = "canonical-sphinx", specifier = "~=0.6" },
+    { name = "canonical-sphinx", specifier = ">=0.5.1" },
     { name = "myst-parser", specifier = "~=4.0" },
     { name = "packaging", specifier = "~=26.1" },
     { name = "rst2html", specifier = ">=2020.7.4" },
@@ -2824,13 +2827,14 @@ docs-sphinx-stack = [
     { name = "sphinx-contributor-listing", specifier = "~=0.1" },
     { name = "sphinx-design", specifier = "==0.6.1" },
     { name = "sphinx-filtered-toctree", specifier = "~=0.1" },
+    { name = "sphinx-last-updated-by-git", specifier = "~=0.3" },
     { name = "sphinx-llm", specifier = "~=0.4" },
     { name = "sphinx-notfound-page", specifier = "~=1.1" },
-    { name = "sphinx-related-links", specifier = ">=0.1.2" },
+    { name = "sphinx-related-links", specifier = "~=0.1" },
     { name = "sphinx-rerediraffe", specifier = ">=0.0.3,<1.0.0" },
     { name = "sphinx-reredirects", specifier = "==0.1.6" },
     { name = "sphinx-roles", specifier = "~=0.1" },
-    { name = "sphinx-sitemap", specifier = "~=2.6.0" },
+    { name = "sphinx-sitemap", specifier = "~=2.9" },
     { name = "sphinx-tabs", specifier = "~=3.5" },
     { name = "sphinx-terminal", specifier = "~=1.0" },
     { name = "sphinx-ubuntu-images", specifier = "~=0.1" },
@@ -2838,7 +2842,7 @@ docs-sphinx-stack = [
     { name = "sphinxcontrib-jquery", specifier = "~=4.1" },
     { name = "sphinxcontrib-svg2pdfconverter", extras = ["cairosvg"], specifier = "~=2.1" },
     { name = "sphinxext-opengraph", specifier = "~=0.13" },
-    { name = "vale", specifier = "~=3.13" },
+    { name = "vale", specifier = "==3.13.0.0" },
 ]
 lint = [{ name = "codespell", extras = ["toml"] }]
 release = [
@@ -3174,6 +3178,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-last-updated-by-git"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/fd/de1685b6dab173dff31da24e0d3b29f02873fc24a1cdbb7678721ddc8581/sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761", size = 10785, upload-time = "2024-08-11T07:15:54.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499", size = 8580, upload-time = "2024-08-11T07:15:53.244Z" },
+]
+
+[[package]]
 name = "sphinx-lint"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3320,14 +3336,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-sitemap"
-version = "2.6.0"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx" },
+    { name = "sphinx-last-updated-by-git" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/ed/96cc112b671e06df01c8306c25ce3331ccfece0d30235e32eb039afc8094/sphinx_sitemap-2.6.0.tar.gz", hash = "sha256:5e0c66b9f2e371ede80c659866a9eaad337d46ab02802f9c7e5f7bc5893c28d2", size = 6042, upload-time = "2024-04-29T00:18:13.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/17/56fe0f65e3567f829b2b4153a622be1d4b222b781e0d90d7db5a7738f30f/sphinx_sitemap-2.9.0.tar.gz", hash = "sha256:70f97bcdf444e3d68e118355cf82a1f54c4d3c03d651cd17fe87398b26e25e21", size = 6978, upload-time = "2025-10-06T00:24:00.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/d4/dffb4da380be24fd390d284634735d6fba560980014050e52569c04d215b/sphinx_sitemap-2.6.0-py3-none-any.whl", hash = "sha256:7478e417d141f99c9af27ccd635f44c03a471a08b20e778a0f9daef7ace1d30b", size = 5632, upload-time = "2024-04-29T00:18:12.147Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/94/3c57e8b1985e755c48972e2ecd59526d4bf0b52a1fe805bc52a8e98cb92d/sphinx_sitemap-2.9.0-py3-none-any.whl", hash = "sha256:f1f1d3a9ad012ba17a7ef0b560d303bff2d0db26647567d6e810bcc754466664", size = 6218, upload-time = "2025-10-06T00:23:58.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
As reported in https://github.com/canonical/sphinx-stack/issues/625, the new Vale release is flagging previously ignored spelling exceptions. By pinning the version, the issue is resolved.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
