### PR TITLE
docs: Remove outdated report reference from why rockcraft page

### DIFF
--- a/docs/explanation/rockcraft.rst
+++ b/docs/explanation/rockcraft.rst
@@ -57,8 +57,6 @@ play when selecting the best container image, such as:
 * compliance
 * provenance
 
-You can find these values and their relevance in `this report`_.
-
 This brings us to the problem statement behind rocks:
 
     *How might we redesign secure container images \
@@ -91,4 +89,3 @@ those already used to building Snaps and Charms.
 
 .. _Unit 42 / Znet: https://www.zdnet.com/article/96-of-third-party-container-applications-deployed-in-cloud-infrastructure-contain-known-vulnerabilities-unit-42/
 .. _Snyk's state of open source security report 2020: https://snyk.io/blog/10-docker-image-security-best-practices/
-.. _this report: https://juju.is/cloud-native-kubernetes-usage-report-2021#selection-criteria-for-container-images


### PR DESCRIPTION
Fixes #1360 

The report has been removed and is no longer available. I am therefore removing the reference to this link. This page does not exist anymore in the `latest` version, as it was a marketing page and not documentation.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
