### PR TITLE
feat(application): enable opt-in monorepo support

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -99,6 +99,7 @@ Makefiles?
 Miniconda
 mitigations?
 mkdir
+monorepo
 MSBuild
 Multipass
 mvn

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,6 +274,7 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/ruby_plugin.rst",
     "common/craft-application/how-to-guides/build-remotely.rst",
     "common/craft-application/how-to-guides/reuse-packages-between-builds.rst",
+    "common/craft-application/how-to-guides/pack-a-pro-artifact.rst",
     "common/craft-application/reference/fetch-service.rst",
     "common/craft-application/reference/remote-builds.rst",
     "common/craft-application/reference/strict-platform-names.rst",

--- a/docs/how-to/crafting/index.rst
+++ b/docs/how-to/crafting/index.rst
@@ -17,6 +17,7 @@ Configure
 - :ref:`how-to-add-an-internal-user`
 - :ref:`how-to-include-local-files-and-remote-resources`
 - :ref:`how-to-override-a-plugins-build`
+- :ref:`how-to-pack-a-rock-in-a-monorepo`
 
 
 Package and publish
@@ -39,6 +40,7 @@ Package and publish
     add-internal-user-to-a-rock
     include-local-files-and-remote-resources
     override-a-plugins-build
+    pack-a-rock-in-a-monorepo
     publish-a-rock
     pack-a-pro-rock
     rockcraft-pack-action

--- a/docs/how-to/crafting/pack-a-rock-in-a-monorepo.rst
+++ b/docs/how-to/crafting/pack-a-rock-in-a-monorepo.rst
@@ -44,8 +44,8 @@ Consider a rock monorepo that looks as follows:
             └── main.c
 
 For rocks located in subdirectories of your repository, set the ``source`` key of
-each rock's main part to the relative directory of the repository root and the
-``source-subdir`` key to the subdirectory path containing the rock's project file.
+each rock's main part to the relative path of the repository root and the
+``source-subdir`` key to the directory containing the rock's project file.
 
 For the rock in the example repository shown previously, these keys would be
 declared as:
@@ -71,10 +71,8 @@ declared as:
     in a subdirectory, you do not need to enable monorepo support. Instead, declare the
     ``source-subdir`` key in the rock's main part.
 
-With monorepo support, Rockcraft mounts the whole repository, not just the rock's own
-directory, so the build instance has the same directory layout as your local checkout.
-As a result, the Makefile can reference ``../shared/common.h`` exactly as it would
-outside of Rockcraft.
+With the whole repository mounted in the build instance, Rockcraft can reference the
+``../shared/common.h`` file exactly as it would outside of Rockcraft.
 
 
 Pack the rock

--- a/docs/how-to/crafting/pack-a-rock-in-a-monorepo.rst
+++ b/docs/how-to/crafting/pack-a-rock-in-a-monorepo.rst
@@ -35,7 +35,7 @@ Consider a rock monorepo that looks as follows:
     │   └── common.h
     └── rocks/
         ├── 24.04/
-        │   └── rockcraft.yaml
+        │   ├── rockcraft.yaml
         │   ├── Makefile
         │   └── main.c
         └── 26.04/

--- a/docs/how-to/crafting/pack-a-rock-in-a-monorepo.rst
+++ b/docs/how-to/crafting/pack-a-rock-in-a-monorepo.rst
@@ -1,0 +1,93 @@
+.. meta::
+    :description: How to pack a rock located in a monorepo structure with shared dependencies.
+
+.. _how-to-pack-a-rock-in-a-monorepo:
+
+Pack a rock in a monorepo
+=========================
+
+By default, Rockcraft isolates the build environment to the directory containing
+the project file. When building in managed environments, such as LXD containers or
+virtual machines, files outside the rock's directory are not copied into the build
+instance.
+
+With experimental monorepo support enabled, Rockcraft detects the root of the enclosing
+Git repository and mounts the entire repository into the build environment. Parts can then
+access parent and sibling directories.
+
+Prerequisites
+-------------
+
+- A Git repository containing your rock and shared assets
+- Rockcraft 1.21 or higher
+
+
+Declare project directories
+---------------------------
+
+Consider a rock monorepo that looks as follows:
+
+.. code-block:: text
+
+    my-monorepo/
+    ├── .git/
+    ├── shared/
+    │   └── common.h
+    └── rocks/
+        ├── 24.04/
+        │   └── rockcraft.yaml
+        │   ├── Makefile
+        │   └── main.c
+        └── 26.04/
+            ├── rockcraft.yaml
+            ├── Makefile
+            └── main.c
+
+For rocks located in subdirectories of your repository, set the ``source`` key of
+each rock's main part to the relative directory of the repository root and the
+``source-subdir`` key to the subdirectory path containing the rock's project file.
+
+For the rock in the example repository shown previously, these keys would be
+declared as:
+
+.. code-block:: yaml
+    :caption: rocks/26.04/rockcraft.yaml
+    :emphasize-lines: 9,10
+
+    name: my-rock
+    base: ubuntu@26.04
+    platforms:
+      amd64:
+
+    parts:
+      my-rock:
+        plugin: make
+        source: ../..
+        source-subdir: rocks/26.04
+
+.. note::
+
+    For repositories with the ``rockcraft.yaml`` file at the root and the rock source
+    in a subdirectory, you do not need to enable monorepo support. Instead, declare the
+    ``source-subdir`` key in the rock's main part.
+
+With monorepo support, Rockcraft mounts the whole repository, not just the rock's own
+directory, so the build instance has the same directory layout as your local checkout.
+As a result, the Makefile can reference ``../shared/common.h`` exactly as it would
+outside of Rockcraft.
+
+
+Pack the rock
+-------------
+
+To pack the rock using the monorepo root as the build root, set the
+``ROCKCRAFT_EXPERIMENTAL_MONOREPO`` environment variable when invoking
+``rockcraft pack``:
+
+.. code-block:: bash
+
+    cd rocks/26.04/
+    ROCKCRAFT_EXPERIMENTAL_MONOREPO=1 rockcraft pack
+
+Rockcraft will mount the root of the Git repository into the build instance and build the
+rock with access to the shared files.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -20,6 +20,7 @@ either locally or remotely, and then published to an image registry.
 - :ref:`how-to-migrate-a-docker-image-to-a-chiselled-rock`
 - :ref:`how-to-publish-a-rock-to-a-registry`
 - :ref:`how-to-pack-a-pro-rock`
+- :ref:`how-to-pack-a-rock-in-a-monorepo`
 
 
 Chiseling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 dependencies = [
     # To use a dev version of a craft library:
     # craft-lib @ git+https://github.com/canonical/craft-lib@ref
-    "craft-application>=7.1.0",
+    "craft-application>=7.2.0",
     "craft-archives>=2.2.1",
     "craft-cli>=3.4.1",
     "craft-parts>=2.35.0",

--- a/rockcraft/application.py
+++ b/rockcraft/application.py
@@ -38,6 +38,7 @@ APP_METADATA = AppMetadata(
     check_supported_base=True,
     artifact_type="rock",
     enable_pro_support=True,
+    allow_git_build_root=True,
 )
 
 

--- a/tests/spread/rockcraft/monorepo/24.04/rockcraft.yaml
+++ b/tests/spread/rockcraft/monorepo/24.04/rockcraft.yaml
@@ -1,0 +1,13 @@
+name: monorepo-test
+base: ubuntu@24.04
+version: "0.1"
+summary: Pack a rock within a monorepo
+description: Pack a rock within a monorepo
+
+platforms:
+  amd64:
+
+parts:
+  hello:
+    plugin: make
+    source: ../shared

--- a/tests/spread/rockcraft/monorepo/26.04/rockcraft.yaml
+++ b/tests/spread/rockcraft/monorepo/26.04/rockcraft.yaml
@@ -1,0 +1,13 @@
+name: monorepo-test
+base: ubuntu@26.04
+version: "0.1"
+summary: Pack a rock within a monorepo
+description: Pack a rock within a monorepo
+
+platforms:
+  amd64:
+
+parts:
+  hello:
+    plugin: make
+    source: ../shared

--- a/tests/spread/rockcraft/monorepo/shared/Makefile
+++ b/tests/spread/rockcraft/monorepo/shared/Makefile
@@ -1,0 +1,19 @@
+CC = gcc
+CFLAGS = -O2 -Wall
+LD = gcc
+LDFLAGS =
+OBJS = hello.o
+BIN = hello
+
+.c.o:
+	$(CC) -c $(CFLAGS) -o$*.o $<
+
+$(BIN): $(OBJS)
+	$(LD) -o $@ $(OBJS)
+
+install:
+	mkdir -p $(DESTDIR)/usr/bin
+	install -m755 $(BIN) $(DESTDIR)/usr/bin
+
+clean:
+	rm -f $(OBJS)

--- a/tests/spread/rockcraft/monorepo/shared/Makefile
+++ b/tests/spread/rockcraft/monorepo/shared/Makefile
@@ -16,4 +16,4 @@ install:
 	install -m755 $(BIN) $(DESTDIR)/usr/bin
 
 clean:
-	rm -f $(OBJS)
+	rm -f $(OBJS) $(BIN)

--- a/tests/spread/rockcraft/monorepo/shared/hello.c
+++ b/tests/spread/rockcraft/monorepo/shared/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("hello\n");
+}

--- a/tests/spread/rockcraft/monorepo/shared/hello.c
+++ b/tests/spread/rockcraft/monorepo/shared/hello.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     printf("hello\n");
+    return 0;
 }

--- a/tests/spread/rockcraft/monorepo/task.yaml
+++ b/tests/spread/rockcraft/monorepo/task.yaml
@@ -1,0 +1,59 @@
+summary: Pack a rock within a monorepo
+
+# Tests the following structure:
+#
+# monorepo/
+# ├── .git             # git root
+# ├── 24.04            # cwd for 'rockcraft pack'
+# ├── 26.04            # cwd for 'rockcraft pack'
+# └── shared
+#     ├── hello.c      # rockcraft will build and bundle this
+#     └── Makefile
+
+environment:
+  ROCKCRAFT_EXPERIMENTAL_MONOREPO: "1"
+
+prepare: |
+  # copy into a disposable tree for easy clean up
+  mkdir -p monorepo
+  cp -r shared 24.04 26.04 monorepo/
+
+  git -C monorepo init
+  git -C monorepo config user.email "test@example.com"
+  git -C monorepo config user.name "Test Name"
+
+execute: |
+  arch="$(dpkg --print-architecture)"
+
+  for base in 24.04 26.04; do
+    rock_file="monorepo-test_0.1_${arch}.rock"
+    image="monorepo-test:${base}"
+
+    pushd "monorepo/${base}"
+    run_rockcraft pack
+
+    test -f "${rock_file}"
+
+    # Verify the rock was built with the expected base
+    mkdir "extracted"
+    tar -xf "${rock_file}" -C "extracted"
+    /snap/rockcraft/current/bin/umoci unpack --rootless --image "extracted:0.1" "rootfs"
+    MATCH "base: ubuntu@${base}" < "rootfs/rootfs/.rock/metadata.yaml"
+
+    # test that "hello.c" was built and bundled into the rock
+    docker images
+    sudo rockcraft.skopeo --insecure-policy copy "oci-archive:${rock_file}" "docker-daemon:${image}"
+    docker images "${image}"
+    docker run --rm "${image}" exec /usr/bin/hello | MATCH "hello"
+    docker run --rm "${image}" help
+    docker run --rm "${image}" --help
+    docker rmi "${image}"
+
+    popd
+  done
+
+restore: |
+  for base in 24.04 26.04; do
+    ( cd "monorepo/${base}" 2>/dev/null && rockcraft clean ) || true
+  done
+  rm -rf monorepo

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -71,7 +71,7 @@ def test_lifecycle_args(
         base_layer_hash=b"deadbeef",
         cache_dir=project_path / "cache",
         ignore_local_sources=[".craft", "*.rock"],
-        ignore_outdated=[".craft", "*.rock"],
+        ignore_outdated=[".craft", "*.rock", ".spread-reuse.*"],
         parallel_build_count=4,
         partitions=None,
         project_name="test-rock",

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -73,3 +73,16 @@ def test_get_app_plugins_missing_project(tmp_path, monkeypatch, mocker):
     app._configure_early_services()
     _ = app._get_app_plugins()
     spied_get_plugins.assert_called_once_with(None)
+
+
+@pytest.mark.parametrize("support", ["0", "1"])
+def test_experimental_monorepo_smoke(support, monkeypatch):
+    """Enable monorepo support with an environment variable."""
+    monkeypatch.setenv("ROCKCRAFT_EXPERIMENTAL_MONOREPO", support)
+
+    app = cli._create_app()
+    app._configure_early_services()
+    app._configure_services(None)
+
+    assert app.services.get("config").get("experimental_monorepo") is bool(int(support))
+    assert app.services.get("provider")._use_git_build_root is bool(int(support))

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ toml = [
 
 [[package]]
 name = "craft-application"
-version = "7.1.0"
+version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -620,9 +620,9 @@ dependencies = [
     { name = "snap-http" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c3/be96c01c1b92a7a7eb6cafa881ccd09a6b9e1db1355835fc98f001680cc3/craft_application-7.1.0.tar.gz", hash = "sha256:e0a3fb2080bf1dd6daf8b570262716f79a5f307a87d3ed2b986eaca50e07efed", size = 663202, upload-time = "2026-07-07T22:02:40.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/aa/592be376d6b4c066bb7bff882179478d07287c1fc65e81bdef32e0f1f514/craft_application-7.2.0.tar.gz", hash = "sha256:182646ef7febe78e1241b393f6cf2b21ec2a3dd00596d323f85c59c3bc705e11", size = 711407, upload-time = "2026-08-11T16:50:12.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/ce/169bdacdfbda0fe8a880d914be0794fc5379b7ec577546444f1572f4762d/craft_application-7.1.0-py3-none-any.whl", hash = "sha256:3319310644d1d935fd7e2fb285fa38bc87c490f3d4fb72fed934e6202164b7bc", size = 212571, upload-time = "2026-07-07T22:02:38.317Z" },
+    { url = "https://files.pythonhosted.org/packages/98/02/c8bb8ec7af9a9c1f7775fc5f8b4174b2ca045b7e5a2a5402fec0d7243792/craft_application-7.2.0-py3-none-any.whl", hash = "sha256:ca0e068f56137b1bb117a0ae92da84db0a9d59360f95106582c7881acb95ec61", size = 212573, upload-time = "2026-08-11T16:50:10.454Z" },
 ]
 
 [[package]]
@@ -2745,7 +2745,7 @@ types = [
 
 [package.metadata]
 requires-dist = [
-    { name = "craft-application", specifier = ">=7.1.0" },
+    { name = "craft-application", specifier = ">=7.2.0" },
     { name = "craft-archives", specifier = ">=2.2.1" },
     { name = "craft-cli", specifier = ">=3.4.1" },
     { name = "craft-parts", specifier = ">=2.35.0" },


### PR DESCRIPTION
Enables monorepo support with the `ROCKCRAFT_EXPERIMENTAL_MONOREPO` environment variable.

Also adds a [how-to](https://canonical-rockcraft--1356.com.readthedocs.build/1356/how-to/crafting/pack-a-rock-in-a-monorepo/) page.

Similar to https://github.com/canonical/charmcraft/pull/2836 and https://github.com/canonical/charmcraft/pull/2844.

(ROCKCRAFT-320)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
