### PR TITLE
fix(tests): skip apt-backed lifecycle test when python3-apt is unavailable

### DIFF
--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -38,6 +38,15 @@ from craft_parts.state_manager.prime_state import PrimeState
 from rockcraft.plugins.python_common import get_python_plugins
 from rockcraft.services import lifecycle as lifecycle_module
 
+try:
+    # The apt backend requires the python3-apt bindings, which are only
+    # available for the interpreter shipped by the distribution.
+    from craft_parts.packages.apt_cache import AptCache  # noqa: F401
+
+    _APT_BACKEND_AVAILABLE = True
+except ImportError:
+    _APT_BACKEND_AVAILABLE = False
+
 
 @pytest.fixture
 def extra_project_params():
@@ -92,6 +101,10 @@ def test_lifecycle_args(
 
 
 @pytest.mark.usefixtures("configured_project", "project_keys")
+@pytest.mark.skipif(
+    not _APT_BACKEND_AVAILABLE,
+    reason="python3-apt bindings not available for this interpreter",
+)
 @pytest.mark.parametrize(
     "project_keys",
     [


### PR DESCRIPTION
## Summary

`test_lifecycle_package_repositories` fails spuriously in environments where the `python3-apt` bindings are not importable for the active interpreter (e.g. non-distro virtualenvs / sandboxed dev environments). In those cases craft-parts raises:

```
craft_application.errors.PartsLifecycleError: Package backend 'apt' is not supported on this environment.
```

(`craft_parts.packages.deb._APT_CACHE_AVAILABLE` is `False` because `from .apt_cache import AptCache` raises `ImportError`.)

This PR detects that situation in the test module and skips the affected test with a clear reason instead of failing. Environments with working apt bindings (e.g. distro Python on CI runners) are unaffected and continue to exercise the test.

## Validation

- Before: `1 failed, 17 passed` in a python3.13 venv without python3-apt.
- After: `17 passed, 1 skipped` in the same environment; `ruff check` and pre-commit hooks pass.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test` (targeted: the affected test module).