### PR TITLE
style: suppress ty warning

### DIFF
--- a/rockcraft/oci.py
+++ b/rockcraft/oci.py
@@ -290,7 +290,7 @@ class Image:
             with (tmpfs_etc / "group").open("a+") as groupf:
                 groupf.write(user_files["group"])
 
-            if user_files["shadow"]:
+            if user_files["shadow"]:  # ty: ignore[redundant-condition]
                 days_since_epoch = (
                     datetime.now(timezone.utc)
                     - datetime(1970, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
ty 0.0.79 thinks `user_files["shadow"]` is always `""`, but there is a block of code before hand that as far as I can tell can alter the dict value.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
